### PR TITLE
Fixed object pooling related bugs

### DIFF
--- a/FishMMO/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.cs
+++ b/FishMMO/Assets/FishNet/Runtime/Managing/Object/ManagedObjects.cs
@@ -133,7 +133,7 @@ namespace FishNet.Managing.Object
                         /* If client-host has visibility
                          * then disable and wait for client-host to get destroy
                          * message. Otherwise destroy immediately. */
-                        if (nob.Observers.Contains(NetworkManager.ClientManager.Connection))
+                        if (NetworkManager.IsHost && nob.Observers.Contains(NetworkManager.ClientManager.Connection))
                             NetworkManager.ServerManager.Objects.AddToPending(nob);
                         else
                             destroy = true;

--- a/FishMMO/Assets/FishNet/Runtime/Object/NetworkObject.cs
+++ b/FishMMO/Assets/FishNet/Runtime/Object/NetworkObject.cs
@@ -667,7 +667,8 @@ namespace FishNet.Object
 
             if (asServer)
             {
-                IsDeinitializing = true;
+				NetworkObserver?.Deinitialize(false);
+				IsDeinitializing = true;
             }
             else
             {

--- a/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -177,12 +177,13 @@ namespace FishNet.Observing
                     {
                         observerFound = true;
 
-                        /* Make an instance of each condition so values are
+						/* Make an instance of each condition so values are
                          * not overwritten when the condition exist more than
                          * once in the scene. Double edged sword of using scriptable
                          * objects for conditions. */
-                        _observerConditions[i] = _observerConditions[i].Clone();
-                        ObserverCondition oc = _observerConditions[i];
+						ObserverCondition oc = _observerConditions[i].Clone();
+						_observerConditions[i] = oc;
+
                         //If timed also register as containing timed conditions.
                         if (oc.Timed())
                             _timedConditions.Add(oc);

--- a/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -199,6 +199,13 @@ namespace FishNet.Observing
                 if (!observerFound)
                     return;
             }
+            else
+            {
+                for (int i = 0; i < _observerConditions.Count; i++)
+                {
+                    _observerConditions[i].Initialize(networkObject);
+                }
+			}
 
 
             RegisterTimedConditions();

--- a/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
+++ b/FishMMO/Assets/FishNet/Runtime/Observing/NetworkObserver.cs
@@ -183,7 +183,6 @@ namespace FishNet.Observing
                          * objects for conditions. */
                         _observerConditions[i] = _observerConditions[i].Clone();
                         ObserverCondition oc = _observerConditions[i];
-                        oc.Initialize(_networkObject);
                         //If timed also register as containing timed conditions.
                         if (oc.Timed())
                             _timedConditions.Add(oc);
@@ -199,12 +198,10 @@ namespace FishNet.Observing
                 if (!observerFound)
                     return;
             }
-            else
+
+            for (int i = 0; i < _observerConditions.Count; i++)
             {
-                for (int i = 0; i < _observerConditions.Count; i++)
-                {
-                    _observerConditions[i].Initialize(networkObject);
-                }
+                _observerConditions[i].Initialize(networkObject);
 			}
 
 

--- a/FishMMO/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
+++ b/FishMMO/Assets/FishNet/Runtime/Transporting/Transports/Tugboat/LiteNetLib/LiteNetLib.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2ad85b0f43f25f1499c27a4dca23ddd8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Object pooling was not properly pooling objects on the scene server. This was because there sometimes was an ID conflict between the connection on the world server, and a game client connected to the scene server.

Pooling also will not generate an exception when a observerCondition tries to do a check on a reused pool object. The condition did not have a correctly working NetworkObject reference. This is fixed in FishNet 3.7 due to some NetworkObserver refactoring.