### PR TITLE
Add FishMMO-AppHealthMonitor

### DIFF
--- a/FishMMO-AppHealthMonitor/.gitignore
+++ b/FishMMO-AppHealthMonitor/.gitignore
@@ -1,0 +1,41 @@
+# Certificates
+*.pem
+*.pfx
+
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+nupkg/
+
+# Visual Studio Code
+.vscode
+
+# Rider
+.idea
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio cache directory
+.vs/

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/AppConfig.cs
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/AppConfig.cs
@@ -1,0 +1,15 @@
+namespace AppHealthMonitor
+{
+	// Represents the configuration for a single application to be monitored.
+	public class AppConfig
+	{
+		public string Name { get; set; }
+		public string ApplicationExePath { get; set; }
+		public string ApplicationProcessName { get; set; }
+		public int MonitoredPort { get; set; }
+		public List<PortType> PortTypes { get; set; } = new List<PortType> { PortType.TCP }; // Default to TCP if not specified
+		public string LaunchArguments { get; set; }
+		public int CheckIntervalSeconds { get; set; }
+		public int LaunchDelaySeconds { get; set; } = 5;
+	}
+}

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/AppHealthMonitor.csproj
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/AppHealthMonitor.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Required for loading configuration from appsettings.json -->
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensure appsettings.json is copied to the output directory -->
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/HealthMonitor.cs
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/HealthMonitor.cs
@@ -1,0 +1,390 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+
+namespace AppHealthMonitor
+{
+	public class HealthMonitor
+	{
+		private readonly string _appName;
+		private readonly string _applicationExePath;
+		private readonly string _applicationProcessName;
+		private readonly int _monitoredPort;
+		private readonly List<PortType> _portTypes;
+		private readonly string _launchArguments;
+		private readonly TimeSpan _checkInterval;
+		private readonly CancellationToken _cancellationToken;
+
+		// NEW: Field to hold the specific process instance launched by this monitor
+		private Process _monitoredProcess;
+
+		/// <summary>
+		/// Initializes a new instance of the HealthMonitor class.
+		/// </summary>
+		/// <param name="appName">A friendly name for the application being monitored.</param>
+		/// <param name="applicationExePath">The full path to the application's executable.</param>
+		/// <param name="applicationProcessName">The name of the application's process (e.g., "myapp" for myapp.exe).</param>
+		/// <param name="monitoredPort">The TCP/UDP/WebSocket port the application should be listening on.</param>
+		/// <param name="portTypes">A list of network port types to monitor (TCP, UDP, WebSocket, or None).</param>
+		/// <param name="launchArguments">Optional arguments to pass when launching the application.</param>
+		/// <param name="checkInterval">The time interval between health checks.</param>
+		/// <param name="cancellationToken">A shared cancellation token to stop monitoring gracefully.</param>
+		public HealthMonitor(
+			string appName,
+			string applicationExePath,
+			string applicationProcessName,
+			int monitoredPort,
+			List<PortType> portTypes,
+			string launchArguments,
+			TimeSpan checkInterval,
+			CancellationToken cancellationToken)
+		{
+			_appName = appName ?? throw new ArgumentNullException(nameof(appName));
+			_applicationExePath = applicationExePath ?? throw new ArgumentNullException(nameof(applicationExePath));
+			_applicationProcessName = applicationProcessName ?? throw new ArgumentNullException(nameof(applicationProcessName));
+			_monitoredPort = monitoredPort;
+			_portTypes = portTypes ?? new List<PortType> { PortType.None };
+			_launchArguments = launchArguments ?? string.Empty;
+			_checkInterval = checkInterval;
+			_cancellationToken = cancellationToken;
+			_monitoredProcess = null; // Initialize to null
+		}
+
+		public async Task StartMonitoring()
+		{
+			// Initial launch of the application if it's not already running
+			// or if it crashed before the daemon started monitoring.
+			if (!IsApplicationProcessRunning())
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Application process not found at startup. Attempting initial launch...");
+				LaunchApplication();
+				// Give it a moment to start up before the first health check
+				await Task.Delay(TimeSpan.FromSeconds(5), _cancellationToken); // Initial startup delay
+			}
+
+
+			while (!_cancellationToken.IsCancellationRequested)
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Performing health check...");
+				bool isHealthy = await CheckApplicationHealth();
+
+				if (!isHealthy)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Application detected as unhealthy. Attempting to restart...");
+					KillApplication(); // Only kills the specific process this monitor manages
+					LaunchApplication(); // Relaunches the specific process
+				}
+				else
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Application is healthy.");
+				}
+
+				try
+				{
+					await Task.Delay(_checkInterval, _cancellationToken);
+				}
+				catch (OperationCanceledException)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Monitoring task cancelled.");
+					break;
+				}
+			}
+			Console.WriteLine($"[{DateTime.Now}] [{_appName}] Monitoring stopped.");
+		}
+
+		/// <summary>
+		/// Checks the health of the application by verifying its specific process and all configured port types.
+		/// </summary>
+		/// <returns>True if the application is considered healthy, false otherwise.</returns>
+		private async Task<bool> CheckApplicationHealth()
+		{
+			// 1. Check if the specific process launched by THIS monitor is running
+			if (!IsApplicationProcessRunning())
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Monitored process is not running or has exited.");
+				return false; // Process not running or exited
+			}
+
+			// If we reached here, _monitoredProcess is not null and is still running.
+			// Refresh its state to ensure accurate HasExited.
+			try
+			{
+				_monitoredProcess.Refresh();
+				if (_monitoredProcess.HasExited)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Monitored process (ID: {_monitoredProcess.Id}) has exited after refresh.");
+					return false;
+				}
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Monitored process (ID: {_monitoredProcess.Id}, Name: {_monitoredProcess.ProcessName}) is running.");
+			}
+			catch (InvalidOperationException) // Process might have exited just before Refresh()
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Monitored process seems to have exited unexpectedly during refresh.");
+				return false;
+			}
+
+
+			// 2. Check if the specified ports are responsive based on ALL configured PortTypes
+			bool allPortsResponsive = true;
+			if (_monitoredPort > 0)
+			{
+				foreach (var portType in _portTypes)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Attempting to connect to port {_monitoredPort} (Type: {portType})...");
+					bool currentPortTypeResponsive = false;
+
+					switch (portType)
+					{
+						case PortType.TCP:
+							currentPortTypeResponsive = await IsTcpPortResponsive("127.0.0.1", _monitoredPort, 2000);
+							break;
+						case PortType.UDP:
+							currentPortTypeResponsive = await IsUdpPortResponsive("127.0.0.1", _monitoredPort, 2000);
+							break;
+						case PortType.WebSocket:
+							currentPortTypeResponsive = await IsWebSocketPortResponsive($"ws://127.0.0.1:{_monitoredPort}", 5000);
+							break;
+						case PortType.None:
+							Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: PortType is None. Skipping specific port check for this type.");
+							currentPortTypeResponsive = true;
+							break;
+						default:
+							Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Unsupported PortType '{portType}'. Skipping this check.");
+							currentPortTypeResponsive = false;
+							break;
+					}
+
+					if (!currentPortTypeResponsive)
+					{
+						Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Port {_monitoredPort} (Type: {portType}) is NOT responsive.");
+						allPortsResponsive = false; // Mark as unhealthy if any port check fails
+						break; // No need to check other ports if one already failed
+					}
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: Port {_monitoredPort} (Type: {portType}) is responsive.");
+				}
+			}
+			else
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Health Check: No port specified for monitoring (MonitoredPort is 0 or less). Skipping all port checks.");
+			}
+
+			return allPortsResponsive; // Return true only if process is running and all ports are healthy
+		}
+
+		/// <summary>
+		/// Determines if the specific process managed by this monitor is currently running.
+		/// </summary>
+		private bool IsApplicationProcessRunning()
+		{
+			if (_monitoredProcess == null)
+			{
+				return false; // Process not launched yet by this monitor
+			}
+
+			try
+			{
+				// Try to refresh its state; if it throws, the process handle is invalid (i.e., it exited)
+				_monitoredProcess.Refresh();
+				return !_monitoredProcess.HasExited;
+			}
+			catch (InvalidOperationException)
+			{
+				// The process has exited. Clear the reference.
+				_monitoredProcess = null;
+				return false;
+			}
+			catch (Exception ex)
+			{
+				// Other errors refreshing process state
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Error refreshing process state for ID: {_monitoredProcess?.Id}. Error: {ex.Message}");
+				_monitoredProcess = null; // Assume it's no longer valid
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Kills the specific process instance launched by this monitor.
+		/// </summary>
+		private void KillApplication()
+		{
+			if (_monitoredProcess == null)
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] No specific process to kill (not launched by this monitor or already exited).");
+				return;
+			}
+
+			// Refresh to get the latest status before attempting to kill
+			_monitoredProcess.Refresh();
+			if (_monitoredProcess.HasExited)
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Process ID: {_monitoredProcess.Id} (Name: {_monitoredProcess.ProcessName}) has already exited.");
+				_monitoredProcess = null; // Clear reference
+				return;
+			}
+
+			try
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Killing specific process ID: {_monitoredProcess.Id} (Name: {_monitoredProcess.ProcessName})...");
+				_monitoredProcess.Kill();
+				_monitoredProcess.WaitForExit(5000); // Wait up to 5 seconds for the process to exit
+
+				if (_monitoredProcess.HasExited)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Process ID: {_monitoredProcess.Id} killed successfully.");
+				}
+				else
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Warning: Process ID: {_monitoredProcess.Id} did not exit after kill command.");
+				}
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Error killing process ID: {_monitoredProcess.Id}. Error: {ex.Message}");
+			}
+			finally
+			{
+				_monitoredProcess = null; // Always clear the reference after attempting to kill
+			}
+		}
+
+		/// <summary>
+		/// Launches the application executable and stores its process reference.
+		/// </summary>
+		private void LaunchApplication()
+		{
+			Console.WriteLine($"[{DateTime.Now}] [{_appName}] Launching application '{_applicationExePath}' with arguments: '{_launchArguments}'...");
+			try
+			{
+				ProcessStartInfo startInfo = new ProcessStartInfo
+				{
+					FileName = _applicationExePath,
+					Arguments = _launchArguments,
+					UseShellExecute = true // Set to true to launch as a separate process, allowing it to run independently
+				};
+
+				_monitoredProcess = Process.Start(startInfo); // Store the launched process
+				if (_monitoredProcess != null)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Application launched successfully. Process ID: {_monitoredProcess.Id}");
+				}
+				else
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] Warning: Process.Start returned null for '{_applicationExePath}'.");
+				}
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[{DateTime.Now}] [{_appName}] Error launching application '{_applicationExePath}'. Error: {ex.Message}");
+				_monitoredProcess = null; // Ensure process reference is cleared on launch failure
+			}
+		}
+
+		private async Task<bool> IsTcpPortResponsive(string host, int port, int timeoutMilliseconds)
+		{
+			using (TcpClient client = new TcpClient())
+			{
+				try
+				{
+					var connectTask = client.ConnectAsync(host, port);
+					if (await Task.WhenAny(connectTask, Task.Delay(timeoutMilliseconds, _cancellationToken)) == connectTask)
+					{
+						_cancellationToken.ThrowIfCancellationRequested();
+						return client.Connected;
+					}
+					else
+					{
+						Console.WriteLine($"[{DateTime.Now}] [{_appName}] TCP Port Check Timeout: {host}:{port} did not respond within {timeoutMilliseconds}ms.");
+						return false;
+					}
+				}
+				catch (OperationCanceledException) { throw; }
+				catch (SocketException ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] TCP Port Check Error: Could not connect to {host}:{port}. Socket error: {ex.SocketErrorCode} - {ex.Message}");
+					return false;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] TCP Port Check Unexpected Error: {ex.Message}");
+					return false;
+				}
+			}
+		}
+
+		private async Task<bool> IsUdpPortResponsive(string host, int port, int timeoutMilliseconds)
+		{
+			using (UdpClient udpClient = new UdpClient())
+			{
+				try
+				{
+					byte[] datagram = Encoding.UTF8.GetBytes("health_check");
+					var sendTask = udpClient.SendAsync(datagram, datagram.Length, host, port);
+
+					if (await Task.WhenAny(sendTask, Task.Delay(timeoutMilliseconds, _cancellationToken)) == sendTask)
+					{
+						_cancellationToken.ThrowIfCancellationRequested();
+						return true;
+					}
+					else
+					{
+						Console.WriteLine($"[{DateTime.Now}] [{_appName}] UDP Port Send Timeout: {host}:{port} did not complete send within {timeoutMilliseconds}ms.");
+						return false;
+					}
+				}
+				catch (OperationCanceledException) { throw; }
+				catch (SocketException ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] UDP Port Check Error: Could not send to {host}:{port}. Socket error: {ex.SocketErrorCode} - {ex.Message}");
+					return false;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] UDP Port Check Unexpected Error: {ex.Message}");
+					return false;
+				}
+			}
+		}
+
+		private async Task<bool> IsWebSocketPortResponsive(string webSocketUri, int timeoutMilliseconds)
+		{
+			using (ClientWebSocket ws = new ClientWebSocket())
+			{
+				try
+				{
+					var connectTask = ws.ConnectAsync(new Uri(webSocketUri), _cancellationToken);
+					if (await Task.WhenAny(connectTask, Task.Delay(timeoutMilliseconds, _cancellationToken)) == connectTask)
+					{
+						_cancellationToken.ThrowIfCancellationRequested();
+						if (ws.State == WebSocketState.Open)
+						{
+							await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Health check", _cancellationToken);
+							return true;
+						}
+						else
+						{
+							Console.WriteLine($"[{DateTime.Now}] [{_appName}] WebSocket Port Check: Connection failed. State: {ws.State}");
+							return false;
+						}
+					}
+					else
+					{
+						Console.WriteLine($"[{DateTime.Now}] [{_appName}] WebSocket Port Check Timeout: {webSocketUri} did not establish connection within {timeoutMilliseconds}ms.");
+						return false;
+					}
+				}
+				catch (OperationCanceledException) { throw; }
+				catch (WebSocketException ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] WebSocket Port Check Error: {webSocketUri}. WebSocket error: {ex.WebSocketErrorCode} - {ex.Message}");
+					return false;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[{DateTime.Now}] [{_appName}] WebSocket Port Check Unexpected Error: {ex.Message}");
+					return false;
+				}
+			}
+		}
+	}
+}

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/PortType.cs
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/PortType.cs
@@ -1,0 +1,10 @@
+namespace AppHealthMonitor
+{
+	public enum PortType
+	{
+		None, // No port monitoring
+		TCP,
+		UDP,
+		WebSocket
+	}
+}

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/Program.cs
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/Program.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace AppHealthMonitor
+{
+	class Program
+	{
+		static async Task Main(string[] args)
+		{
+			Console.WriteLine("Starting Application Health Monitor Daemon...");
+
+			// --- Load Configuration from appsettings.json ---
+			var builder = new ConfigurationBuilder()
+				.SetBasePath(Directory.GetCurrentDirectory())
+				.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+
+			IConfiguration configuration = builder.Build();
+
+			var appConfigs = configuration.GetSection("Applications").Get<List<AppConfig>>();
+
+			if (appConfigs == null || appConfigs.Count == 0)
+			{
+				Console.WriteLine("Error: No application configurations found in 'Applications' section of appsettings.json. Please configure at least one application.");
+				return;
+			}
+
+			Console.WriteLine("Configurations loaded for multiple applications:");
+			List<Task> monitoringTasks = new List<Task>();
+			// Central CancellationTokenSource to stop all monitors gracefully
+			using (var sharedCts = new CancellationTokenSource())
+			{
+				// Register a single handler for Ctrl+C to cancel the shared token source
+				Console.CancelKeyPress += (sender, eventArgs) =>
+				{
+					if (!sharedCts.IsCancellationRequested)
+					{
+						Console.WriteLine("\nCtrl+C pressed. Signalling all monitors to stop...");
+						sharedCts.Cancel();
+						eventArgs.Cancel = true; // Prevent immediate termination
+					}
+				};
+
+				for (int i = 0; i < appConfigs.Count; i++) // Use a for loop to check index
+				{
+					var appConfig = appConfigs[i];
+
+					// Basic validation for each application's configuration
+					if (string.IsNullOrWhiteSpace(appConfig.Name))
+					{
+						Console.WriteLine("Warning: An application configuration is missing 'Name'. Skipping this entry.");
+						continue;
+					}
+					if (string.IsNullOrWhiteSpace(appConfig.ApplicationExePath))
+					{
+						Console.WriteLine($"Error: '{appConfig.Name}' - 'ApplicationExePath' is not configured. Skipping this entry.");
+						continue;
+					}
+					if (string.IsNullOrWhiteSpace(appConfig.ApplicationProcessName))
+					{
+						Console.WriteLine($"Error: '{appConfig.Name}' - 'ApplicationProcessName' is not configured. Skipping this entry.");
+						continue;
+					}
+
+					TimeSpan checkInterval = TimeSpan.FromSeconds(appConfig.CheckIntervalSeconds > 0 ? appConfig.CheckIntervalSeconds : 10); // Default to 10 seconds
+
+					Console.WriteLine($"  [{appConfig.Name}]");
+					Console.WriteLine($"    ApplicationExePath: {appConfig.ApplicationExePath}");
+					Console.WriteLine($"    ApplicationProcessName: {appConfig.ApplicationProcessName}");
+					Console.WriteLine($"    MonitoredPort: {appConfig.MonitoredPort} (Types: {string.Join(", ", appConfig.PortTypes)})"); // Show all types
+					Console.WriteLine($"    LaunchArguments: {appConfig.LaunchArguments}");
+					Console.WriteLine($"    CheckInterval: {checkInterval.TotalSeconds} seconds");
+					Console.WriteLine($"    LaunchDelay: {appConfig.LaunchDelaySeconds} seconds"); // New: Show launch delay
+
+					// Create a HealthMonitor instance for each application, passing the shared CancellationToken
+					HealthMonitor monitor = new HealthMonitor(
+						appConfig.Name,
+						appConfig.ApplicationExePath,
+						appConfig.ApplicationProcessName,
+						appConfig.MonitoredPort,
+						appConfig.PortTypes,
+						appConfig.LaunchArguments,
+						checkInterval,
+						sharedCts.Token
+					);
+
+					// Add the monitoring task to a list to run concurrently
+					monitoringTasks.Add(monitor.StartMonitoring());
+
+					// Add a delay IF it's not the last application
+					if (appConfig.LaunchDelaySeconds > 0 && i < appConfigs.Count - 1)
+					{
+						Console.WriteLine($"[{DateTime.Now}] Pausing for {appConfig.LaunchDelaySeconds} seconds before starting the next monitor...");
+						try
+						{
+							await Task.Delay(TimeSpan.FromSeconds(appConfig.LaunchDelaySeconds), sharedCts.Token);
+						}
+						catch (OperationCanceledException)
+						{
+							Console.WriteLine($"[{DateTime.Now}] Launch delay cancelled.");
+							break; // Exit the loop if cancelled during delay
+						}
+					}
+				}
+
+				if (monitoringTasks.Count == 0)
+				{
+					Console.WriteLine("No valid application configurations were found to monitor. Exiting.");
+					return;
+				}
+
+				Console.WriteLine("\nAll configured applications are now being monitored concurrently.");
+				Console.WriteLine("Press Ctrl+C to stop the daemon and all monitoring tasks.");
+
+				// Wait for all monitoring tasks to complete (which will happen when Ctrl+C is pressed and token cancelled)
+				await Task.WhenAll(monitoringTasks);
+
+				Console.WriteLine("Application Health Monitor Daemon stopped.");
+			}
+		}
+	}
+}

