### PR TITLE
FishNet: WebGL Reliable framing + AddressableSceneProcessor wiring (PR-2/7)

### DIFF
--- a/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Scened/DefaultSceneProcessor.cs
@@ -68,7 +68,18 @@ namespace FishNet.Managing.Scened
         /// <param name = "sceneName">Scene name to load.</param>
         public override void BeginLoadAsync(string sceneName, UnityEngine.SceneManagement.LoadSceneParameters parameters)
         {
+            // Null when the scene is not in Build Settings (e.g. Addressables-only scenes).
+            // FishMMO clients must use AddressableSceneProcessor — this guards a miswired SceneManager.
             AsyncOperation ao = UnitySceneManager.LoadSceneAsync(sceneName, parameters);
+            if (ao == null)
+            {
+                SceneManager.NetworkManager.LogError(
+                    $"LoadSceneAsync returned null for scene '{sceneName}'. " +
+                    "Assign AddressableSceneProcessor on SceneManager when using Addressable scenes.");
+                CurrentAsyncOperation = null;
+                return;
+            }
+
             LoadingAsyncOperations.Add(ao);
 
             _lastLoadedScene = UnitySceneManager.GetSceneAt(UnitySceneManager.sceneCount - 1);

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Scened/SceneManager.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Scened/SceneManager.cs
@@ -236,7 +236,14 @@ namespace FishNet.Managing.Scened
         {
             UnitySceneManager.sceneUnloaded += SceneManager_SceneUnloaded;
             if (_sceneProcessor == null)
-                _sceneProcessor = gameObject.AddComponent<DefaultSceneProcessor>();
+            {
+                // Prefer an existing custom processor on this object (e.g. AddressableSceneProcessor)
+                // before adding DefaultSceneProcessor. DefaultSceneProcessor uses Build Settings
+                // LoadSceneAsync and returns null for Addressables-only scenes → NRE.
+                _sceneProcessor = GetComponent<SceneProcessorBase>();
+                if (_sceneProcessor == null)
+                    _sceneProcessor = gameObject.AddComponent<DefaultSceneProcessor>();
+            }
             _sceneProcessor.Initialize(this);
         }
 

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Timing/TimeManager.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Timing/TimeManager.cs
@@ -617,7 +617,14 @@ namespace FishNet.Managing.Timing
                 _networkTrafficStatistics.AddOutboundPacketIdData(PacketId.PingPong, string.Empty, writer.Length, gameObject: null, asServer: false);
 #endif
 
-            NetworkManager.TransportManager.SendToServer((byte)Channel.Unreliable, writer.GetArraySegment());
+            // WebGL remaps Unreliable→stream; keep channel Reliable so it rides the same
+            // path as remapped prediction (see TransportManager.CheckSetReliableChannel).
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Channel pingChannel = Channel.Reliable;
+#else
+            Channel pingChannel = Channel.Unreliable;
+#endif
+            NetworkManager.TransportManager.SendToServer((byte)pingChannel, writer.GetArraySegment());
             writer.Store();
         }
 

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Transporting/TransportManager.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Runtime/Managing/Transporting/TransportManager.cs
@@ -656,9 +656,19 @@ namespace FishNet.Managing.Transporting
             if (channel == Channel.Reliable)
                 return;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+            /* WebTransport.SendToServer remaps browser channel 1 (DATAGRAM) → stream (0)
+             * for H3 stability. FishNet Unreliable packets omit the Int32 length header
+             * that Reliable parse expects, so remapped Replicate traffic desyncs the
+             * dedicated server (PacketId 0 flood) while the client still "feels fine".
+             * Force Reliable *before* CreateRpc so wire format matches the stream. */
+            channel = Channel.Reliable;
+            return;
+#else
             bool requiresMultipleMessages = GetRequiredMessageCount((byte)channel, dataLength, out _) > 1;
             if (requiresMultipleMessages)
                 channel = Channel.Reliable;
+#endif
         }
 
         /// <summary>

--- a/FishMMO-Unity/Assets/Scenes/Client/ClientPostboot.unity
+++ b/FishMMO-Unity/Assets/Scenes/Client/ClientPostboot.unity
@@ -478,7 +478,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15895a51081447d46bda466e7e830c08, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _sceneProcessor: {fileID: 0}
+  _sceneProcessor: {fileID: 6776049995475983712}
   _lightProbeUpdating: 0
   _moveClientObjects: 1
   _setActiveScene: 1


### PR DESCRIPTION
## Summary

Selective batch **PR-2 of 7** from UnityEQ `fishmmo-pr-dev` (tip `7a6e677c`).

Small FishNet runtime + client postboot wiring that **pairs with PR-1** for WebGL wire format and fixes Addressables scene loads in the Editor/client.

**5 files, ~+38/−3** — easy to review.

## Depends on / must-pair

| Pair | Why |
|------|-----|
| **PR-1** WebTransport WebGL ch1→0 | This PR forces Reliable *before* CreateRpc so remapped stream traffic uses the length-prefixed Reliable framing. PR-1 alone leaves Unreliable format on streams → server **PacketId 0** flood. |
| ClientPostboot + SceneManager prefer custom processor | Code preference alone does not wire the scene field; YAML + prefer-existing prevents DefaultSceneProcessor NRE on Addressables-only scenes. |

Merge order: ideally **after or with** [PR #80](https://github.com/jimdroberts/FishMMO/pull/80). This PR compiles and is safe alone; full WebGL spawn micro-test needs both.

## What's included

| Path | Change |
|------|--------|
| `TransportManager.cs` | `#if UNITY_WEBGL && !UNITY_EDITOR` force Reliable in `CheckSetReliableChannel` before CreateRpc |
| `TimeManager.cs` | Companion WebGL framing/tick alignment |
| `SceneManager.cs` | Prefer existing `SceneProcessorBase` before adding DefaultSceneProcessor |
| `DefaultSceneProcessor.cs` | Null guards when scene not in Build Settings |
| `ClientPostboot.unity` | `_sceneProcessor` → AddressableSceneProcessor instance |

## Explicitly not in this PR

- Native WT / Unity WebTransport plugin (**PR-1** / #80)
- ClientConnectionManager / auth (**PR-3**)
- DB / matchmaking / prefabs (**PR-4+**)

## Micro-test

1. Compile Editor + WebGL player scripts.
2. Editor: play with Addressables world scene load — no DefaultSceneProcessor NRE.
3. After PR-1 + this PR: WebGL post-spawn should not PacketId-0-flood the dedicated server (full proof also needs spawn contract PR-5).

## Test plan

- [ ] Diff is only the 5 paths above
- [ ] Editor client scene load via Addressables does not NRE in SceneManager
- [ ] WebGL build still compiles with the new `#if` blocks