### PR TITLE
Add Debugging to Login Server Auth

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/Authentication/ClientLoginAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Authentication/ClientLoginAuthenticator.cs
@@ -79,7 +79,10 @@ namespace FishMMO.Client
 		/// </summary>
 		private void ClientManager_OnClientConnectionState(ClientConnectionStateArgs args)
 		{
-			if (args.ConnectionState == LocalConnectionState.Stopping)
+			if (args.ConnectionState == LocalConnectionState.Stopping ||
+				args.ConnectionState == LocalConnectionState.Stopped ||
+				args.ConnectionState == LocalConnectionState.StoppedClosed ||
+				args.ConnectionState == LocalConnectionState.StoppedError)
 			{
 				if (rsa != null)
 				{
@@ -88,11 +91,6 @@ namespace FishMMO.Client
 				}
 			}
 
-			/* If anything but the started state then exit early.
-			 * Only try to authenticate on started state. The server
-			* doesn't have to send an authentication request before client
-			* can authenticate, that is entirely optional and up to you. In this
-			* example the client tries to authenticate soon as they connect. */
 			if (args.ConnectionState != LocalConnectionState.Started)
 				return;
 

--- a/FishMMO-Unity/Assets/Scripts/Server/Account/AccountManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Account/AccountManager.cs
@@ -20,11 +20,9 @@ namespace FishMMO.Server
 
 		public static void AddConnectionEncryptionData(NetworkConnection connection, byte[] publicKey)
 		{
-			ConnectionEncryptionDatas.Remove(connection);
-
-			ConnectionEncryptionDatas.Add(connection, new ConnectionEncryptionData(publicKey,
-																					CryptoHelper.GenerateKey(32),
-																					CryptoHelper.GenerateKey(16)));
+			ConnectionEncryptionDatas[connection] = new ConnectionEncryptionData(publicKey,
+																				 CryptoHelper.GenerateKey(32),
+																				 CryptoHelper.GenerateKey(16));
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/FishMMO-Unity/Assets/Scripts/Server/LoginServer/Authentication/LoginServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/LoginServer/Authentication/LoginServerAuthenticator.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.Text;
 using FishMMO.Server.DatabaseServices;
 using FishMMO.Shared;
+using UnityEngine;
 
 namespace FishMMO.Server
 {
@@ -73,6 +74,7 @@ namespace FishMMO.Server
 			else
 			{
 				// Something weird happened... Adding a connection IV should not be an issue.
+				Debug.LogWarning("Failed to generation encryption keys for connection.");
 				conn.Disconnect(true);
 			}
 		}

--- a/FishMMO-Unity/Assets/Scripts/Server/World/SceneServer/SceneServerSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/World/SceneServer/SceneServerSystem.cs
@@ -56,6 +56,7 @@ namespace FishMMO.Server
 					if (Configuration.GlobalSettings.TryGetString("ServerName", out string name))
 					{
 						SceneServerService.Add(dbContext, name, server.Address, server.Port, characterCount, locked, out id);
+						SceneService.Delete(dbContext, id);
 					}
 
 					characterSystem.OnDisconnect += CharacterSystem_OnDisconnect;


### PR DESCRIPTION
Scene Servers will now delete their Scene entries in the database on load just in-case they are missed during exit.