--- a/FishMMO-AppHealthMonitor/AppHealthMonitor/appsettings.json
+++ b/FishMMO-AppHealthMonitor/AppHealthMonitor/appsettings.json
@@ -1,0 +1,34 @@
+{
+  "Applications": [
+    {
+      "Name": "LoginServer",
+      "ApplicationExePath": "C:\\Path\\To\\Your\\All-In-One.exe",
+      "ApplicationProcessName": "All-In-One",
+      "MonitoredPort": 7770,
+      "PortTypes": [ "TCP", "UDP" ],
+      "LaunchArguments": "LOGIN",
+      "CheckIntervalSeconds": 10,
+      "LaunchDelaySeconds": 5
+    },
+    {
+      "Name": "WorldServer",
+      "ApplicationExePath": "C:\\Path\\To\\Your\\All-In-One.exe",
+      "ApplicationProcessName": "All-In-One",
+      "MonitoredPort": 7780,
+      "PortTypes": [ "TCP", "UDP" ],
+      "LaunchArguments": "WORLD",
+      "CheckIntervalSeconds": 10,
+      "LaunchDelaySeconds": 5
+    },
+    {
+      "Name": "SceneServer",
+      "ApplicationExePath": "C:\\Path\\To\\Your\\All-In-One.exe",
+      "ApplicationProcessName": "All-In-One",
+      "MonitoredPort": 7781,
+      "PortTypes": [ "TCP", "UDP" ],
+      "LaunchArguments": "SCENE",
+      "CheckIntervalSeconds": 10,
+      "LaunchDelaySeconds": 5
+    }
+  ]
+}

--- a/FishMMO-AppHealthMonitor/FishMMO-AppHealthMonitor.sln
+++ b/FishMMO-AppHealthMonitor/FishMMO-AppHealthMonitor.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHealthMonitor", "AppHealthMonitor\AppHealthMonitor.csproj", "{80DAA458-6B64-4E3A-8C63-39E686098704}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{80DAA458-6B64-4E3A-8C63-39E686098704}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80DAA458-6B64-4E3A-8C63-39E686098704}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80DAA458-6B64-4E3A-8C63-39E686098704}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80DAA458-6B64-4E3A-8C63-39E686098704}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
FishMMO-AppHealthMonitor is the new server launcher and health monitoring system. It is designed to monitor the status of the server ports by attempting connections to them. If the connection fails or times out it will kill the server process and restart it. AppHealthMonitor is taking over as our new dedicated server launching system.

Configure the appsettings.json to specify the executable path, process name, port, and any other details.