### PR TITLE
Client/server auth + connection hop: Started-gated handshake, ForceStop, token re-stage (PR-3/7)

### DIFF
--- a/FishMMO-Auth/FishMMO-AuthShared/Implementation/Services/SrpService.cs
+++ b/FishMMO-Auth/FishMMO-AuthShared/Implementation/Services/SrpService.cs
@@ -465,7 +465,10 @@ namespace FishMMO.Auth.Implementation
 		}
 
 		/// <summary>
-		/// Decrypts an auth token from a SRP success message.
+		/// Decrypts an auth token from a SRP success (or mid-session renewal) message.
+		/// Must use <see cref="CryptoHelper.AuthMessageType.TokenTransfer"/> AAD — the same
+		/// type used by <see cref="TokenService.EncryptTokenForSend"/>. Using SrpSuccess here
+		/// causes AES-GCM tag mismatch (<c>TokenDecryptFailed</c>) after a successful login.
 		/// </summary>
 		/// <param name="encryptedToken">AES-GCM encrypted token bytes.</param>
 		/// <param name="serverToClientKey">AES-256 key for server→client direction.</param>
@@ -479,7 +482,8 @@ namespace FishMMO.Auth.Implementation
 			ushort agreedVersion)
 		{
 			var (tokenNonce, tokenRseq) = receiveNonceCtx.NextNonce();
-			byte[] tokenAad = CryptoHelper.BuildAad((byte)CryptoHelper.AuthMessageType.TokenTransfer, agreedVersion, tokenRseq);
+			byte[] tokenAad = CryptoHelper.BuildAad(
+				(byte)CryptoHelper.AuthMessageType.TokenTransfer, agreedVersion, tokenRseq);
 			return CryptoHelper.DecryptAES(serverToClientKey, tokenNonce, encryptedToken, tokenAad);
 		}
 

--- a/FishMMO-Auth/FishMMO-ClientAuth/Implementation/Auth/ClientAuthenticatorCore.cs
+++ b/FishMMO-Auth/FishMMO-ClientAuth/Implementation/Auth/ClientAuthenticatorCore.cs
@@ -147,6 +147,11 @@ namespace FishMMO.Auth.Implementation
 			if (register && (string.IsNullOrWhiteSpace(email) || !IsAllowedEmailUsername(email)))
 				return false;
 
+			// Registration requires a real calendar age (UI maps dropdown index → 13..120).
+			// Passing the raw dropdown index (e.g. 1 for "13") is a client bug and must fail here.
+			if (register && (age < 13 || age > 120))
+				return false;
+
 			this.username = username;
 			this.password = password;
 			this.register = register;
@@ -174,6 +179,23 @@ namespace FishMMO.Auth.Implementation
 			srpSuccessProcessed = 0;
 			cookieEchoed = 0;
 
+			_ = Log.Info(LogPrefix,
+				$"OnConnected register={register} hasUser={!string.IsNullOrEmpty(username)} " +
+				$"hasEmail={!string.IsNullOrEmpty(email)} age={age} " +
+				$"tokenLen={connectionToken?.Length ?? 0} hasAuthToken={storedAuthToken != null} " +
+				"(sending ClientHandshake; CreateAccount only after ECDH if register=true)");
+
+			// Credentials must survive the Stop→Start race. If they are missing on a
+			// login/register path, handshake still goes out but CreateAccount/SRP will fail later.
+			if (storedAuthToken == null &&
+				(string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password)))
+			{
+				_ = Log.Error(LogPrefix,
+					"OnConnected with empty credentials and no auth token — " +
+					"CreateAccount/SRP will fail after ECDH. " +
+					"Likely SetLoginCredentials was wiped before Started (credential race).");
+			}
+
 			SendClientHandshake(
 				ephemeralKeyPair.PublicKey,
 				cookie: null,
@@ -185,7 +207,9 @@ namespace FishMMO.Auth.Implementation
 
 		/// <summary>
 		/// Call when the transport connection stops or is stopped.
-		/// Clears all per-connection key material (not the stored auth token).
+		/// Clears per-connection crypto keys only — login/register credentials are kept
+		/// so a <c>StopConnection</c>→<c>StartConnection</c> race (used by every connect)
+		/// cannot wipe <c>register=true</c> before ECDH completes and CreateAccount is sent.
 		/// </summary>
 		public void OnDisconnected()
 		{
@@ -200,6 +224,7 @@ namespace FishMMO.Auth.Implementation
 			ephemeralKeyPair?.Dispose();
 			ephemeralKeyPair = null;
 			ClearKeyMaterial();
+			ClearCredentials();
 			ClearAuthToken();
 		}
 
@@ -353,6 +378,10 @@ namespace FishMMO.Auth.Implementation
 
 			if (register)
 			{
+				_ = Log.Info(LogPrefix,
+					$"ECDH complete — register path encrypting CreateAccount fields " +
+					$"(userLen={username?.Length ?? 0} emailLen={email?.Length ?? 0} age={age})");
+
 				srpData.GetSaltAndVerifier(username, password, out string salt, out string verifier);
 
 				byte[] encryptedEmail;
@@ -376,6 +405,11 @@ namespace FishMMO.Auth.Implementation
 				}
 
 				SendCreateAccount(encryptedUsername, encryptedEmail, encryptedAge, encryptedSalt, encryptedVerifier, createAccountSeq);
+
+				// Password/email no longer needed after CreateAccount is queued; keep username for verify UI.
+				password = null;
+				email = null;
+				_ = Log.Info(LogPrefix, "CreateAccount broadcast queued (await AccountCreationSystem server-side handle)");
 			}
 			else
 			{
@@ -505,35 +539,54 @@ namespace FishMMO.Auth.Implementation
 
 			if (srpData.Verify(proof, out string _))
 			{
-
-				if (result == ClientAuthenticationResult.LoginSuccess &&
-					encryptedToken != null && encryptedToken.Length > 0)
+				// LoginSuccess requires a decryptable auth token for world handoff.
+				// Decrypt first; never emit LoginSuccess if the token cannot be stored
+				// (avoids CharacterSelect + spurious LoginSuccess then TokenDecryptFailed).
+				if (result == ClientAuthenticationResult.LoginSuccess)
 				{
+					if (encryptedToken == null || encryptedToken.Length == 0)
+					{
+						_ = Log.Warning(LogPrefix,
+							"LoginSuccess received without encrypted auth token.");
+						storedAuthToken = null;
+						OnAuthResultCallback(ClientAuthenticationResult.TokenDecryptFailed);
+						_ = Log.Debug(LogPrefix, ClientAuthenticationResult.TokenDecryptFailed.ToString());
+						srpData.Clear();
+						srpData = null;
+						return;
+					}
+
 					try
 					{
-						storedAuthToken = SrpService.ClientDecryptAuthToken(encryptedToken, serverToClientKey, receiveNonceCtx, agreedVersion);
+						storedAuthToken = SrpService.ClientDecryptAuthToken(
+							encryptedToken, serverToClientKey, receiveNonceCtx, agreedVersion);
 						if (storedAuthToken == null || storedAuthToken.Length == 0)
 						{
 							if (storedAuthToken != null)
-							{
 								CryptographicOperations.ZeroMemory(storedAuthToken);
-							}
 							storedAuthToken = null;
 							_ = Log.Warning(LogPrefix, "Decrypted auth token is null or empty.");
+							OnAuthResultCallback(ClientAuthenticationResult.TokenDecryptFailed);
+							_ = Log.Debug(LogPrefix, ClientAuthenticationResult.TokenDecryptFailed.ToString());
+							srpData.Clear();
+							srpData = null;
+							return;
 						}
 					}
 					catch (CryptographicException tokenEx)
 					{
-						_ = Log.Warning(LogPrefix, $"Failed to decrypt auth token (non-fatal): {tokenEx.Message}");
+						_ = Log.Warning(LogPrefix,
+							$"Failed to decrypt auth token: {tokenEx.Message}");
 						storedAuthToken = null;
+						OnAuthResultCallback(ClientAuthenticationResult.TokenDecryptFailed);
+						_ = Log.Debug(LogPrefix, ClientAuthenticationResult.TokenDecryptFailed.ToString());
+						srpData.Clear();
+						srpData = null;
+						return;
 					}
 				}
 
-				OnAuthResultCallback(
-					result == ClientAuthenticationResult.LoginSuccess && storedAuthToken == null
-						? ClientAuthenticationResult.TokenDecryptFailed
-						: result);
-
+				OnAuthResultCallback(result);
 				_ = Log.Debug(LogPrefix, result.ToString());
 
 				srpData.Clear();
@@ -661,8 +714,10 @@ namespace FishMMO.Auth.Implementation
 		#region Key Material Cleanup
 
 		/// <summary>
-		/// Zeroes all per-connection key material and resets state.
-		/// Does NOT clear <see cref="storedAuthToken"/>.
+		/// Zeroes all per-connection crypto key material and resets handshake state.
+		/// Does NOT clear <see cref="storedAuthToken"/> or login/register credentials.
+		/// Credentials are intentionally preserved across transport Stop→Start so
+		/// create-account / login can complete after the connection is fully ready.
 		/// </summary>
 		public void ClearKeyMaterial()
 		{
@@ -685,6 +740,17 @@ namespace FishMMO.Auth.Implementation
 			receiveNonceCtx?.Dispose();
 			receiveNonceCtx = null;
 			agreedVersion = 0;
+			// NOTE: do not clear username/password/email/register/age here.
+			// ConnectToServer always StopConnection() first; that fired OnDisconnected
+			// and previously wiped register=true before ECDH → CreateAccount never sent.
+		}
+
+		/// <summary>
+		/// Clears login/register credentials from memory. Call on explicit cancel,
+		/// logout, dispose, or after a terminal auth failure the UI has handled.
+		/// </summary>
+		public void ClearCredentials()
+		{
 			username = null;
 			password = null;
 			email = null;

--- a/FishMMO-Auth/FishMMO-ServerAuth/Implementation/Auth/SrpAuthenticatorCore.cs
+++ b/FishMMO-Auth/FishMMO-ServerAuth/Implementation/Auth/SrpAuthenticatorCore.cs
@@ -592,7 +592,7 @@ namespace FishMMO.Auth.Implementation
 				PurgeConnectionAuthState(conn, disconnect: true);
 				return;
 			}
-			if (!sem.Wait(TimeSpan.Zero))
+			if (!sem.Wait(0))
 			{
 				BroadcastAuthResult(conn, ClientAuthenticationResult.TwoFactorInvalid, reliable: true);
 				return;

--- a/FishMMO-Unity/Assets/Scripts/Client/Authentication/ClientLoginAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Authentication/ClientLoginAuthenticator.cs
@@ -3,11 +3,14 @@ using FishNet.Connection;
 using FishNet.Managing;
 using FishNet.Transporting;
 using System;
+using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using FishMMO.Auth.Core;
 using FishMMO.Shared;
 using FishMMO.Auth.Implementation;
+using FishMMO.Logging;
+using UnityEngine;
 
 namespace FishMMO.Client
 {
@@ -53,15 +56,41 @@ namespace FishMMO.Client
 			/// </summary>
 			protected override void SendClientHandshake(byte[] publicKey, byte[] cookie, string connectionToken, ushort minVersion, ushort maxVersion, string gameVersion)
 			{
-				Client.Broadcast(new ClientHandshake()
+				// Require full readiness: FishNet.ClientManager.Started AND managerState=Started.
+				// Sending when manager is still Starting was logging "sent OK" with zero server payload.
+				if (!outer.IsFullyReadyToBroadcast())
 				{
-					PublicKey = publicKey,
-					Cookie = cookie,
-					ConnectionToken = connectionToken,
-					MinVersion = minVersion,
-					MaxVersion = maxVersion,
-					GameVersion = gameVersion,
-				}, Channel.Reliable);
+					outer.lastHandshakeSendSucceeded = false;
+					Log.Warning("ClientLoginAuthenticator",
+						$"Send ClientHandshake deferred: fishNetStarted={outer.IsFishNetClientStarted()} " +
+						$"managerState={outer.GetManagerState()}. Need both Started.");
+					return;
+				}
+				Log.Info("ClientLoginAuthenticator",
+					$"Send ClientHandshake pubKeyLen={publicKey?.Length ?? 0} cookieLen={cookie?.Length ?? 0} " +
+					$"tokenLen={connectionToken?.Length ?? 0} gameVersion={gameVersion ?? "?"} " +
+					$"managerState={outer.GetManagerState()} (fully ready — Broadcast now)");
+				try
+				{
+					// Client.Broadcast is the static helper on FishMMO.Client.Client.
+					Client.Broadcast(new ClientHandshake()
+					{
+						PublicKey = publicKey,
+						Cookie = cookie,
+						ConnectionToken = connectionToken,
+						MinVersion = minVersion,
+						MaxVersion = maxVersion,
+						GameVersion = gameVersion,
+					}, Channel.Reliable);
+					outer.lastHandshakeSendSucceeded = true;
+				}
+				catch (Exception ex)
+				{
+					outer.lastHandshakeSendSucceeded = false;
+					// Do not rethrow: Client.OnLogMessage used to ForceDisconnect on network-stack
+					// exceptions, which produced establish → instant TRANSPORT shutdown.
+					Log.Error("ClientLoginAuthenticator", $"ClientHandshake Broadcast failed: {ex.Message}", ex);
+				}
 			}
 
 			/// <summary>
@@ -111,15 +140,35 @@ namespace FishMMO.Client
 				byte[] encryptedUsername, byte[] encryptedEmail, byte[] encryptedAge,
 				byte[] encryptedSalt, byte[] encryptedVerifier, uint seq)
 			{
-				Client.Broadcast(new CreateAccountBroadcast()
+				if (!outer.IsFullyReadyToBroadcast())
 				{
-					Username = encryptedUsername,
-					Email = encryptedEmail,
-					Age = encryptedAge,
-					Salt = encryptedSalt,
-					Verifier = encryptedVerifier,
-					Seq = seq,
-				}, Channel.Reliable);
+					Log.Error("ClientLoginAuthenticator",
+						$"Send CreateAccountBroadcast aborted: fishNetStarted={outer.IsFishNetClientStarted()} " +
+						$"managerState={outer.GetManagerState()}");
+					return;
+				}
+				Log.Info("ClientLoginAuthenticator",
+					$"Send CreateAccountBroadcast seq={seq} " +
+					$"userEnc={encryptedUsername?.Length ?? 0} emailEnc={encryptedEmail?.Length ?? 0} " +
+					$"ageEnc={encryptedAge?.Length ?? 0} saltEnc={encryptedSalt?.Length ?? 0} " +
+					$"verifierEnc={encryptedVerifier?.Length ?? 0} (register path after ECDH — " +
+					"LoginServer must log CreateAccountBroadcast received)");
+				try
+				{
+					Client.Broadcast(new CreateAccountBroadcast()
+					{
+						Username = encryptedUsername,
+						Email = encryptedEmail,
+						Age = encryptedAge,
+						Salt = encryptedSalt,
+						Verifier = encryptedVerifier,
+						Seq = seq,
+					}, Channel.Reliable);
+				}
+				catch (Exception ex)
+				{
+					Log.Error("ClientLoginAuthenticator", $"CreateAccountBroadcast failed: {ex.Message}", ex);
+				}
 			}
 
 			/// <summary>
@@ -206,6 +255,45 @@ namespace FishMMO.Client
 		private bool initialized;
 
 		/// <summary>
+		/// True after a successful initial <see cref="ClientHandshake"/> broadcast on this connection
+		/// while fully ready (FishNet + connection manager both Started).
+		/// Cleared on Stopped/Stopping so the next connect can send again.
+		/// </summary>
+		private bool initialClientHandshakeSent;
+
+		/// <summary>
+		/// Set by <see cref="LoginAuthenticatorCore.SendClientHandshake"/> so the outer can
+		/// know whether the last send actually went out (vs deferred/aborted).
+		/// </summary>
+		private bool lastHandshakeSendSucceeded;
+
+		/// <summary>
+		/// Connection token held until handshake send succeeds (survives deferred retry).
+		/// </summary>
+		private string pendingHandshakeConnectionToken;
+
+		/// <summary>
+		/// True once any <see cref="ServerHandshake"/> is received this connection.
+		/// "sent OK" alone is not progress — server must reply.
+		/// </summary>
+		private bool serverHandshakeReceived;
+
+		/// <summary>Coroutine waiting for connection-manager Started before first handshake.</summary>
+		private Coroutine waitForManagerReadyRoutine;
+
+		/// <summary>Coroutine watching for ServerHandshake after ClientHandshake send.</summary>
+		private Coroutine serverHandshakeWatchdogRoutine;
+
+		/// <summary>How long to wait for ClientConnectionManager.ClientState == Started after FishNet starts.</summary>
+		private const float ManagerReadyWaitSeconds = 10f;
+
+		/// <summary>How long after ClientHandshake send to wait for ServerHandshake before declaring failure.</summary>
+		private const float ServerHandshakeTimeoutSeconds = 12f;
+
+		/// <summary>Resend ClientHandshake once if no ServerHandshake after this many seconds (wire path verified).</summary>
+		private const float ClientHandshakeResendAfterSeconds = 2f;
+
+		/// <summary>
 		/// Client authentication event. Subscribe to receive authentication results from the server.
 		/// </summary>
 		public event Action<ClientAuthenticationResult> OnClientAuthenticationResult;
@@ -269,12 +357,14 @@ namespace FishMMO.Client
 		// the transport may have fired connection state callbacks (e.g., disconnect
 		// due to timeout, or the server dropped us). If we call OnConnected on a
 		// stopped connection, the core state machine will be in an inconsistent
-		// state. Only proceed if the connection is still valid.
-		if (Client == null || Client.Connection == null ||
-			Client.Connection.ClientState == LocalConnectionState.Stopped)
+		// state. Only proceed if FishNet is still Started.
+		if (!IsFishNetClientStarted())
 			return;
+		// Force a full re-handshake (queue admit path); token already recovered.
+		ResetHandshakeSessionState();
+		pendingHandshakeConnectionToken = null;
 		core.OnDisconnected();
-		core.OnConnected(connectionToken: null);
+		TrySendInitialClientHandshake("RetryHandshakeAsync");
 	}
 
 		/// <summary>
@@ -305,6 +395,7 @@ namespace FishMMO.Client
 		/// </summary>
 		private void OnDestroy()
 		{
+			UnsubscribeConnectionReady();
 			if (initialized && networkManager != null && networkManager.ClientManager != null)
 			{
 				networkManager.ClientManager.OnClientConnectionState -= ClientManager_OnClientConnectionState;
@@ -321,12 +412,323 @@ namespace FishMMO.Client
 
 		/// <summary>
 		/// Sets the client instance for broadcasting messages.
+		/// Subscribes to <see cref="ClientConnectionManager.OnConnectionSuccessful"/> so
+		/// ClientHandshake can be retried after the connection manager reaches Started
+		/// if the first attempt was deferred.
 		/// </summary>
 		/// <param name="client">The client instance.</param>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public void SetClient(Client client)
 		{
+			UnsubscribeConnectionReady();
 			Client = client;
+			if (Client?.Connection != null)
+				Client.Connection.OnConnectionSuccessful += OnConnectionManagerSuccessful;
+		}
+
+		private void UnsubscribeConnectionReady()
+		{
+			if (Client?.Connection != null)
+				Client.Connection.OnConnectionSuccessful -= OnConnectionManagerSuccessful;
+		}
+
+		/// <summary>
+		/// True when FishNet reports the client transport as Started (broadcasts allowed).
+		/// Prefers the cached networkManager from InitializeOnce; falls back to base.NetworkManager.
+		/// </summary>
+		private bool IsFishNetClientStarted()
+		{
+			var nm = networkManager ?? base.NetworkManager;
+			return nm != null
+				&& nm.ClientManager != null
+				&& nm.ClientManager.Started;
+		}
+
+		/// <summary>
+		/// True only when both FishNet and our connection manager report Started.
+		/// Sending while managerState is still Starting marks "sent OK" but LoginServer
+		/// often sees zero app payload — do not send until both are Started.
+		/// </summary>
+		private bool IsFullyReadyToBroadcast()
+		{
+			if (!IsFishNetClientStarted())
+				return false;
+			// When Client/Connection is wired, require managerState == Started.
+			if (Client?.Connection != null
+				&& Client.Connection.ClientState != LocalConnectionState.Started)
+				return false;
+			return true;
+		}
+
+		private LocalConnectionState GetManagerState()
+		{
+			return Client?.Connection?.ClientState ?? LocalConnectionState.Stopped;
+		}
+
+		/// <summary>
+		/// Capture ConnectionToken into pending so deferred handshake retries keep it.
+		/// </summary>
+		private void CapturePendingToken()
+		{
+			if (pendingHandshakeConnectionToken == null && !string.IsNullOrEmpty(ConnectionToken))
+			{
+				pendingHandshakeConnectionToken = ConnectionToken;
+				ConnectionToken = null;
+			}
+		}
+
+		/// <summary>
+		/// Backup path: ClientConnectionManager has applied Started. This is the preferred
+		/// send path — managerState is guaranteed Started when this fires.
+		/// </summary>
+		private void OnConnectionManagerSuccessful()
+		{
+			CapturePendingToken();
+			TrySendInitialClientHandshake("ClientConnection.OnConnectionSuccessful");
+		}
+
+		/// <summary>
+		/// Sends the initial ClientHandshake once per connection, only when fully ready
+		/// (FishNet.ClientManager.Started AND ClientConnectionManager.ClientState == Started).
+		/// </summary>
+		private void TrySendInitialClientHandshake(string source)
+		{
+			if (core == null || !initialized) return;
+			if (initialClientHandshakeSent)
+			{
+				Log.Debug("ClientLoginAuthenticator",
+					$"Skip ClientHandshake ({source}): already sent this connection");
+				return;
+			}
+
+			CapturePendingToken();
+
+			bool fishNet = IsFishNetClientStarted();
+			var managerState = GetManagerState();
+			if (!IsFullyReadyToBroadcast())
+			{
+				Log.Warning("ClientLoginAuthenticator",
+					$"Defer ClientHandshake ({source}): fishNetStarted={fishNet} " +
+					$"managerState={managerState} (need both Started — will retry on manager ready)");
+				// Poll until manager catches up (covers missing OnConnectionSuccessful race).
+				EnsureWaitForManagerReadyRoutine();
+				return;
+			}
+
+			string token = pendingHandshakeConnectionToken;
+			lastHandshakeSendSucceeded = false;
+
+			Log.Info("ClientLoginAuthenticator",
+				$"TrySendInitialClientHandshake source={source} tokenLen={token?.Length ?? 0} " +
+				$"fishNetStarted=true managerState={managerState} (fully ready)");
+
+			try
+			{
+				// Clear any partial crypto from a deferred prior attempt, then start clean.
+				core.OnDisconnected();
+				core.OnConnected(token);
+			}
+			catch (Exception ex)
+			{
+				Log.Error("ClientLoginAuthenticator",
+					$"OnConnected/handshake failed ({source}): {ex.Message}", ex);
+				return;
+			}
+
+			if (lastHandshakeSendSucceeded)
+			{
+				initialClientHandshakeSent = true;
+				// Keep pendingHandshakeConnectionToken until ServerHandshake arrives so a
+				// 2s resend still has tokenLen>0 (IPFetch token was already consumed once).
+				pendingHandshakeConnectionToken = token;
+				StopWaitForManagerReadyRoutine();
+				Log.Info("ClientLoginAuthenticator",
+					$"ClientHandshake Broadcast returned ({source}) managerState=Started " +
+					$"tokenLenKept={token?.Length ?? 0} — NOT progress until WIRE SEND OK + ServerHandshake");
+				LogWireStats("post-broadcast");
+				// Only start watchdog once per connection (resend reuses it).
+				if (serverHandshakeWatchdogRoutine == null && !serverHandshakeReceived)
+					StartServerHandshakeWatchdog();
+			}
+			else
+			{
+				// Keep token for the next ready signal.
+				pendingHandshakeConnectionToken = token;
+				Log.Warning("ClientLoginAuthenticator",
+					$"ClientHandshake not sent ({source}); will retry on next fully-ready signal");
+				EnsureWaitForManagerReadyRoutine();
+			}
+		}
+
+		private void EnsureWaitForManagerReadyRoutine()
+		{
+			if (waitForManagerReadyRoutine != null) return;
+			if (!isActiveAndEnabled) return;
+			waitForManagerReadyRoutine = StartCoroutine(WaitForManagerReadyThenHandshake());
+		}
+
+		private void StopWaitForManagerReadyRoutine()
+		{
+			if (waitForManagerReadyRoutine == null) return;
+			StopCoroutine(waitForManagerReadyRoutine);
+			waitForManagerReadyRoutine = null;
+		}
+
+		/// <summary>
+		/// Polls until managerState == Started (or timeout/disconnect), then sends handshake once.
+		/// </summary>
+		private IEnumerator WaitForManagerReadyThenHandshake()
+		{
+			float deadline = Time.realtimeSinceStartup + ManagerReadyWaitSeconds;
+			while (Time.realtimeSinceStartup < deadline)
+			{
+				if (initialClientHandshakeSent)
+				{
+					waitForManagerReadyRoutine = null;
+					yield break;
+				}
+				if (!IsFishNetClientStarted())
+				{
+					Log.Warning("ClientLoginAuthenticator",
+						"WaitForManagerReady aborted: FishNet no longer Started");
+					waitForManagerReadyRoutine = null;
+					yield break;
+				}
+				if (IsFullyReadyToBroadcast())
+				{
+					waitForManagerReadyRoutine = null;
+					TrySendInitialClientHandshake("WaitForManagerReady.coroutine");
+					yield break;
+				}
+				yield return null;
+			}
+			waitForManagerReadyRoutine = null;
+			Log.Error("ClientLoginAuthenticator",
+				$"Timed out after {ManagerReadyWaitSeconds:0}s waiting for managerState=Started " +
+				$"(last managerState={GetManagerState()}). ClientHandshake never sent.");
+		}
+
+		private void StartServerHandshakeWatchdog()
+		{
+			serverHandshakeReceived = false;
+			if (serverHandshakeWatchdogRoutine != null)
+				StopCoroutine(serverHandshakeWatchdogRoutine);
+			if (!isActiveAndEnabled) return;
+			serverHandshakeWatchdogRoutine = StartCoroutine(ServerHandshakeWatchdog());
+		}
+
+		private void StopServerHandshakeWatchdog()
+		{
+			if (serverHandshakeWatchdogRoutine == null) return;
+			StopCoroutine(serverHandshakeWatchdogRoutine);
+			serverHandshakeWatchdogRoutine = null;
+		}
+
+		/// <summary>
+		/// After ClientHandshake is queued, require ServerHandshake within a timeout.
+		/// "Broadcast queued" is NOT success — prove ServerHandshake or wire silence.
+		/// Optional one resend at ~2s if still no reply.
+		/// </summary>
+		private IEnumerator ServerHandshakeWatchdog()
+		{
+			float start = Time.realtimeSinceStartup;
+			float deadline = start + ServerHandshakeTimeoutSeconds;
+			bool resendAttempted = false;
+
+			while (Time.realtimeSinceStartup < deadline)
+			{
+				if (serverHandshakeReceived)
+				{
+					serverHandshakeWatchdogRoutine = null;
+					yield break;
+				}
+				if (!IsFishNetClientStarted())
+				{
+					serverHandshakeWatchdogRoutine = null;
+					yield break;
+				}
+
+				// One resend after 2s if no ServerHandshake (only when still fully ready).
+				if (!resendAttempted
+					&& (Time.realtimeSinceStartup - start) >= ClientHandshakeResendAfterSeconds
+					&& IsFullyReadyToBroadcast())
+				{
+					resendAttempted = true;
+					LogWireStats("pre-resend");
+					Log.Warning("ClientLoginAuthenticator",
+						$"No ServerHandshake after {ClientHandshakeResendAfterSeconds:0.#}s — " +
+						"resending ClientHandshake once (wire path re-prove)");
+					// Allow TrySend to run again with same connection.
+					initialClientHandshakeSent = false;
+					lastHandshakeSendSucceeded = false;
+					TrySendInitialClientHandshake("ServerHandshakeWatchdog.resend");
+				}
+
+				yield return null;
+			}
+			serverHandshakeWatchdogRoutine = null;
+			if (serverHandshakeReceived) yield break;
+
+			LogWireStats("timeout");
+			Log.Error("ClientLoginAuthenticator",
+				$"NO ServerHandshake within {ServerHandshakeTimeoutSeconds:0}s after ClientHandshake. " +
+				"Wire send failed or transport silent (not server busy). " +
+				"Check [FishWT] WIRE SEND OK / wireSentOk; LoginServer for FIRST_APP_PAYLOAD. " +
+				"CreateAccount cannot run without ServerHandshake.");
+
+			// Do NOT map to ServerBusy — that misleads the player. Unlock via disconnect.
+			try
+			{
+				Client?.ForceDisconnect();
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("ClientLoginAuthenticator",
+					$"ForceDisconnect after handshake timeout failed: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Log FishNet→WebTransport wire counters so we can see Broadcast queued vs WT send.
+		/// </summary>
+		private void LogWireStats(string tag)
+		{
+			try
+			{
+				var nm = networkManager ?? base.NetworkManager;
+				var wt = nm?.TransportManager?.Transport as FishNet.Transporting.WebTransport.WebTransport;
+				if (wt == null && nm?.TransportManager?.Transport is FishNet.Transporting.Multipass.Multipass mp)
+					wt = mp.ClientTransport as FishNet.Transporting.WebTransport.WebTransport;
+
+				if (wt == null)
+				{
+					Log.Warning("ClientLoginAuthenticator",
+						$"WireStats[{tag}]: WebTransport client transport not found");
+					return;
+				}
+				wt.GetClientWireStats(out long queued, out long sentOk, out long sentFail,
+					out long sentBytes, out long dropNotStarted);
+				Log.Info("ClientLoginAuthenticator",
+					$"WireStats[{tag}]: queued={queued} wireSentOk={sentOk} wireSentFail={sentFail} " +
+					$"wireBytes={sentBytes} dropNotStarted={dropNotStarted} " +
+					$"(if queued>0 && wireSentOk==0 → FishNet→WT glue bug)");
+				UnityEngine.Debug.Log(
+					$"[FishWT] WireStats[{tag}] queued={queued} sentOk={sentOk} sentFail={sentFail} " +
+					$"bytes={sentBytes} dropNotStarted={dropNotStarted}");
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("ClientLoginAuthenticator", $"WireStats[{tag}] failed: {ex.Message}");
+			}
+		}
+
+		private void ResetHandshakeSessionState()
+		{
+			initialClientHandshakeSent = false;
+			lastHandshakeSendSucceeded = false;
+			serverHandshakeReceived = false;
+			StopWaitForManagerReadyRoutine();
+			StopServerHandshakeWatchdog();
 		}
 
 		/// <summary>
@@ -374,6 +776,17 @@ namespace FishMMO.Client
 		public void ClearAuthToken()
 		{
 			core?.ClearAuthToken();
+		}
+
+		/// <summary>
+		/// Clears login/register credentials (username/password/email/register flag).
+		/// Safe after a terminal auth UI result or user cancel; do not call between
+		/// SetLoginCredentials and post-ECDH CreateAccount/SRP send.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public void ClearCredentials()
+		{
+			core?.ClearCredentials();
 		}
 
 		/// <summary>
@@ -449,19 +862,33 @@ namespace FishMMO.Client
 
 		/// <summary>
 		/// FishNet callback invoked when the local client connection state changes.
-		/// Forwards <c>Started</c> to <see cref="ClientAuthenticatorCore.OnConnected"/> and
-		/// <c>Stopping</c>/<c>Stopped</c> to <see cref="ClientAuthenticatorCore.OnDisconnected"/>.
+		/// <c>Started</c> → send ClientHandshake (or schedule retry via connection-manager ready).
+		/// <c>Stopping</c>/<c>Stopped</c> → clear per-connection crypto; credentials kept.
 		/// </summary>
 		private void ClientManager_OnClientConnectionState(ClientConnectionStateArgs args)
 		{
+			Log.Info("ClientLoginAuthenticator",
+				$"ConnectionState={args.ConnectionState} fishNetStarted={IsFishNetClientStarted()} " +
+				$"managerState={GetManagerState()} handshakeSent={initialClientHandshakeSent} " +
+				$"serverHandshakeReceived={serverHandshakeReceived}");
+
 			if (args.ConnectionState == LocalConnectionState.Stopping ||
 				args.ConnectionState == LocalConnectionState.Stopped)
 			{
+				// Crypto only — credentials intentionally survive for create-account race.
 				core.OnDisconnected();
+				ResetHandshakeSessionState();
+				// Drop pending token on full stop so a stale IPFetch token is not reused.
+				if (args.ConnectionState == LocalConnectionState.Stopped)
+					pendingHandshakeConnectionToken = null;
 			}
 			else if (args.ConnectionState == LocalConnectionState.Started)
 			{
-				core.OnConnected(ConnectionToken); ConnectionToken = null;
+				CapturePendingToken();
+				// Do NOT force-send here if managerState is still Starting — that was the
+				// "Broadcast logged OK / zero server payload" bug. Fully-ready gate defers
+				// until ClientConnection.OnConnectionSuccessful or the wait coroutine.
+				TrySendInitialClientHandshake("FishNet.OnClientConnectionState.Started");
 			}
 		}
 
@@ -473,6 +900,30 @@ namespace FishMMO.Client
 		/// </summary>
 		private void OnClientServerHandshakeBroadcastReceived(ServerHandshake msg, Channel channel)
 		{
+			// Phase 1 cookie challenge: PublicKey null/empty + Cookie set, agreedVersion often 0.
+			// Phase 2 ECDH complete: PublicKey 32 bytes, agreedVersion negotiated.
+			// Both are intentional — not mis-routed frames.
+			bool isCookieChallenge = msg.PublicKey == null || msg.PublicKey.Length == 0;
+			if (isCookieChallenge)
+			{
+				// Do not stop the ServerHandshake watchdog yet — wait for phase-2 ECDH.
+				Log.Info("ClientLoginAuthenticator",
+					$"ServerHandshake PHASE1 cookie-challenge pubKeyLen=0 " +
+					$"cookieLen={msg.Cookie?.Length ?? 0} agreedVersion={msg.AgreedVersion} " +
+					"(expected — client will echo cookie; ECDH on next ServerHandshake)");
+			}
+			else
+			{
+				serverHandshakeReceived = true;
+				// Token no longer needed for resend once server completed ECDH.
+				pendingHandshakeConnectionToken = null;
+				StopServerHandshakeWatchdog();
+				LogWireStats("server-handshake-received");
+				Log.Info("ClientLoginAuthenticator",
+					$"ServerHandshake PHASE2 ECDH pubKeyLen={msg.PublicKey?.Length ?? 0} " +
+					$"cookieLen={msg.Cookie?.Length ?? 0} agreedVersion={msg.AgreedVersion} " +
+					"(app payload path confirmed — session keys / CreateAccount / SRP can proceed)");
+			}
 			core.OnServerHandshakeReceived(msg.PublicKey, msg.Cookie, msg.AgreedVersion);
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Client.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Client.cs
@@ -244,6 +244,14 @@ namespace FishMMO.Client
 			KinematicCharacterSystem.Settings.AutoSimulation = false;
 
 			Connection = new ClientConnectionManager(NetworkManager);
+			// World/Scene reconnect must re-stage an IPFetch HMAC token on ClientHandshake.
+			Connection.ReconnectConnectOverride = (address, port) =>
+			{
+				InvalidateLoginServerCache();
+				StartCoroutine(ConnectToServerWithConnectionToken(port, isWorldServer: true,
+					onFail: (err) => Log.Error("Client",
+						$"Reconnect token fetch failed for {address}:{port}: {err}")));
+			};
 
 			// Initialize the OnReconnectFailed -> OnQuitToLogin forwarding delegate.
 			this.onReconnectFailedQuitToLogin = () => OnQuitToLogin?.Invoke();
@@ -260,19 +268,6 @@ namespace FishMMO.Client
 					Connection.OnConnectionSuccessful += (Action)d;
 
 			Connection.OnReconnectFailed += this.onReconnectFailedQuitToLogin;
-
-			// When a non-reconnectable connection fails (e.g. login server unreachable),
-			// invalidate the cached login server list so the next attempt re-fetches from
-			// IPFetch instead of retrying the same potentially dead server/port.
-			Connection.OnConnectionAttemptFailed += () =>
-			{
-				if (this.loginServerPorts != null)
-				{
-					Log.Info("Client", "Login server connection attempt failed — invalidating cached server list.");
-					this.loginServerPorts = null;
-					this.cachedConnectionToken = null;
-				}
-			};
 
 			this.combatDisplay = new ClientCombatDisplay();
 			this.combatDisplay.Initialize();
@@ -292,19 +287,7 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Unity Update. Delegates tick processing to the Connection manager.
 		/// </summary>
-		private void Update()
-		{
-			Connection?.Update();
-			
-			if (pendingErrorStackTrace != null)
-			{
-				string st = pendingErrorStackTrace;
-				pendingErrorStackTrace = null;
-				if (Connection?.ClientState == LocalConnectionState.Stopped) return;
-				try { loginAuthenticator?.RevokeAndClearAuthToken(); } catch { }
-				Connection?.ForceDisconnect();
-			}
-		}
+		private void Update() => Connection?.Update();
 
 		/// <summary>
 		/// Unity OnDestroy. Cleans up event subscriptions, managers, authenticator, connection, and settings.
@@ -347,22 +330,6 @@ namespace FishMMO.Client
 			UIManager.SetClient(null);
 			this.clientPostbootSystem?.UnsetClient(this);
 			Application.logMessageReceived -= OnLogMessage;
-
-#if UNITY_WEBGL || UNITY_IOS || UNITY_ANDROID
-			// ── FIX #5: Best-effort token revocation for WebGL/mobile ──
-			// OnApplicationQuit is not reliably called on these platforms.
-			// OnApplicationPause(true) sets wasApplicationPaused before
-			// OnDestroy fires during tab-close / app-kill.  This is a
-			// best-effort revocation; if the runtime is killed abruptly
-			// (force-quit, browser crash), the token remains valid until
-			// its natural TTL (default 10 min on server).  The auth token
-			// expiry window is the effective revocation delay.
-			if (wasApplicationPaused)
-			{
-				try { this.loginAuthenticator?.RevokeAndClearAuthToken(); }
-				catch { /* best effort — runtime may already be tearing down */ }
-			}
-#endif
 		}
 
 		// ── Init helpers ────────────────────────────────────────────────
@@ -469,14 +436,136 @@ namespace FishMMO.Client
 
 		/// <summary>
 		/// Connects the client to a game server at the specified port.
-		/// Hostname is always <see cref="Constants.Configuration.GameHost"/>.
+		/// Hostname is chosen from the configured hosts by port band
+		/// (login / world / scene) via <see cref="Constants.Configuration.GetGameHostForPort"/>.
 		/// With WebTransport, the port is a QUIC connection parameter, not a URL path.
 		/// </summary>
+		/// <remarks>
+		/// Login UI must set <see cref="ClientLoginAuthenticator.ConnectionToken"/> from IPFetch
+		/// before calling this. World/Scene hops that omit a token automatically re-fetch one
+		/// via <see cref="ConnectToServerWithConnectionToken"/> so WorldServerAuthenticator
+		/// does not reject the first ClientHandshake with cookieLen=0.
+		/// </remarks>
 		/// <param name="port">The server port.</param>
 		/// <param name="isWorldServer">If true, marks this as a world server connection.</param>
 		public void ConnectToServer(ushort port, bool isWorldServer = false)
 		{
-			Connection?.ConnectToServer(Constants.Configuration.GameHost, port, isWorldServer);
+			// World/scene reconnect and server-select often call Connect without re-staging
+			// the IPFetch HMAC token. Login already set ConnectionToken before connect.
+			if (LoginAuthenticator != null && string.IsNullOrEmpty(LoginAuthenticator.ConnectionToken))
+			{
+				Log.Info("Client",
+					$"ConnectToServer port={port} isWorld={isWorldServer}: " +
+					"no staged connection token — fetching fresh IPFetch token first");
+				StartCoroutine(ConnectToServerWithConnectionToken(port, isWorldServer));
+				return;
+			}
+
+			string host = Constants.Configuration.GetGameHostForPort(port);
+			Log.Info("Client",
+				$"ConnectToServer host={host} port={port} isWorld={isWorldServer} " +
+				$"tokenPresent={!string.IsNullOrEmpty(LoginAuthenticator?.ConnectionToken)} " +
+				$"tokenLen={LoginAuthenticator?.ConnectionToken?.Length ?? 0}");
+			Connection?.ConnectToServer(host, port, isWorldServer);
+		}
+
+		/// <summary>
+		/// Fetches a fresh IPFetch HMAC connection token, stages it on
+		/// <see cref="LoginAuthenticator"/>, then connects to the given port.
+		/// Required for Login → World and World → Scene hops behind an L4 UDP proxy:
+		/// the first ClientHandshake must carry ConnectionToken so the server can
+		/// recover the real client IP (otherwise World rejects with cookieLen=0).
+		/// </summary>
+		/// <param name="port">Server port (world or scene).</param>
+		/// <param name="isWorldServer">If true, marks this as a world server connection.</param>
+		/// <param name="onFail">Optional failure callback (IPFetch / empty token).</param>
+		public IEnumerator ConnectToServerWithConnectionToken(
+			ushort port,
+			bool isWorldServer = false,
+			Action<string> onFail = null)
+		{
+			// Always re-fetch: login may have consumed the prior token hours ago, and
+			// IPFetch tokens expire (~60s). Cache hit with a still-valid token is fine.
+			bool ok = false;
+			string failMsg = null;
+
+			// Prefer a still-valid cached token; otherwise hit IPFetch.
+			if (!ShouldRefreshLoginServerList()
+				&& !string.IsNullOrEmpty(this.cachedConnectionToken)
+				&& LoginAuthenticator != null)
+			{
+				LoginAuthenticator.ConnectionToken = this.cachedConnectionToken;
+				ok = true;
+				Log.Info("Client",
+					$"ConnectToServerWithConnectionToken: reusing cached token " +
+					$"len={this.cachedConnectionToken.Length} port={port} isWorld={isWorldServer}");
+			}
+			else
+			{
+				// Drop stale cache so GetLoginServerList always hits IPFetch for a new HMAC.
+				this.loginServerPorts = null;
+				this.loginServerPortsFetchedAt = DateTime.MinValue;
+				this.cachedConnectionToken = null;
+
+				yield return GetLoginServerList(
+					(e) => { failMsg = e; },
+					(ports, token) =>
+					{
+						if (string.IsNullOrEmpty(token))
+						{
+							failMsg = "IPFetch response missing ConnectionToken.";
+							return;
+						}
+						if (LoginAuthenticator != null)
+							LoginAuthenticator.ConnectionToken = token;
+						ok = true;
+						Log.Info("Client",
+							$"ConnectToServerWithConnectionToken: fresh token len={token.Length} " +
+							$"port={port} isWorld={isWorldServer}");
+					});
+			}
+
+			if (!ok || LoginAuthenticator == null || string.IsNullOrEmpty(LoginAuthenticator.ConnectionToken))
+			{
+				string msg = failMsg ?? "Failed to obtain connection token for world/scene handoff.";
+				Log.Error("Client", msg);
+				onFail?.Invoke(msg);
+				yield break;
+			}
+
+			string host = Constants.Configuration.GetGameHostForPort(port);
+			Log.Info("Client",
+				$"ConnectToServer (after token) host={host} port={port} isWorld={isWorldServer} " +
+				$"tokenLen={LoginAuthenticator.ConnectionToken.Length}");
+			Connection?.ConnectToServer(host, port, isWorldServer);
+		}
+
+		/// <summary>
+		/// Clears cached login ports and connection token so the next discovery hits IPFetch.
+		/// Call when the user idles past token TTL or after connect timeout / token rejection.
+		/// </summary>
+		public void InvalidateLoginServerCache()
+		{
+			this.loginServerPorts = null;
+			this.loginServerPortsFetchedAt = DateTime.MinValue;
+			this.cachedConnectionToken = null;
+			if (LoginAuthenticator != null)
+				LoginAuthenticator.ConnectionToken = null;
+			Log.Info("Client", "Login server cache invalidated (ports + connection token).");
+		}
+
+		/// <summary>
+		/// True when the login-server cache is missing, past TTL, or lacks a connection token.
+		/// Token TTL on IPFetch is 60s; client cache is 55s — still force re-fetch if token empty.
+		/// </summary>
+		public bool ShouldRefreshLoginServerList()
+		{
+			if (this.loginServerPorts == null || this.loginServerPorts.Count == 0)
+				return true;
+			if (string.IsNullOrEmpty(this.cachedConnectionToken))
+				return true;
+			double age = Math.Max(0.0, (DateTime.UtcNow - this.loginServerPortsFetchedAt).TotalSeconds);
+			return LoginServerCacheTtlSeconds > 0 && age >= LoginServerCacheTtlSeconds;
 		}
 		/// <summary>
 		/// Checks whether the client connection is ready (authenticated by default).
@@ -546,13 +635,19 @@ namespace FishMMO.Client
 		/// <returns>Coroutine enumerator.</returns>
 		public IEnumerator GetLoginServerList(Action<string> onFail, Action<List<ushort>, string> onDone)
 		{
-			if (this.loginServerPorts != null && this.loginServerPorts.Count > 0)
+			// Require a non-empty connection token; empty token after cache hit forces re-fetch.
+			if (!ShouldRefreshLoginServerList())
 			{
-				double age = Math.Max(0.0, (DateTime.UtcNow - this.loginServerPortsFetchedAt).TotalSeconds);
-				if (LoginServerCacheTtlSeconds <= 0 || age < LoginServerCacheTtlSeconds) { onDone?.Invoke(this.loginServerPorts, this.cachedConnectionToken); yield break; }
+				Log.Info("Client",
+					$"GetLoginServerList: cache hit ports={this.loginServerPorts.Count} tokenLen={this.cachedConnectionToken?.Length ?? 0}");
+				onDone?.Invoke(this.loginServerPorts, this.cachedConnectionToken);
+				yield break;
 			}
+
 			var candidates = ApiHostResolver.GetCandidates() ?? new List<string>();
 			if (candidates.Count == 0) { onFail?.Invoke("Failed to configure APIHost."); yield break; }
+			Log.Info("Client",
+				$"GetLoginServerList: probing {candidates.Count} APIHost candidate(s); first={candidates[0]}");
 			float stagger = this.probeStaggerInterval;
 			var pending = new List<PendingProbe>(candidates.Count);
 			float lastStart = float.NegativeInfinity;
@@ -564,6 +659,7 @@ namespace FishMMO.Client
 					if (next < candidates.Count && (pending.Count == 0 || Time.realtimeSinceStartup - lastStart >= stagger))
 					{
 						var url = candidates[next++] + "loginserver";
+						Log.Info("Client", $"GetLoginServerList: GET {url}");
 						var req = UnityWebRequest.Get(url);
 						req.certificateHandler = new ClientSSLCertificateHandler();
 						req.redirectLimit = -1; // -1 disables redirect following entirely
@@ -581,18 +677,33 @@ namespace FishMMO.Client
 						var done = pending[i]; pending[i] = default;
 						try
 						{
-							if (done.Request.result != UnityWebRequest.Result.Success) { lastErr = done.Request.error; continue; }
-							var parsed = JsonUtility.FromJson<ServerAddresses>(done.Request.downloadHandler.text);
-							if (parsed?.Ports == null) 
-							{ 
-								string rawText = done.Request.downloadHandler.text;
-								lastErr = "Parse failed.";
-								Log.Debug("Client", $"GetLoginServerList: JSON parse failed. Raw response (truncated): {(rawText != null && rawText.Length > 200 ? rawText.Substring(0, 200) + "..." : rawText)}");
-								continue; 
+							long code = done.Request.responseCode;
+							if (done.Request.result != UnityWebRequest.Result.Success)
+							{
+								lastErr = $"HTTP {code}: {done.Request.error}";
+								Log.Warning("Client", $"GetLoginServerList: failed {done.Request.url} → {lastErr}");
+								continue;
 							}
-							// NOTE: Token not explicitly cleared in the cache path. TTL (55s) < server token TTL (60s), providing a 5s safety margin. Reset on QuitToLogin().
+							string rawText = done.Request.downloadHandler?.text;
+							var parsed = JsonUtility.FromJson<ServerAddresses>(rawText);
+							if (parsed?.Ports == null || parsed.Ports.Count == 0)
+							{
+								lastErr = "Parse failed or empty Ports.";
+								Log.Warning("Client",
+									$"GetLoginServerList: parse failed HTTP {code}. Raw (truncated): " +
+									$"{(rawText != null && rawText.Length > 200 ? rawText.Substring(0, 200) + "..." : rawText)}");
+								continue;
+							}
+							if (string.IsNullOrEmpty(parsed.ConnectionToken))
+							{
+								lastErr = "IPFetch response missing ConnectionToken.";
+								Log.Warning("Client", "GetLoginServerList: empty ConnectionToken — cannot complete WT handshake.");
+								continue;
+							}
 							this.cachedConnectionToken = parsed.ConnectionToken;
 							winner = parsed.Ports;
+							Log.Info("Client",
+								$"GetLoginServerList: OK ports=[{string.Join(",", winner)}] tokenLen={parsed.ConnectionToken.Length}");
 							break;
 						}
 						finally { done.Request.Dispose(); }
@@ -657,7 +768,23 @@ namespace FishMMO.Client
 		/// </summary>
 		/// <param name="msg">The world scene connect message.</param>
 		/// <param name="ch">The network channel.</param>
-		private void OnWorldSceneConnect(WorldSceneConnectBroadcast msg, Channel ch) { try { if (IsConnectionReady()) ConnectToServer(msg.Port); } catch (Exception ex) { Log.Error("Client", $"OnWorldSceneConnect: {ex}"); } }
+		private void OnWorldSceneConnect(WorldSceneConnectBroadcast msg, Channel ch)
+		{
+			try
+			{
+				if (!IsConnectionReady())
+					return;
+				// Scene hop is a new WT session — need a fresh IPFetch connection token
+				// just like Login → World (WorldSceneConnect only carries the port).
+				InvalidateLoginServerCache();
+				StartCoroutine(ConnectToServerWithConnectionToken(msg.Port, isWorldServer: false,
+					onFail: (err) => Log.Error("Client", $"Scene connect token fetch failed: {err}")));
+			}
+			catch (Exception ex)
+			{
+				Log.Error("Client", $"OnWorldSceneConnect: {ex}");
+			}
+		}
 		/// <summary>
 		/// Handles a validated scene broadcast by beginning the world scene preload queue.
 		/// </summary>
@@ -726,23 +853,9 @@ namespace FishMMO.Client
 			if (UIManager.TryGet("UIDialogBox", out UIDialogBox d) && d.Visible)
 				d.Hide();
 
-			/* async void local function captures Unity's SynchronizationContext
-			 * so the continuation after await runs on the main thread.
-			 * ContinueWith would run on the ThreadPool, making Log.Error
-			 * and any future Unity API calls unsafe. */
-			async void RetryWithFaultHandling()
-			{
-				try
-				{
-					if (loginAuthenticator != null)
-						await loginAuthenticator.RetryHandshakeAsync();
-				}
-				catch (Exception ex)
-				{
-					Log.Error("Client", $"RetryHandshakeAsync failed: {ex.Message}");
-				}
-			}
-			RetryWithFaultHandling();
+			_ = (loginAuthenticator?.RetryHandshakeAsync() ?? System.Threading.Tasks.Task.CompletedTask)
+				.ContinueWith(static t => Log.Error("Client", $"RetryHandshakeAsync failed: {t.Exception?.InnerException?.Message}"),
+					System.Threading.Tasks.TaskContinuationOptions.OnlyOnFaulted);
 		}
 		else // position -1 = cancelled (timeout / shutdown)
 		{
@@ -770,9 +883,38 @@ namespace FishMMO.Client
 		{
 			switch (r)
 			{
-				case ClientAuthenticationResult.LoginSuccess: Connection.CurrentConnectionType = ServerConnectionType.Login; break;
-				case ClientAuthenticationResult.WorldLoginSuccess: Connection.CurrentConnectionType = ServerConnectionType.World; break;
-				case ClientAuthenticationResult.SceneLoginSuccess: Connection.CurrentConnectionType = ServerConnectionType.Scene; DismissLoadingScreen(true); OnEnterGameWorld?.Invoke(); break;
+				case ClientAuthenticationResult.LoginSuccess:
+					Connection.CurrentConnectionType = ServerConnectionType.Login;
+					break;
+				case ClientAuthenticationResult.WorldLoginSuccess:
+					Connection.CurrentConnectionType = ServerConnectionType.World;
+					break;
+				case ClientAuthenticationResult.SceneLoginSuccess:
+					Connection.CurrentConnectionType = ServerConnectionType.Scene;
+					DismissLoadingScreen(true);
+					OnEnterGameWorld?.Invoke();
+					break;
+				// Expected intermediate / failure codes — UI panels own presentation.
+				case ClientAuthenticationResult.TokenDecryptFailed:
+				case ClientAuthenticationResult.TokenInvalid:
+				case ClientAuthenticationResult.TokenExpired:
+				case ClientAuthenticationResult.TokenRevoked:
+				case ClientAuthenticationResult.AccountCreated:
+				case ClientAuthenticationResult.AccountVerified:
+				case ClientAuthenticationResult.AccountUnverified:
+				case ClientAuthenticationResult.InvalidUsernameOrPassword:
+				case ClientAuthenticationResult.AlreadyOnline:
+				case ClientAuthenticationResult.Banned:
+				case ClientAuthenticationResult.ServerFull:
+				case ClientAuthenticationResult.ServerBusy:
+				case ClientAuthenticationResult.VersionMismatch:
+				case ClientAuthenticationResult.TwoFactorRequired:
+				case ClientAuthenticationResult.TwoFactorInvalid:
+				case ClientAuthenticationResult.SrpVerify:
+				case ClientAuthenticationResult.SrpProof:
+				case ClientAuthenticationResult.NoCharacterSelected:
+					Log.Info("Client", $"Auth result: {r}");
+					break;
 				default:
 					Log.Warning("Client", $"Unhandled auth result: {r}");
 					break;
@@ -780,19 +922,9 @@ namespace FishMMO.Client
 		}
 
 		// ── Log guard ───────────────────────────────────────────────────
-		
+
 		/// <summary>
-		/// Set by <see cref="OnLogMessage"/> on any thread when a networking-related
-		/// exception is logged.  Checked and cleared on the main thread in
-		/// <see cref="Update"/> so that Unity API calls (ForceDisconnect, auth
-		/// token revocation) always execute on the main thread.
-		/// </summary>
-		private volatile string pendingErrorStackTrace;
-		
-		/// <summary>
-		/// Handles Unity log messages. Thread-safe: stores the stack trace in a
-		/// volatile field for main-thread processing in <see cref="Update"/>.
-		/// Forces a disconnect on unhandled exceptions from the networking stack.
+		/// Handles Unity log messages. Forces a disconnect on unhandled exceptions from the networking stack.
 		/// </summary>
 		/// <param name="condition">The log message.</param>
 		/// <param name="stackTrace">The stack trace.</param>
@@ -800,9 +932,26 @@ namespace FishMMO.Client
 		private void OnLogMessage(string condition, string stackTrace, LogType type)
 		{
 			if (type != LogType.Exception) return;
-			Log.Error("Client", stackTrace);
+			Log.Error("Client",
+				$"Unhandled exception (will not auto-disconnect unless network stack): {condition}\n{stackTrace}");
+			if (Connection?.ClientState == LocalConnectionState.Stopped) return;
 			if (string.IsNullOrEmpty(stackTrace) || !IsNetworkStack(stackTrace)) return;
-			pendingErrorStackTrace = stackTrace;
+			// Force-disconnecting on every network exception produces the production
+			// create-account signature: WT session established → instant TRANSPORT
+			// shutdown with zero CreateAccountBroadcast. Prefer logging + leave the
+			// connection up so auth can still complete; only kill on true transport faults.
+			bool isTransportFault =
+				stackTrace.IndexOf("FishNet.Transporting.", StringComparison.Ordinal) >= 0 ||
+				stackTrace.IndexOf("WebTransport", StringComparison.Ordinal) >= 0;
+			if (!isTransportFault)
+			{
+				Log.Warning("Client",
+					"Network-adjacent exception during auth/game code — keeping connection open " +
+					"(avoids create-account hang from premature ForceDisconnect).");
+				return;
+			}
+			try { loginAuthenticator?.RevokeAndClearAuthToken(); } catch { }
+			Connection?.ForceDisconnect();
 		}
 		/// <summary>
 		/// Determines whether a stack trace originates from the networking layer.
@@ -818,37 +967,9 @@ namespace FishMMO.Client
 		/// kills WebGL tab blur / mobile sessions. Only revoke on explicit quit or logout.
 		/// </summary>
 		/// <param name="paused">True if the application is being paused.</param>
-		/// <summary>
-		/// Unity OnApplicationPause. Does NOT revoke the auth token — revoking on pause
-		/// kills WebGL tab blur / mobile sessions. On WebGL/mobile, flags the application
-		/// as terminating so <see cref="OnDestroy"/> can attempt best-effort revocation.
-		/// </summary>
-		/// <param name="paused">True if the application is being paused.</param>
-		private void OnApplicationPause(bool paused)
-		{
-			/* Auth token preserved across pause/unpause cycle.
-			 * ── FIX #5: Flag termination for OnDestroy fallback ──
-			 * On WebGL, iOS, and Android, Unity does not reliably call
-			 * OnApplicationQuit when the app is terminated (tab close,
-			 * app kill).  OnApplicationPause(true) is the closest signal
-			 * we get.  Flag wasApplicationPaused so OnDestroy can
-			 * attempt a best-effort token revocation. */
-#if UNITY_WEBGL || UNITY_IOS || UNITY_ANDROID
-			wasApplicationPaused = paused;
-#endif
-		}
-#if UNITY_WEBGL || UNITY_IOS || UNITY_ANDROID
-		/// <summary>
-		/// Set to true by OnApplicationPause when the app is backgrounded
-		/// (WebGL tab blur / mobile app suspend).  OnDestroy uses this flag
-		/// to decide whether to attempt best-effort token revocation.
-		/// </summary>
-		private bool wasApplicationPaused = false;
-#endif
+		private void OnApplicationPause(bool paused) { /* Auth token preserved across pause/unpause cycle. */ }
 		/// <summary>
 		/// Unity OnApplicationQuit. Revokes the auth token when the application exits.
-		/// NOTE: Not reliably called on WebGL or mobile platforms.
-		/// On those platforms, OnApplicationPause + OnDestroy provide a fallback.
 		/// </summary>
 		private void OnApplicationQuit() { try { this.loginAuthenticator?.RevokeAndClearAuthToken(); } catch { } }
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Connection/ClientConnectionManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Connection/ClientConnectionManager.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using FishNet.Managing;
 using FishNet.Transporting;
+using FishNet.Transporting.Multipass;
+using FishNet.Transporting.WebTransport;
 using FishMMO.Logging;
 using FishMMO.Shared;
 using UnityEngine;
@@ -30,20 +32,6 @@ namespace FishMMO.Client
 		/// a defensive measure — it costs nothing on x86/ARM and documents the intent against future refactoring
 		/// that might introduce background-thread access.</remarks>
 		private int connectingGuard = 0;
-		/// <summary>
-		/// Timestamp (double precision, seconds since startup) of the most recent
-		/// successful connectingGuard acquisition. Used to detect and recover from a
-		/// leaked guard. Double precision prevents float loss after ~24h of client
-		/// uptime, which would cause guardAge to compute as zero.
-		/// </summary>
-		private double connectingGuardAcquiredAt = 0.0;
-		/// <summary>
-		/// ── FIX #10: Reference to the in-flight connection coroutine ──
-		/// Stored so ResetReconnectState can stop the coroutine before
-		/// releasing the connectingGuard.  Uses IEnumerator because
-		/// CoroutineRunner.Start/Stop accept IEnumerator, not UnityEngine.Coroutine.
-		/// </summary>
-		private System.Collections.IEnumerator inFlightConnectionCoroutine;
 		/// <summary>Thread-safe disconnect flag. Volatile for visibility across transport-worker callbacks.</summary>
 		private volatile bool forceDisconnect;
 		private string lastWorldAddress = "";
@@ -60,10 +48,18 @@ namespace FishMMO.Client
 		public float ReconnectAttemptWaitTime { get; set; } = 5f;
 		/// <summary>Maximum delay in seconds for exponential backoff. Default 60.</summary>
 		public float MaxReconnectDelay { get; set; } = 60f;
-		/// <summary>Timeout in seconds waiting for a connection to fully stop. Default 10.</summary>
-		public float ConnectionStopTimeoutSeconds { get; set; } = 10f;
-		/// <summary>Timeout in seconds waiting for a new connection to reach Started state. Default 20.</summary>
-		public float ConnectionEstablishTimeoutSeconds { get; set; } = 20f;
+		/// <summary>
+		/// Timeout in seconds waiting for a connection to fully stop before force-reset.
+		/// Default 3s (was 10s) — World→Scene must not stall on hung Editor native QUIC stop.
+		/// </summary>
+		public float ConnectionStopTimeoutSeconds { get; set; } = 3f;
+
+		/// <summary>
+		/// Max seconds to wait for <see cref="LocalConnectionState.Started"/> after
+		/// <c>StartConnection</c>. Prevents register/login UI from hanging forever when
+		/// WebTransport/QUIC never completes (UDP blocked, bad host, silent handshake fail).
+		/// </summary>
+		public float ConnectTimeoutSeconds { get; set; } = 20f;
 
 		/// <summary>Fired when a connection to the server is successfully established.</summary>
 		public event Action OnConnectionSuccessful;
@@ -71,8 +67,19 @@ namespace FishMMO.Client
 		public event Action<int, int> OnReconnectAttempt;
 		/// <summary>Fired when all reconnect attempts are exhausted without success.</summary>
 		public event Action OnReconnectFailed;
-		/// <summary>Fired when a non-reconnectable connection attempt fails (e.g. login server unreachable).</summary>
-		public event Action OnConnectionAttemptFailed;
+		/// <summary>
+		/// Fired when a connect attempt times out without reaching Started.
+		/// Args: address, port, message for UI.
+		/// </summary>
+		public event Action<string, ushort, string> OnConnectTimedOut;
+
+		/// <summary>
+		/// Optional override for reconnect connects. When set, <see cref="TryReconnect"/>
+		/// invokes this instead of <see cref="ConnectToServer"/> so the client can
+		/// re-fetch an IPFetch HMAC connection token before the World/Scene handshake.
+		/// Args: address, port.
+		/// </summary>
+		public Action<string, ushort> ReconnectConnectOverride;
 
 		/// <summary>Returns true if the current connection type supports reconnection (World or Scene).</summary>
 		public bool CanReconnect =>
@@ -124,12 +131,20 @@ namespace FishMMO.Client
 				Log.Warning("ClientConnection", "ConnectToServer already in progress; ignoring duplicate call.");
 				return;
 			}
-			connectingGuardAcquiredAt = (double)Time.realtimeSinceStartup;
-		if (isWorldServer) CurrentConnectionType = ServerConnectionType.ConnectingToWorld;
-			NetworkManager.ClientManager.StopConnection();
-			var routine = OnAwaitingConnectionReady(address, port, isWorldServer);
-			inFlightConnectionCoroutine = routine;
-			CoroutineRunner.Start(routine);
+			if (isWorldServer) CurrentConnectionType = ServerConnectionType.ConnectingToWorld;
+			// Stop any prior session first — but only if not already Stopped.
+			// Unnecessary Stop+Start churn was producing double WTConnect (index=0 then index=1).
+			// Auth core must NOT wipe login/register credentials on Stop events.
+			Log.Info("ClientConnection",
+				$"ConnectToServer begin host={address} port={port} priorState={ClientState} " +
+				"(single StartConnection after clean stop — one WT session)");
+			if (ClientState != LocalConnectionState.Stopped)
+			{
+				Log.Info("ClientConnection",
+					$"Stopping prior connection state={ClientState} before new connect");
+				NetworkManager.ClientManager.StopConnection();
+			}
+			CoroutineRunner.Start(OnAwaitingConnectionReady(address, port, isWorldServer));
 		}
 
 		/// <summary>Attempts a reconnect with exponential backoff. The backoff delay is set in
@@ -145,7 +160,12 @@ namespace FishMMO.Client
 				{
 					ReconnectsAttempted++;
 					OnReconnectAttempt?.Invoke(ReconnectsAttempted, MaxReconnectAttempts);
-					ConnectToServer(lastWorldAddress, lastWorldPort);
+					// Prefer override so Client can stage a fresh IPFetch connection token
+					// (World/Scene reject first ClientHandshake without one behind L4 proxy).
+					if (ReconnectConnectOverride != null)
+						ReconnectConnectOverride(lastWorldAddress, lastWorldPort);
+					else
+						ConnectToServer(lastWorldAddress, lastWorldPort);
 				}
 			}
 			else
@@ -172,21 +192,10 @@ namespace FishMMO.Client
 			ReconnectsAttempted = 0; nextReconnect = -1;
 			CurrentConnectionType = ServerConnectionType.None;
 			lastWorldAddress = ""; lastWorldPort = 0;
-			// ── FIX #10: Stop in-flight coroutine BEFORE releasing guard ──
-			// If a connection coroutine is suspended at a yield point,
-			// releasing the guard would allow a second ConnectToServer to
-			// start a concurrent coroutine on the same transport.  Stop the
-			// coroutine first, then release the guard.
-			if (inFlightConnectionCoroutine != null)
-			{
-				CoroutineRunner.Stop(inFlightConnectionCoroutine);
-				inFlightConnectionCoroutine = null;
-			}
 			// Reset the in-flight connection guard. If a coroutine was
 			// interrupted (e.g., StopAllCoroutines in QuitToLogin), the
 			// guard would otherwise be permanently stuck at 1, blocking
 			// all future ConnectToServer calls.
-			connectingGuardAcquiredAt = 0.0;
 			System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
 		}
 
@@ -215,6 +224,8 @@ namespace FishMMO.Client
 		private void OnClientConnectionState(ClientConnectionStateArgs args)
 		{
 			ClientState = args.ConnectionState;
+			Log.Info("ClientConnection",
+				$"State → {ClientState} forceDisconnect={forceDisconnect} type={CurrentConnectionType}");
 			switch (ClientState)
 			{
 				case LocalConnectionState.Stopped:
@@ -228,18 +239,86 @@ namespace FishMMO.Client
 						// once in TryReconnect() when the actual reconnect begins, so
 						// consumers don't receive duplicate events per cycle.
 					}
-					else if (!forceDisconnect)
-					{
-						// Non-reconnectable connection failed (e.g. login server).
-						// Fire so listeners can invalidate cached discovery data.
-						OnConnectionAttemptFailed?.Invoke();
-					}
 					CurrentConnectionType = ServerConnectionType.None;
 					break;
 				case LocalConnectionState.Started:
+					// FishNet is usable for broadcasts only after Started — not merely
+					// "WebTransport session established" on the wire.
+					Log.Info("ClientConnection",
+						"Started — FishNet ready for ClientHandshake / CreateAccountBroadcast");
 					OnConnectionSuccessful?.Invoke();
 					ReconnectsAttempted = 0; nextReconnect = -1; forceDisconnect = false;
 					break;
+			}
+		}
+
+		/// <summary>
+		/// Invokes FishNet <c>StartConnection</c> without yielding (safe inside try/catch).
+		/// </summary>
+		private bool TryStartConnection(string address, ushort port, out Exception error)
+		{
+			error = null;
+			try
+			{
+				return NetworkManager.ClientManager.StartConnection(address, port);
+			}
+			catch (Exception ex)
+			{
+				error = ex;
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Hard-stop WebTransport/FishNet client so a hop (Login→World, World→Scene) can
+		/// open a new session. Editor native QUIC has been observed stuck Started while
+		/// StopConnection never delivered Stopped — WebGL usually stops cleanly.
+		/// </summary>
+		private void ForceStopTransportForHop(string reason)
+		{
+			Log.Warning("ClientConnection",
+				$"ForceStopTransportForHop: {reason} (localState={ClientState})");
+
+			// Suppress auto-reconnect while we tear down for an intentional hop.
+			bool savedForce = forceDisconnect;
+			forceDisconnect = true;
+			nextReconnect = -1;
+
+			try
+			{
+				try { NetworkManager.ClientManager.StopConnection(); }
+				catch (Exception ex) { Log.Warning("ClientConnection", $"StopConnection: {ex.Message}"); }
+
+				Transport t = NetworkManager.TransportManager != null
+					? NetworkManager.TransportManager.Transport
+					: null;
+
+				if (t is Multipass multipass)
+				{
+					try { multipass.StopConnection(server: false); }
+					catch (Exception ex) { Log.Warning("ClientConnection", $"Multipass.Stop: {ex.Message}"); }
+
+					foreach (Transport nested in multipass.Transports)
+					{
+						if (nested is WebTransport nestedWt)
+						{
+							try { nestedWt.ForceStopClient(); }
+							catch (Exception ex) { Log.Warning("ClientConnection", $"ForceStop nested WT: {ex.Message}"); }
+						}
+					}
+				}
+				else if (t is WebTransport wt)
+				{
+					try { wt.ForceStopClient(); }
+					catch (Exception ex) { Log.Warning("ClientConnection", $"ForceStop WT: {ex.Message}"); }
+				}
+			}
+			finally
+			{
+				// Local state must read Stopped so StartConnection is allowed, even if
+				// FishNet never raised OnClientConnectionState(Stopped).
+				ClientState = LocalConnectionState.Stopped;
+				forceDisconnect = savedForce;
 			}
 		}
 
@@ -252,46 +331,24 @@ namespace FishMMO.Client
 				while (ClientState != LocalConnectionState.Stopped && Time.realtimeSinceStartup < deadline)
 				{
 					if (--maxWaitIters <= 0)
-					{
-						Log.Error("ClientConnection", "Connection stop wait iteration limit exceeded.");
-						System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
-						yield break;
-					}
+						break;
 					yield return null;
 				}
 				if (ClientState != LocalConnectionState.Stopped)
 				{
-					Log.Warning("ClientConnection", $"Timed out waiting for connection stop; forcing teardown.");
-					NetworkManager.ClientManager.StopConnection();
-					// Wait for the forced stop to complete before starting a new connection.
-					// Without this wait, StartConnection may fail because the transport
-					// is still in Stopping state.
-					float forcedDeadline = Time.realtimeSinceStartup + Mathf.Max(0.1f, ConnectionStopTimeoutSeconds);
-					int maxForcedIters = 1000;
-					while (ClientState != LocalConnectionState.Stopped && Time.realtimeSinceStartup < forcedDeadline)
-					{
-						if (--maxForcedIters <= 0)
-						{
-							Log.Error("ClientConnection", "Forced stop wait iteration limit exceeded.");
-							System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
-							yield break;
-						}
-						yield return null;
-					}
+					// Do NOT abort the hop — force the transport down and continue.
+					// Aborting here was the Editor-only World→Scene failure: never
+					// StartConnection to sceneserver:7790, no scene handshake.
+					ForceStopTransportForHop(
+						$"stop wait timed out after {ConnectionStopTimeoutSeconds:0.#}s " +
+						$"before connect {address}:{port}");
+					// One frame so any queued connection-state callbacks settle.
+					yield return null;
 					if (ClientState != LocalConnectionState.Stopped)
-					{
-						Log.Error("ClientConnection", "Forced connection stop timed out; aborting connect.");
-						forceDisconnect = false;
-						System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
-						yield break;
-					}
+						ClientState = LocalConnectionState.Stopped;
 				}
 			}
-			// Release the in-flight guard only after StartConnection has been called
-			// (force-disconnect path above releases early and exits because we don't
-			// want to start).  Releasing before StartConnection would allow a concurrent
-			// ConnectToServer call to acquire the guard and start a second connection
-			// while the first is still being set up.
+			// Intentional quit/force path — do not start a new session.
 			if (forceDisconnect)
 			{
 				forceDisconnect = false;
@@ -299,59 +356,110 @@ namespace FishMMO.Client
 				yield break;
 			}
 			if (isWorldServer) { lastWorldAddress = address; lastWorldPort = port; }
-			try
+
+			// If still Starting/Started after force-stop, force again then proceed.
+			if (ClientState == LocalConnectionState.Starting || ClientState == LocalConnectionState.Started)
 			{
-				Log.Info("ClientConnection", $"StartConnection host={address} port={port} isWorld={isWorldServer} timeout={ConnectionEstablishTimeoutSeconds}s");
-				NetworkManager.ClientManager.StartConnection(address, port);
-			}
-			catch (System.Exception ex)
-			{
-				Log.Error("ClientConnection", $"StartConnection threw: {ex}");
-				System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
-				yield break;
+				Log.Warning("ClientConnection",
+					$"Still {ClientState} before StartConnection to {address}:{port} — force-stop and continue.");
+				ForceStopTransportForHop($"pre-Start still {ClientState}");
+				yield return null;
+				ClientState = LocalConnectionState.Stopped;
 			}
 
-			// Wait for the connection to reach Started or Stopped, with a timeout.
-			// The connectingGuard stays acquired during this wait to prevent
-			// concurrent ConnectToServer calls from starting a second connection
-			// while this one is still being established.
-			float connectDeadline = Time.realtimeSinceStartup + Mathf.Max(1f, ConnectionEstablishTimeoutSeconds);
-			int connectMaxIters = Mathf.CeilToInt(ConnectionEstablishTimeoutSeconds * 120f); // ~120 checks/s
-			while (ClientState == LocalConnectionState.Starting && Time.realtimeSinceStartup < connectDeadline)
+			Log.Info("ClientConnection",
+				$"StartConnection host={address} port={port} isWorld={isWorldServer} " +
+				$"priorState={ClientState} timeout={ConnectTimeoutSeconds:0.#}s " +
+				"(expect exactly one [FishWT] WTConnect BEGIN)");
+
+			// TryStartConnection cannot yield — keep try/catch free of yield (CS1626).
+			bool started = TryStartConnection(address, port, out Exception startEx);
+			if (startEx != null)
 			{
-				if (--connectMaxIters <= 0)
+				Log.Error("ClientConnection", $"StartConnection threw: {startEx.Message}", startEx);
+				System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+				OnConnectTimedOut?.Invoke(address, port,
+					$"Could not start connection to {address}:{port} — {startEx.Message}");
+				yield break;
+			}
+			if (!started)
+			{
+				// One more force-stop + retry — socket may still have been Starting.
+				Log.Warning("ClientConnection",
+					$"StartConnection returned false for {address}:{port}; force-stop and retry once.");
+				ForceStopTransportForHop("StartConnection returned false");
+				yield return null;
+				ClientState = LocalConnectionState.Stopped;
+				started = TryStartConnection(address, port, out startEx);
+				if (startEx != null)
 				{
-					Log.Error("ClientConnection", "Connection establish wait iteration limit exceeded.");
-					NetworkManager.ClientManager.StopConnection();
+					Log.Error("ClientConnection", $"StartConnection retry threw: {startEx.Message}", startEx);
 					System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+					OnConnectTimedOut?.Invoke(address, port,
+						$"Could not start connection to {address}:{port} — {startEx.Message}");
 					yield break;
 				}
+				if (!started)
+				{
+					Log.Error("ClientConnection",
+						$"StartConnection still false for {address}:{port} after force-stop retry");
+					System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+					OnConnectTimedOut?.Invoke(address, port,
+						$"Could not start WebTransport to {address}:{port} (StartConnection false)");
+					yield break;
+				}
+			}
+
+			// Guard released so ForceDisconnect / concurrent cleanup can proceed while
+			// we wait for Started (or timeout).
+			System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+
+			// Wait until Started, Stopped, or hard timeout — never leave UI waiting forever.
+			float timeout = Mathf.Max(1f, ConnectTimeoutSeconds);
+			float connectDeadline = Time.realtimeSinceStartup + timeout;
+			while (ClientState != LocalConnectionState.Started
+				&& ClientState != LocalConnectionState.Stopped
+				&& Time.realtimeSinceStartup < connectDeadline)
+			{
+				if (forceDisconnect)
+					yield break;
 				yield return null;
+			}
+
+			if (ClientState == LocalConnectionState.Started)
+			{
+				Log.Info("ClientConnection", $"Connected to {address}:{port}");
+				yield break;
 			}
 
 			if (ClientState == LocalConnectionState.Stopped)
 			{
-				// The transport already reported an error (WebGlOnError / HandleNativeDisconnect).
-				// Log context and release the guard — the UI layer will surface the error.
-				Log.Error("ClientConnection", $"Connection to {address}:{port} failed before reaching Started state. " +
-					"The transport reported an error — check preceding [WebTransport Client] log lines for the specific reason.");
-				System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+				// Transport failed fast (WebTransport onError / create failed / handshake refused).
+				// Surface a UI message — previously only unlocked the form with no dialog.
+				string failMsg =
+					$"WebTransport failed to open https://{address}:{port} " +
+					"(server down, TLS/cert, origin, or browser WebTransport). " +
+					"See [FishWT] lines in the browser console.";
+				Log.Warning("ClientConnection",
+					$"Connection to {address}:{port} stopped before Started — {failMsg}");
+				OnConnectTimedOut?.Invoke(address, port, failMsg);
 				yield break;
 			}
 
-			if (ClientState != LocalConnectionState.Started)
-			{
-				// Still in Starting state — timed out waiting for the transport to connect.
-				string serverType = isWorldServer ? "world" : "login";
-				Log.Error("ClientConnection", $"Could not reach {serverType} server {address}:{port} " +
-					$"within {ConnectionEstablishTimeoutSeconds}s. " +
-					"Check network/UDP (QUIC), DNS resolution, and that the server is running and accepting connections on this port.");
-				NetworkManager.ClientManager.StopConnection();
-				System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
-				yield break;
-			}
-
-			System.Threading.Interlocked.Exchange(ref connectingGuard, 0);
+			// Still Starting/Stopping past deadline — hard fail for UI.
+			// Typical when LoginServer is dead/SEGV, or QUIC_NETWORK_IDLE_TIMEOUT
+			// (handshake never completed). close() while connecting is fallout of this.
+			string msg =
+				$"Could not reach login server {address}:{port} within {timeout:0}s " +
+				$"(WebTransport URL https://{address}:{port}). " +
+				"LoginServer may have crashed (SEGV) or is not completing the QUIC handshake — " +
+				"check journalctl -u fishmmo-loginserver, UDP 7770, DNS (direct A, not Cloudflare), " +
+				"and browser console for [FishWT] Ready failed / QUIC_NETWORK_IDLE_TIMEOUT.";
+			Log.Error("ClientConnection", msg);
+			forceDisconnect = true;
+			try { NetworkManager.ClientManager.StopConnection(); }
+			catch (Exception ex) { Log.Warning("ClientConnection", $"Stop after timeout failed: {ex.Message}"); }
+			OnConnectTimedOut?.Invoke(address, port, msg);
 		}
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
@@ -3,16 +3,15 @@ using FishNet.Connection;
 using FishNet.Managing;
 using FishNet.Transporting;
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FishMMO.Server.Core;
-using FishMMO.Server.Core.Collections;
 using FishMMO.Auth.Core;
 using FishMMO.Auth.Implementation;
+using FishMMO.Server.Core.Collections;
 using FishMMO.Server.Core.LoginServer;
 using FishMMO.Database.Npgsql.Services.Interfaces;
 using FishMMO.Shared;
@@ -35,45 +34,6 @@ namespace FishMMO.Server.Implementation
 		[UnityEngine.SerializeField]
 		private int maxMainThreadActionsPerUpdate = 100;
 
-		/// <summary>
-		/// Per-key rate limiter for incoming <see cref="ClientHandshake"/> broadcasts.
-		/// Limits to 10 handshakes per second per key (real IP when available, otherwise
-		/// transport address or ClientId). Prevents CPU exhaustion from HMAC-SHA256
-		/// verification of forged connection tokens before the handshake enters the
-		/// core's capacity-limited SRP channels.
-		/// </summary>
-		private readonly ExpiringKeyTracker<string> handshakeRateLimiter = new ExpiringKeyTracker<string>(StringComparer.OrdinalIgnoreCase);
-
-		/// <summary>Minimum interval between accepted handshakes per rate-limit key (100ms = 10/sec).</summary>
-		private static readonly TimeSpan HandshakeRateLimitInterval = TimeSpan.FromMilliseconds(100);
-
-		/// <summary>
-		/// Maximum time a newly-connected client has to send a valid <see cref="ClientHandshake"/>
-		/// before being disconnected. Prevents slot exhaustion from silent connections
-		/// (clients that open a QUIC connection but never authenticate). Default 15 seconds.
-		/// Configurable via the Unity Inspector.
-		/// </summary>
-		[UnityEngine.SerializeField]
-		private float authHandshakeTimeoutSeconds = 15f;
-
-		/// <summary>
-		/// Thread-safe map of ClientId → UTC timestamp when the remote connection was established.
-		/// Used by the authentication timeout sweep in <see cref="OnAuthSweep"/> to disconnect
-		/// clients that connect but never send a <see cref="ClientHandshake"/>.
-		/// Entries are added on <see cref="RemoteConnectionState.Started"/> and removed on
-		/// <see cref="RemoteConnectionState.Stopped"/> or successful authentication.
-		/// </summary>
-		private protected readonly ConcurrentDictionary<int, DateTime> connectionStartTimes = new ConcurrentDictionary<int, DateTime>();
-
-		/// <summary>
-		/// Per-connection random nonce, assigned when a remote connection starts and removed
-		/// when it stops. Used by <see cref="OnServerClientHandshakeReceivedAsync"/> to
-		/// detect connection recycling: if FishNet reuses a ClientId between two await
-		/// points, the nonce will not match, and the handshake is safely aborted rather
-		/// than routed to the wrong connection. See BUG 6 in the security audit.
-		/// </summary>
-		private protected readonly ConcurrentDictionary<int, string> connectionNonces = new ConcurrentDictionary<int, string>();
-
 
 		/// <summary>Thread-safe queue for marshalling network operations to the main Unity thread.</summary>
 		private readonly ConcurrentQueue<Action> mainThreadQueue = new ConcurrentQueue<Action>();
@@ -87,15 +47,16 @@ namespace FishMMO.Server.Implementation
 		/// </summary>
 		private CancellationToken shutdownToken;
 
-		/// <summary>
-		/// Exposed to subclasses so fire-and-forget async operations (e.g. renewal token
-		/// issuance) can cooperatively cancel during server shutdown rather than accessing
-		/// disposed database handles after <see cref="Server.PerformShutdown"/> completes.
-		/// </summary>
-		protected CancellationToken ShutdownToken => shutdownToken;
-
 		/// <summary>Cached handler delegate for ClientHandshake broadcast registration/unregistration.</summary>
 		private Action<NetworkConnection, ClientHandshake, Channel> clientHandshakeHandler;
+
+		/// <summary>
+		/// Per-connection real-IP cache recovered from HMAC connection tokens (and auth tokens).
+		/// Lives on the authenticator so Login, World, and Scene servers all work behind L4 proxies
+		/// without requiring Login-only <see cref="IAccountCreationSystemRuntimeData"/>.
+		/// </summary>
+		private readonly LastSeenCacheTracker<int, string> connectionIpByClientId =
+			new LastSeenCacheTracker<int, string>();
 
 		/// <summary>The engine-independent authenticator core. Created by <see cref="InitializeCoreInstance"/>.</summary>
 		protected abstract BaseAuthenticatorCore<NetworkConnection> Core { get; }
@@ -119,38 +80,9 @@ namespace FishMMO.Server.Implementation
 		{
 			base.InitializeOnce(networkManager);
 			networkManager.ServerManager.OnRemoteConnectionState += ServerManager_OnRemoteConnectionState;
-			this.clientHandshakeHandler = async (conn, msg, channel) =>
+			this.clientHandshakeHandler = (conn, msg, channel) =>
 			{
-				/* Fire-and-forget the async handshake via async void so the
-				 * continuation runs on Unity's main thread (SynchronizationContext).
-				 * ContinueWith would run on the ThreadPool, making conn.Disconnect()
-				 * and Log calls unsafe.  The try/catch prevents unobserved Task
-				 * exceptions from terminating the process (.NET Framework) or
-				 * silently hanging the connection (.NET Core).
-				 *
-				 * IMPORTANT: Capture ClientId BEFORE any await.  The
-				 * NetworkConnection object may be disconnected and recycled
-				 * by FishNet while the async operation is in flight.  After
-				 * each await, re-resolve the connection from the server's
-				 * client dictionary via TryResolveConnection.  Never carry
-				 * a NetworkConnection reference across an await boundary. */
-				int clientId = conn.ClientId;
-				try
-				{
-					await OnServerClientHandshakeReceivedAsync(clientId, msg, channel);
-				}
-				catch (Exception ex)
-				{
-					_ = Log.Error(LogPrefix,
-						$"Unhandled exception in handshake for connection " +
-						$"{clientId}: {ex.Message}");
-					try
-					{
-						if (TryResolveConnection(clientId, out var staleConn))
-							staleConn.Disconnect(true);
-					}
-					catch { /* best effort */ }
-				}
+				_ = OnServerClientHandshakeReceivedAsync(conn, msg, channel);
 			};
 			networkManager.ServerManager.RegisterBroadcast<ClientHandshake>(this.clientHandshakeHandler, false);
 			RegisterProtocolHandlers(networkManager);
@@ -185,48 +117,42 @@ namespace FishMMO.Server.Implementation
 					"Set GameVersion in the MainBootstrap prefab to enable version enforcement.");
 			}
 #endif
-			// Validate that the IConnectionTokenKeyService is available in the
-			// database service registry. Connection token HMAC keys come SOLELY
-			// from the database — no environment variable or .cfg file fallbacks.
-			// If the service is not registered, the server will be unable to verify
-			// connection tokens from proxy-authenticated clients.
+			// Validate connection token HMAC key is configured.
+			// Without this key, connection token verification will fail and all
+			// proxy-authenticated clients will be rejected.
 			{
-				bool serviceAvailable = Server?.Database?.ServiceRegistry != null &&
-					Server.Database.ServiceRegistry.TryGet<IConnectionTokenKeyService>(out _);
+				// Prefer env. Ignore empty cfg and unexpanded ${ENV} template placeholders
+				// that would otherwise block env fallback with a non-empty bogus string.
+				string? hmacKeyB64 = System.Environment.GetEnvironmentVariable("FISHMMO_CONNECTION_TOKEN_HMAC_KEY_BASE64");
+				if (IsUnsetSecretTemplate(hmacKeyB64) && Server?.Configuration != null)
+				{
+					Server.Configuration.TryGetString("ConnectionTokenHmacKeyBase64", out hmacKeyB64);
+					if (IsUnsetSecretTemplate(hmacKeyB64))
+						hmacKeyB64 = null;
+				}
 #if !UNITY_EDITOR && !DEVELOPMENT_BUILD
-				if (!serviceAvailable)
+				if (string.IsNullOrWhiteSpace(hmacKeyB64))
 				{
 					_ = Log.Error(LogPrefix,
-						"FATAL: IConnectionTokenKeyService is not registered in the database service registry. " +
-						"Clients will be unable to authenticate through the proxy. " +
-						"Connection token HMAC keys must come from the database — no environment variable or " +
-						".cfg file fallbacks are supported. Ensure the database service assembly is loaded.");
-					throw new InvalidOperationException(
-						"IConnectionTokenKeyService is not registered. " +
-						"The server cannot start without a valid database-backed connection token key service. " +
-						"Connection token HMAC keys must come from the database — no environment variable or " +
-						".cfg file fallbacks are supported.");
+						"FATAL: ConnectionTokenHmacKeyBase64 is not configured. " +
+						"Clients will be unable to authenticate. " +
+						"Set ConnectionTokenHmacKeyBase64 in the server .cfg file " +
+						"or FISHMMO_CONNECTION_TOKEN_HMAC_KEY_BASE64 environment variable.");
 				}
 #else
-				if (!serviceAvailable)
+				if (string.IsNullOrWhiteSpace(hmacKeyB64))
 				{
 					_ = Log.Warning(LogPrefix,
-						"IConnectionTokenKeyService is not registered in the database service registry. " +
-						"Connection token verification will fail — clients connecting through the proxy " +
-						"will be rejected. For local testing, ensure clients connect directly " +
-						"(not through the HTTP IPFetch flow).");
+						"ConnectionTokenHmacKeyBase64 is not configured. " +
+						"Connection token verification will fail -- clients connecting " +
+						"through the proxy will be rejected. For local testing, ensure " +
+						"clients connect directly (not through the HTTP IPFetch flow).");
 				}
 #endif
 			}
 			workerCts = new CancellationTokenSource();
 			shutdownToken = workerCts.Token;
 			Core.InitializeWorkers(workerCts.Token);
-
-			// Start DB-backed connection token key loading and periodic refresh.
-			// The initial load populates the key map; the refresh loop polls every 60s.
-			// The database is the ONLY source — no env var or .cfg file fallbacks exist.
-			_ = LoadConnectionTokenKeysFromDbAsync();
-			_ = KeyRefreshLoop(shutdownToken);
 
 		}
 
@@ -271,156 +197,6 @@ namespace FishMMO.Server.Implementation
 			Core?.Tick();
 			OnUpdate();
 			OnAuthSweep();
-			SweepAuthTimeouts();
-			// Sweep expired entries from the handshake rate limiter to prevent
-			// unbounded memory growth under sustained handshake traffic.
-			handshakeRateLimiter.SweepExpired(DateTime.UtcNow, maxScan: 64, maxRemove: 16);
-		}
-
-		/// <summary>
-		/// Disconnects clients that connected but never sent a valid
-		/// <see cref="ClientHandshake"/> within <see cref="authHandshakeTimeoutSeconds"/>.
-		/// Bounded scan (max 32 entries/frame) to keep per-frame cost low.
-		/// Authenticated connections are removed from the tracker without disconnecting.
-		/// </summary>
-		private void SweepAuthTimeouts()
-		{
-			if (authHandshakeTimeoutSeconds <= 0f || connectionStartTimes.IsEmpty)
-				return;
-
-			DateTime now = DateTime.UtcNow;
-			TimeSpan timeout = TimeSpan.FromSeconds(authHandshakeTimeoutSeconds);
-			const int maxScanPerFrame = 32;
-
-			// Refresh the snapshot when the cursor is at the start (new cycle)
-			// or when the snapshot is null/stale (first call or dictionary changed).
-			if (authTimeoutSweepCursor == 0 || authTimeoutSnapshot == null)
-			{
-				authTimeoutSnapshot = connectionStartTimes.ToArray();
-			}
-
-			var snapshot = authTimeoutSnapshot;
-			int scanned = 0;
-
-			for (int i = authTimeoutSweepCursor; i < snapshot.Length && scanned < maxScanPerFrame; i++, scanned++)
-			{
-				var kvp = snapshot[i];
-				int clientId = kvp.Key;
-				DateTime started = kvp.Value;
-
-				// Skip entries that were already removed between snapshot and now.
-				if (!connectionStartTimes.ContainsKey(clientId))
-					continue;
-
-				NetworkConnection conn = null;
-				var clients = NetworkManager?.ServerManager?.Clients;
-				if (clients != null)
-					clients.TryGetValue(clientId, out conn);
-				if (conn != null && conn.IsAuthenticated)
-				{
-					connectionStartTimes.TryRemove(clientId, out _);
-					continue;
-				}
-
-				if (conn == null)
-				{
-					connectionStartTimes.TryRemove(clientId, out _);
-					continue;
-				}
-
-				if (now - started > timeout)
-				{
-					_ = Log.Warning(LogPrefix,
-						$"Connection {clientId} timed out waiting for ClientHandshake " +
-						$"({(now - started).TotalSeconds:F1}s > {authHandshakeTimeoutSeconds}s). Disconnecting.");
-					connectionStartTimes.TryRemove(clientId, out _);
-					try { conn.Disconnect(true); } catch { /* best effort */ }
-				}
-			}
-
-			// Advance cursor; wrap to 0 when we've covered the entire snapshot.
-			authTimeoutSweepCursor += scanned;
-			if (authTimeoutSweepCursor >= snapshot.Length)
-				authTimeoutSweepCursor = 0;
-
-			// Periodic full sweep to prevent unbounded dictionary growth under
-			// sustained connection churn.  The per-frame bounded scan (32 entries)
-			// with cursor provides fair coverage; this periodic full pass ensures
-			// stale entries are eventually cleaned up regardless of cursor position.
-			if (Time.realtimeSinceStartup - lastFullAuthTimeoutSweepTime >= FullAuthTimeoutSweepIntervalSeconds)
-			{
-				lastFullAuthTimeoutSweepTime = Time.realtimeSinceStartup;
-				PerformFullAuthTimeoutSweep(timeout, now);
-			}
-		}
-
-		/// <summary>Timestamp of the last full auth-timeout sweep (seconds since startup).</summary>
-		private float lastFullAuthTimeoutSweepTime = 0f;
-
-		/// <summary>Interval in seconds between full sweeps of <see cref="connectionStartTimes"/>.</summary>
-		private const float FullAuthTimeoutSweepIntervalSeconds = 30f;
-
-		/// <summary>
-		/// Cursor into the most recent snapshot of <see cref="connectionStartTimes"/>.
-		/// Advances each frame by <c>maxScanPerFrame</c> entries to guarantee every entry
-		/// is eventually visited, unlike <c>foreach</c> on a <see cref="ConcurrentDictionary{TKey,TValue}"/>
-		/// which returns a snapshot-at-enumeration that may skip entries indefinitely
-		/// under high connection churn.
-		/// </summary>
-		private int authTimeoutSweepCursor = 0;
-
-		/// <summary>
-		/// Most recent snapshot of <see cref="connectionStartTimes"/> for the per-frame
-		/// bounded scan.  Refreshed when the cursor wraps around or on first use each cycle.
-		/// </summary>
-		private KeyValuePair<int, DateTime>[] authTimeoutSnapshot = null;
-
-		/// <summary>
-		/// Processes ALL entries in <see cref="connectionStartTimes"/> to remove stale
-		/// entries that the per-frame bounded scan may have repeatedly skipped.
-		/// Uses <see cref="ConcurrentDictionary{TKey,TValue}.ToArray"/> to obtain a
-		/// stable snapshot; the allocation is acceptable at 30-second intervals.
-		/// </summary>
-		private void PerformFullAuthTimeoutSweep(TimeSpan timeout, DateTime now)
-		{
-			if (connectionStartTimes.IsEmpty) return;
-
-			int removed = 0;
-			foreach (var kvp in connectionStartTimes.ToArray())
-			{
-				int clientId = kvp.Key;
-				DateTime started = kvp.Value;
-
-				NetworkConnection conn = null;
-				var clients = NetworkManager?.ServerManager?.Clients;
-				if (clients != null)
-					clients.TryGetValue(clientId, out conn);
-
-				// Remove stale entries: connection gone or already authenticated.
-				if (conn == null || conn.IsAuthenticated)
-				{
-					connectionStartTimes.TryRemove(clientId, out _);
-					removed++;
-				}
-				// Timed-out connections: disconnect AND remove.
-				else if (now - started > timeout)
-				{
-					_ = Log.Warning(LogPrefix,
-						$"Connection {clientId} timed out waiting for ClientHandshake " +
-						$"({(now - started).TotalSeconds:F1}s > {timeout.TotalSeconds:F1}s) — " +
-						"disconnecting (full sweep).");
-					connectionStartTimes.TryRemove(clientId, out _);
-					try { conn.Disconnect(true); } catch { /* best effort */ }
-					removed++;
-				}
-			}
-
-			if (removed > 0)
-			{
-				_ = Log.Debug(LogPrefix,
-					$"Full auth-timeout sweep removed {removed} stale entries " +
-					$"({connectionStartTimes.Count} remaining).");
-			}
 		}
 
 		/// <summary>Override for subclass-specific per-frame logic (e.g., additional rate-limit sweeps).</summary>
@@ -504,10 +280,17 @@ namespace FishMMO.Server.Implementation
 			// Look up the real IP recovered from the connection/auth token.
 			// Never fall back to conn.GetAddress() (which returns 127.0.0.1
 			// behind an L4 proxy) or conn.ClientId (which resets on reconnect).
+			if (connectionIpByClientId.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out string? realIp)
+				&& !string.IsNullOrEmpty(realIp))
+			{
+				return HandshakeService.NormalizeIp(realIp);
+			}
+			// Login server may also mirror IPs into AccountCreation runtime data.
 			if (Server?.DataContainerRegistry != null &&
 				Server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out var rt) &&
 				rt.ConnectionIpCache != null &&
-				rt.ConnectionIpCache.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out string? realIp))
+				rt.ConnectionIpCache.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out realIp)
+				&& !string.IsNullOrEmpty(realIp))
 			{
 				return HandshakeService.NormalizeIp(realIp);
 			}
@@ -519,27 +302,14 @@ namespace FishMMO.Server.Implementation
 		#region FishNet Broadcast / Event Routing
 
 		/// <summary>Routes incoming ClientHandshake broadcast to the core handshake handler
-		/// and processes the connection token for real-IP recovery.
-		/// Accepts <paramref name="clientId"/> rather than a <see cref="NetworkConnection"/>
-		/// reference because the connection may be disconnected and recycled by FishNet
-		/// while this async method is suspended at an await point.</summary>
-		internal async Task OnServerClientHandshakeReceivedAsync(int clientId, ClientHandshake msg, Channel channel)
+		/// and processes the connection token for real-IP recovery.</summary>
+		internal async Task OnServerClientHandshakeReceivedAsync(NetworkConnection conn, ClientHandshake msg, Channel channel)
 		{
-			// Resolve the connection at entry.  If it's already gone, bail.
-			if (!TryResolveConnection(clientId, out var conn))
-				return;
-
 			if (conn.IsAuthenticated)
 			{
 				conn.Disconnect(true);
 				return;
 			}
-
-			// Capture the connection-instance nonce NOW, before any await.
-			// If the ClientId is recycled while we're suspended, the nonce
-			// in the dictionary will not match, and we abort the handshake
-			// rather than routing it to the wrong connection.
-			connectionNonces.TryGetValue(clientId, out string? capturedNonce);
 
 			// Validate field sizes before forwarding to the core handler.
 			// Reject oversized payloads on the network thread before any allocation or crypto work.
@@ -552,115 +322,54 @@ namespace FishMMO.Server.Implementation
 				return;
 			}
 
-				// ── FIX #3: Validate protocol version range semantics ──
-				// MinVersion/MaxVersion are ushort — wire-type safe but never
-				// semantically validated before expensive crypto operations
-				// (HMAC-SHA256 token verification, ECDH key agreement).
-				// Reject invalid ranges here to avoid wasting CPU on
-				// connections that will inevitably fail version negotiation.
-				// Version 0 is reserved (indicates uninitialized client).
-				if (msg.MinVersion == 0 || msg.MaxVersion == 0 || msg.MinVersion > msg.MaxVersion)
-				{
-					conn.Disconnect(true);
-					return;
-				}
-
-			// Rate-limit handshake processing BEFORE the connection token HMAC
-			// verification (which is CPU-bound). Without this gate, an attacker
-			// can open a single QUIC connection and flood ClientHandshake messages
-			// with forged tokens, consuming HMAC-SHA256 cycles without ever reaching
-			// the capacity-limited SRP channels deeper in the core.
-			// Uses the resolved real IP when available; falls back to transport
-			// address or ClientId for initial connections where IP isn't yet known.
-			//
-			// IMPORTANT: Never use conn.GetAddress() as the fallback key when it
-			// returns a loopback address (127.0.0.1, ::1). Behind an L4 UDP proxy
-			// all connections appear to come from 127.0.0.1, which would make every
-			// pre-authentication client share one rate-limit bucket — a single
-			// attacker could saturate it and deny service to all legitimate clients.
-			// Fall back to ClientId (unique per QUIC connection) instead.
-			{
-				string? rateLimitKey = ResolveRateLimitKey(conn);
-				if (string.IsNullOrEmpty(rateLimitKey))
-				{
-					string addr = conn.GetAddress();
-					if (!string.IsNullOrEmpty(addr) && !NetHelper.IsLoopbackAddress(addr))
-						rateLimitKey = addr;
-					else
-						rateLimitKey = $"conn:{clientId}";
-				}
-				if (!handshakeRateLimiter.TryBegin(rateLimitKey, DateTime.UtcNow, HandshakeRateLimitInterval))
-				{
-					conn.Disconnect(true);
-					return;
-				}
-			}
-
 			// Process connection token for real-IP recovery synchronously.
 			// When behind an L4 UDP proxy, conn.GetAddress() returns 127.0.0.1.
 			// The token bridges the real IP from the HTTP layer into the QUIC layer.
 			// We await resolution because rate limiting requires a verified real IP —
 			// falling back to proxy IP or ClientId is not acceptable for DoS protection.
+			//
+			// ConnectionToken is required on the *first* ClientHandshake only.
+			// Later handshakes intentionally omit it:
+			//   • Phase-1 cookie echo (ClientAuthenticatorCore) — Cookie set, token null
+			//   • Queue-admit RetryHandshakeAsync — token already consumed, IP already bound
+			// Reject only when there is no token AND no real IP already bound to this conn.
 			if (!string.IsNullOrEmpty(msg.ConnectionToken))
 			{
 				try
 				{
-					if (!await ProcessConnectionTokenAsync(clientId, msg.ConnectionToken))
+					if (!await ProcessConnectionTokenAsync(conn, msg.ConnectionToken))
 					{
-						if (TryResolveConnection(clientId, out conn))
-							conn.Disconnect(true);
+						conn.Disconnect(true);
 						return;
 					}
 				}
 				catch (Exception ex)
 				{
-					await Log.Error(LogPrefix, $"ProcessConnectionTokenAsync threw for connection {clientId}: {ex.Message}");
-					if (TryResolveConnection(clientId, out conn))
-						conn.Disconnect(true);
+					await Log.Error(LogPrefix, $"ProcessConnectionTokenAsync threw for connection {conn.ClientId}: {ex.Message}");
+					conn.Disconnect(true);
 					return;
 				}
 			}
-			else
+			else if (ResolveRateLimitKey(conn) == null)
 			{
-				// No connection token provided — client is not coming through the
-				// IPFetch proxy path. Disconnect immediately.
-				await Log.Warning(LogPrefix, $"Connection {clientId} rejected: no connection token.");
-				if (TryResolveConnection(clientId, out conn))
-					conn.Disconnect(true);
-				return;
-			}
-
-			// ── Re-resolve connection after await ──────────────────
-			// ProcessConnectionTokenAsync yielded at an await.  The
-			// connection may have been disconnected (e.g. by the auth
-			// timeout sweep) or recycled while we were suspended.
-			// Re-resolve from the server's client dictionary before
-			// touching any connection state.
-			if (!TryResolveConnection(clientId, out conn))
-				return;
-
-			// Nonce guard: ensure the connection wasn't recycled during
-			// ProcessConnectionTokenAsync's await.
-			if (!IsConnectionNonceValid(clientId, capturedNonce))
-				return;
-
-			// ── FIX #4: Re-check IsAuthenticated after await ──────
-			// ProcessConnectionTokenAsync (above) and the rate-limit
-			// resolution are both async operations that yield.  A
-			// second ClientHandshake broadcast on the same connection
-			// could have completed authentication between our initial
-			// IsAuthenticated guard and this point.  Without this
-			// re-check, duplicate handshakes enter the auth pipeline
-			// and consume worker-channel capacity.
-			if (conn.IsAuthenticated)
-			{
+				// First contact without IPFetch token — not allowed behind L4 proxy.
+				await Log.Warning(LogPrefix,
+					$"Connection {conn.ClientId} rejected: no connection token " +
+					$"(and no real IP bound yet). cookieLen={msg.Cookie?.Length ?? 0}");
 				conn.Disconnect(true);
 				return;
+			}
+			else
+			{
+				await Log.Debug(LogPrefix,
+					$"Connection {conn.ClientId}: ClientHandshake without token accepted " +
+					$"(cookie-echo or re-handshake; real IP already bound). " +
+					$"cookieLen={msg.Cookie?.Length ?? 0}");
 			}
 
 			if (Core == null)
 			{
-				await Log.Warning(LogPrefix, $"Core is null during OnHandshakeReceived for connection {clientId} — handshake discarded. Ensure InitializeWorkers() was called before accepting connections.");
+				await Log.Warning(LogPrefix, $"Core is null during OnHandshakeReceived for connection {conn.ClientId} — handshake discarded. Ensure InitializeWorkers() was called before accepting connections.");
 			}
 			else
 			{
@@ -671,201 +380,48 @@ namespace FishMMO.Server.Implementation
 		/// <summary>
 		/// Validates a connection token against the database and stores the real IP
 		/// for rate-limiting and logging. Fire-and-forget — does not block the handshake.
-		/// Accepts <paramref name="clientId"/> rather than a <see cref="NetworkConnection"/>
-		/// because the caller may have yielded at an await and the original connection
-		/// reference may be stale.
 		/// </summary>
 		/// <returns>true if the real IP was successfully recovered; false if the client should be disconnected.</returns>
-		private async Task<bool> ProcessConnectionTokenAsync(int clientId, string rawToken)
+		private async Task<bool> ProcessConnectionTokenAsync(NetworkConnection conn, string rawToken)
 		{
 			CancellationToken ct = shutdownToken;
 			if (ct.IsCancellationRequested) return false;
 
 			var server = Server;
-			if (server?.DataContainerRegistry == null ||
-				!server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out _))
+			// World/Scene authenticators do not host AccountCreationSystem — only need
+			// Server.Configuration (or env) for the shared HMAC key.
+			if (server == null)
 				return false;
 
-			// Try stateless HMAC verification (format: payloadB64.sigB64).
-			// Uses the database-backed key map — no environment variable or .cfg file fallbacks.
-			string? realIp = TryVerifyStatelessConnectionToken(rawToken);
+			// Stateless HMAC verification (payloadB64.sigB64). Shared key with IPFetch.
+			string? realIp = TryVerifyStatelessConnectionToken(rawToken, server.Configuration);
 			if (realIp != null)
 			{
-				StoreRealIpForConnection(clientId, realIp);
-				await Log.Debug(LogPrefix, $"Real IP {realIp} recovered via HMAC token for connection {clientId}.");
+				StoreRealIpForConnection(conn.ClientId, realIp);
+				await Log.Debug(LogPrefix, $"Real IP {realIp} recovered via HMAC token for connection {conn.ClientId}.");
 				return true;
 			}
 
 			// Legacy DB-backed token path removed (IConnectionTokenService deleted
 			// when connection tokens migrated to stateless HMAC).
-			await Log.Warning(LogPrefix, $"Legacy connection token not supported for {clientId}.");
+			await Log.Warning(LogPrefix, $"Connection token invalid/expired/unsigned for {conn.ClientId}.");
 			return false;
 		}
 
 		/// <summary>
-		/// Resolves a <see cref="NetworkConnection"/> from its ClientId using the
-		/// server's active client dictionary.  Returns <c>false</c> if the connection
-		/// has been disconnected or the server is not running.
-		/// </summary>
-		private bool TryResolveConnection(int clientId, out NetworkConnection conn)
-		{
-			conn = null;
-			var clients = NetworkManager?.ServerManager?.Clients;
-			return clients != null && clients.TryGetValue(clientId, out conn) && conn != null;
-		}
-
-		/// <summary>
-		/// Validates that the connection identified by <paramref name="clientId"/> still
-		/// has the same instance nonce that was captured before the first await in
-		/// <see cref="OnServerClientHandshakeReceivedAsync"/>.  If the nonce does not
-		/// match (or is missing), the ClientId was recycled while we were suspended,
-		/// and the handshake must be aborted to avoid routing auth data to the wrong
-		/// connection.
-		/// </summary>
-		/// <returns>True if the nonce matches or no nonce was captured (pre-nonce server); false if the connection was recycled.</returns>
-		private bool IsConnectionNonceValid(int clientId, string? capturedNonce)
-		{
-			if (capturedNonce == null) return true; // Pre-nonce server — no validation possible
-			return connectionNonces.TryGetValue(clientId, out string? currentNonce) &&
-			       currentNonce == capturedNonce;
-		}
-
-		/// <summary>
-		/// Thread-safe store for connection token keys loaded from the database.
-		/// Populated by <see cref="LoadConnectionTokenKeysFromDbAsync"/> and refreshed
-		/// every 60 seconds by <see cref="KeyRefreshLoop"/>.
-		/// The database is the ONLY source — no environment variable or .cfg file fallbacks.
-		/// </summary>
-		private static volatile Dictionary<string, byte[]>? s_dbConnectionTokenKeyMap;
-		private static readonly object s_dbConnectionTokenKeyMapLock = new();
-
-
-		/// <summary>
-		/// Loads all active connection token keys from the database into the
-		/// <see cref="s_dbConnectionTokenKeyMap"/> static field. Uses the
-		/// <see cref="IConnectionTokenKeyService"/> resolved from the server's
-		/// database service registry.
-		/// This is called once on startup and then periodically by <see cref="KeyRefreshLoop"/>.
-		/// The database is the ONLY source — no environment variable or .cfg file fallbacks exist.
-		/// If the database is unavailable, connection token verification will fail.
-		/// </summary>
-		private async Task LoadConnectionTokenKeysFromDbAsync()
-		{
-			try
-			{
-				var server = Server;
-				if (server?.Database?.ServiceRegistry == null)
-				{
-					await Log.Debug(LogPrefix, "Database not available yet — skipping connection token key load.");
-					return;
-				}
-
-				if (!server.Database.ServiceRegistry.TryGet<IConnectionTokenKeyService>(out var service))
-				{
-					await Log.Error(LogPrefix,
-						"CRITICAL: IConnectionTokenKeyService not registered in database service registry. " +
-						"Connection token keys must come from the database — no environment variable or " +
-						".cfg file fallbacks exist. Ensure the service assembly is loaded.");
-					return;
-				}
-
-				// Check cancellation before the DB call.
-				var ct = shutdownToken;
-				if (ct.IsCancellationRequested) return;
-
-				var result = await service.FetchAllActiveAsync(ct);
-				if (result.IsSuccess && result.Data != null && result.Data.Length > 0)
-				{
-					var map = new Dictionary<string, byte[]>(StringComparer.Ordinal);
-					foreach (var keyData in result.Data)
-					{
-						if (keyData.HmacKey != null && keyData.HmacKey.Length >= 32)
-						{
-							map[keyData.KeyId] = keyData.HmacKey;
-						}
-						else
-						{
-							await Log.Warning(LogPrefix,
-								$"Skipping connection token key '{keyData.KeyId}' from database: " +
-								$"HMAC key is {(keyData.HmacKey == null ? "null" : $"too short ({keyData.HmacKey.Length} bytes)")}.");
-						}
-					}
-
-					lock (s_dbConnectionTokenKeyMapLock)
-					{
-						s_dbConnectionTokenKeyMap = map;
-					}
-					await Log.Debug(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
-				}
-				else if (result.IsSuccess)
-				{
-					// No active keys in DB — clear any stale map so we don't use rotated-out keys.
-					lock (s_dbConnectionTokenKeyMapLock)
-					{
-						s_dbConnectionTokenKeyMap = null;
-					}
-					await Log.Warning(LogPrefix,
-						"Database returned zero active connection token keys. " +
-						"No connection token keys are available — token verification will fail.");
-				}
-				else
-				{
-					await Log.Warning(LogPrefix,
-						$"Failed to fetch connection token keys from database: " +
-						$"[{result.ErrorCode}] {result.ErrorMessage}. " +
-						"No connection token keys are available — token verification will fail.");
-				}
-			}
-			catch (OperationCanceledException)
-			{
-				// Shutdown in progress — not actionable.
-			}
-			catch (Exception ex)
-			{
-				await Log.Warning(LogPrefix,
-					$"Exception loading connection token keys from database: {ex.Message}. " +
-					"No connection token keys are available — token verification will fail.");
-			}
-		}
-
-		/// <summary>
-		/// Periodic background loop that refreshes the DB-loaded connection token key map
-		/// every 60 seconds. Runs for the lifetime of the server, cooperatively cancelling
-		/// via <paramref name="ct"/>.
-		/// </summary>
-		private async Task KeyRefreshLoop(CancellationToken ct)
-		{
-			while (!ct.IsCancellationRequested)
-			{
-				try
-				{
-					await Task.Delay(TimeSpan.FromSeconds(60), ct);
-					await LoadConnectionTokenKeysFromDbAsync();
-				}
-				catch (OperationCanceledException)
-				{
-					break;
-				}
-				catch (Exception ex)
-				{
-					await Log.Error(LogPrefix,
-						$"Unhandled exception in connection token key refresh loop: {ex.Message}");
-				}
-			}
-		}
-
-		/// <summary>
 		/// Attempts to verify a stateless HMAC-signed connection token.
-		/// Supports format: base64url(keyId:realIp|expiryUnix).base64url(HMAC-SHA256(key, payload))
-		/// The keyId is used to look up the verification key from the database-backed key map.
+		/// Token format: base64url(realIp|expiryUnix).base64url(HMAC-SHA256(key, payload))
 		/// Returns the real IP on success, null if the token is invalid/expired
-		/// or the HMAC key is not available.
+		/// or the HMAC key is not configured.
 		/// </summary>
-		private static string? TryVerifyStatelessConnectionToken(string rawToken)
+		private static string? TryVerifyStatelessConnectionToken(string rawToken, IServerConfiguration? config)
 		{
 			if (string.IsNullOrEmpty(rawToken)) return null;
 			int dotIdx = rawToken.LastIndexOf('.');
 			if (dotIdx <= 0 || dotIdx >= rawToken.Length - 1) return null;
+
+			var hmacKey = ResolveConnectionTokenHmacKey(config);
+			if (hmacKey == null) return null;
 
 			try
 			{
@@ -878,64 +434,16 @@ namespace FishMMO.Server.Implementation
 				var payload = Convert.FromBase64String(payloadB64);
 				var expectedSig = Convert.FromBase64String(sigB64);
 
-				var payloadStr = Encoding.UTF8.GetString(payload);
-				int pipeIdx = payloadStr.LastIndexOf('|');
-				if (pipeIdx <= 0) return null;
-
-				// Determine token format by checking for a keyId prefix.
-				// Format: "keyId:realIp|expiryUnix" - first colon separates
-				// keyId from IP (keyId is looked up in the database-backed key map).
-				// Safe for IPv6: we only treat the prefix as a keyId if it is
-				// actually found in the key map.  This avoids rejecting tokens where an
-				// IPv6 address segment happens to be separated by a colon.
-				int colonIdx = payloadStr.IndexOf(':');
-				bool hasKeyId = false;
-
-				byte[]? hmacKey = null;
-				if (colonIdx > 0 && colonIdx < pipeIdx)
-				{
-					string potentialKeyId = payloadStr.Substring(0, colonIdx);
-					// Keys come SOLELY from the database — no environment variable or
-					// .cfg file fallbacks.
-					var keyMap = s_dbConnectionTokenKeyMap;
-					hasKeyId = keyMap != null && keyMap.TryGetValue(potentialKeyId, out hmacKey);
-				}
-				else
-				{
-					// No keyId prefix in the payload — use the default shared key.
-					// This is the path taken when IpFetchServer.GetConnectionTokenKeyId()
-					// returns null/empty and the payload is simply "realIp|expiryUnix".
-					//
-					// NOTE: IPv6 addresses in the realIp position contain colons that
-					// would be caught by the keyId branch above.  The first colon is
-					// interpreted as a keyId separator, and when TryGetValue fails
-					// (because "2001" is not a registered keyId), hmacKey stays null.
-					// For single-region deployments, setting GetConnectionTokenKeyId()
-					// to "shared" (non-null) produces "shared:2001:db8::1|..." —
-					// unambiguous regardless of IP version.
-					var keyMap = s_dbConnectionTokenKeyMap;
-					hmacKey = keyMap != null && keyMap.TryGetValue("shared", out var defaultKey)
-						? defaultKey : null;
-				}
-
-				if (hmacKey == null) return null;
-
 				using var hmac = new HMACSHA256(hmacKey);
 				var computedSig = hmac.ComputeHash(payload);
 				if (!CryptographicOperations.FixedTimeEquals(computedSig, expectedSig))
 					return null;
 
-				// Extract the real IP from the payload.
-				string realIp;
-				if (hasKeyId)
-				{
-					realIp = payloadStr.Substring(colonIdx + 1, pipeIdx - colonIdx - 1);
-				}
-				else
-				{
-					realIp = payloadStr.Substring(0, pipeIdx);
-				}
+				var payloadStr = Encoding.UTF8.GetString(payload);
+				int pipeIdx = payloadStr.LastIndexOf('|');
+				if (pipeIdx <= 0) return null;
 
+				var realIp = payloadStr.Substring(0, pipeIdx);
 				if (!long.TryParse(payloadStr.Substring(pipeIdx + 1), out long expiryUnix))
 					return null;
 
@@ -951,11 +459,51 @@ namespace FishMMO.Server.Implementation
 		}
 
 		/// <summary>
+		/// Resolves the shared HMAC key for connection token verification.
+		/// Order: ConnectionTokenHmacKeyBase64 in server .cfg, then
+		/// FISHMMO_CONNECTION_TOKEN_HMAC_KEY_BASE64 env var.
+		/// </summary>
+		private static byte[]? ResolveConnectionTokenHmacKey(IServerConfiguration? config)
+		{
+			// Env first (production preferred), then cfg — skip empty / ${VAR} templates.
+			string? b64 = System.Environment.GetEnvironmentVariable("FISHMMO_CONNECTION_TOKEN_HMAC_KEY_BASE64");
+			if (IsUnsetSecretTemplate(b64)
+				&& config != null
+				&& config.TryGetString("ConnectionTokenHmacKeyBase64", out var cfgValue))
+			{
+				b64 = cfgValue;
+			}
+			if (IsUnsetSecretTemplate(b64)) return null;
+			b64 = b64!.Trim();
+			try { return Convert.FromBase64String(b64); }
+			catch { return null; }
+		}
+
+		/// <summary>
+		/// True when a secret string is missing or is an unexpanded shell-style template
+		/// (e.g. <c>${FISHMMO_CONNECTION_TOKEN_HMAC_KEY_BASE64}</c>) that must not block env fallback.
+		/// </summary>
+		private static bool IsUnsetSecretTemplate(string? value)
+		{
+			if (string.IsNullOrWhiteSpace(value)) return true;
+			string t = value.Trim();
+			return t.StartsWith("${", StringComparison.Ordinal) && t.EndsWith("}", StringComparison.Ordinal);
+		}
+
+		/// <summary>
 		/// Stores the real client IP for a connection so that rate-limiting and
 		/// logging use the actual address instead of the proxy's loopback IP.
+		/// Always writes the authenticator-local cache (Login/World/Scene). When
+		/// present, also mirrors into AccountCreation runtime data for login-only
+		/// account-creation rate limits.
 		/// </summary>
-		private void StoreRealIpForConnection(int clientId, string realIp)
+		protected void StoreRealIpForConnection(int clientId, string realIp)
 		{
+			if (string.IsNullOrEmpty(realIp))
+				return;
+
+			connectionIpByClientId.Upsert(clientId, realIp, DateTime.UtcNow);
+
 			if (Server?.DataContainerRegistry != null &&
 				Server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out var runtimeData))
 			{
@@ -966,26 +514,10 @@ namespace FishMMO.Server.Implementation
 		/// <summary>Notifies the core when a remote connection stops so transient auth state can be purged.</summary>
 		private void ServerManager_OnRemoteConnectionState(NetworkConnection conn, RemoteConnectionStateArgs args)
 		{
-			if (args.ConnectionState == RemoteConnectionState.Started)
+			if (args.ConnectionState == RemoteConnectionState.Stopped)
 			{
-				// Record the connection start time for the authentication timeout sweep.
-				// TryAdd is a no-op if the key already exists (defense against duplicate Started events).
-				connectionStartTimes.TryAdd(conn.ClientId, DateTime.UtcNow);
-				// Generate a random nonce to bind this handshake to this specific
-				// connection instance.  If the ClientId is recycled during an await
-				// in OnServerClientHandshakeReceivedAsync, the nonce check detects
-				// the mismatch and aborts safely.  TryAdd is a no-op on duplicate
-				// Started events (same defense as connectionStartTimes).
-				connectionNonces.TryAdd(conn.ClientId, Guid.NewGuid().ToString("N"));
-			}
-			else if (args.ConnectionState == RemoteConnectionState.Stopped)
-			{
-				// Clean up the auth timeout tracker and nonce — the connection is
-				// gone regardless of whether it authenticated successfully.
-				connectionStartTimes.TryRemove(conn.ClientId, out _);
-				connectionNonces.TryRemove(conn.ClientId, out _);
-
 				Core?.HandleConnectionStopped(conn);
+				connectionIpByClientId.Remove(conn.ClientId);
 				// Immediately notify the login queue so dead connections
 				// don't consume admission ticks for up to 10 seconds.
 				if (Server?.BehaviourRegistry != null &&

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/ServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/ServerAuthenticator.cs
@@ -38,18 +38,6 @@ namespace FishMMO.Server.Implementation
 
 		private static readonly TimeSpan RevokeRateLimitDuration = TimeSpan.FromSeconds(5);
 
-		/// <summary>
-		/// Global secondary rate limiter for revocation, keyed by the string "global".
-		/// Acts as a safety net when the per-IP limiter falls back to conn:{clientId}
-		/// (e.g. behind an L4 proxy where real IP lookup fails).  Without this global
-		/// cap, an attacker could open many connections and send one revoke per connection
-		/// per 5 seconds — bounded by total connection slots.  This global limiter caps
-		/// total revocations at 10/second regardless of connection count.
-		/// </summary>
-		private readonly ExpiringKeyTracker<string> revokeGlobalRateLimiter = new ExpiringKeyTracker<string>(StringComparer.OrdinalIgnoreCase);
-
-		private static readonly TimeSpan RevokeGlobalRateLimitDuration = TimeSpan.FromMilliseconds(100);
-
 		/// <summary>The SRP-specific core instance. Null until <see cref="InitializeCoreInstance"/> is called.</summary>
 		private ServerAuthenticatorCore core;
 
@@ -228,9 +216,6 @@ namespace FishMMO.Server.Implementation
 			// Sweep expired entries from the per-IP revoke rate limiter to prevent
 			// unbounded memory growth under sustained token-revoke traffic.
 			revokeRateLimiter.SweepExpired(DateTime.UtcNow, maxScan: 64, maxRemove: 16);
-			// Global revocation limiter has only one entry ("global") so sweeping
-			// is cheap — just remove expired entries.
-			revokeGlobalRateLimiter.SweepExpired(DateTime.UtcNow, maxScan: 1, maxRemove: 1);
 		}
 
 		#endregion
@@ -239,41 +224,15 @@ namespace FishMMO.Server.Implementation
 
 		/// <summary>Routes an incoming <see cref="SrpVerifyRequestBroadcast"/> to the core SRP verify channel.</summary>
 		internal void OnServerSrpVerifyBroadcastReceived(NetworkConnection conn, SrpVerifyRequestBroadcast msg, Channel channel)
-		{
-			// Validate wire-format bounds before any allocation or crypto work.
-			// Reject oversized payloads on the network thread.
-			if (msg.Username == null || msg.Username.Length > AuthSizeLimits.MaxSrpUsernameSize ||
-				msg.PublicEphemeral == null || msg.PublicEphemeral.Length > AuthSizeLimits.MaxSrpEphemeralSize)
-			{
-				conn.Disconnect(true);
-				return;
-			}
-			core?.OnSrpVerifyReceived(conn, msg.Username, msg.PublicEphemeral, msg.Seq);
-		}
+			=> core?.OnSrpVerifyReceived(conn, msg.Username, msg.PublicEphemeral, msg.Seq);
 
 		/// <summary>Routes an incoming <see cref="SrpProofBroadcast"/> to the core SRP proof channel.</summary>
 		internal void OnServerSrpProofBroadcastReceived(NetworkConnection conn, SrpProofBroadcast msg, Channel channel)
-		{
-			// Validate wire-format bounds before any allocation or crypto work.
-			if (msg.Proof == null || msg.Proof.Length > AuthSizeLimits.MaxSrpProofSize)
-			{
-				conn.Disconnect(true);
-				return;
-			}
-			core?.OnSrpProofReceived(conn, msg.Proof, msg.Seq);
-		}
+			=> core?.OnSrpProofReceived(conn, msg.Proof, msg.Seq);
 
 		/// <summary>Routes an incoming <see cref="TwoFactorVerifyBroadcast"/> to the core TOTP verification handler.</summary>
 		internal void OnServerTwoFactorVerifyBroadcastReceived(NetworkConnection conn, TwoFactorVerifyBroadcast msg, Channel channel)
-		{
-			// Validate wire-format bounds before any allocation or crypto work.
-			if (msg.Code == null || msg.Code.Length > AuthSizeLimits.MaxTotpCodeSize)
-			{
-				conn.Disconnect(true);
-				return;
-			}
-			core?.OnTwoFactorVerifyReceived(conn, msg.Code, msg.Seq);
-		}
+			=> core?.OnTwoFactorVerifyReceived(conn, msg.Code, msg.Seq);
 
 		/// <summary>
 		/// Handles an incoming <see cref="RevokeTokenBroadcast"/> from a client that is explicitly
@@ -285,21 +244,6 @@ namespace FishMMO.Server.Implementation
 		{
 			// Validate payload bounds up front on the network thread; defer DB work to a Task.
 			if (msg.Token == null || msg.Token.Length == 0 || msg.Token.Length > 4096)
-			{
-				return;
-			}
-
-			// Reject revocation requests from connections that have not started the
-			// authentication process.  This broadcast is registered with
-			// requiresAuthentication:false to allow authenticated clients to revoke
-			// tokens after the auth channel is torn down on logout, but completely
-			// unauthenticated connections (those that never sent a ClientHandshake)
-			// must not trigger DB queries.
-			//
-			// connectionStartTimes is populated on RemoteConnectionState.Started and
-			// removed on Stopped.  A connection that never started the auth process
-			// will not have an entry here.
-			if (!connectionStartTimes.ContainsKey(conn.ClientId))
 			{
 				return;
 			}
@@ -316,16 +260,6 @@ namespace FishMMO.Server.Implementation
 				return;
 			}
 
-			// Global secondary rate limit: even if the per-IP limiter uses a per-connection
-			// fallback key (conn:{clientId}), this global cap prevents an attacker from
-			// saturating the DB with revocation queries across many connections.
-			// Limits total revocations to 10/sec regardless of connection count.
-			if (!revokeGlobalRateLimiter.TryBegin("global", DateTime.UtcNow, RevokeGlobalRateLimitDuration))
-			{
-				_ = Log.Warning(LogPrefix, "Revoke token globally rate limited.");
-				return;
-			}
-
 			// Copy so the deserialized buffer is not mutated by FishNet after we hand off.
 			byte[] tokenCopy = new byte[msg.Token.Length];
 			Buffer.BlockCopy(msg.Token, 0, tokenCopy, 0, tokenCopy.Length);
@@ -334,11 +268,6 @@ namespace FishMMO.Server.Implementation
 			{
 				try
 				{
-					// Check cancellation before any DB work.  If the server is shutting
-					// down, bail immediately rather than competing with teardown.
-					if (ShutdownToken.IsCancellationRequested)
-						return;
-
 					string tokenHash = null;
 					try
 					{
@@ -354,20 +283,11 @@ namespace FishMMO.Server.Implementation
 						return;
 					}
 
-					// Re-check cancellation before accessing Server.Database, which
-					// may already be nulled by PerformShutdown during teardown.
-					if (ShutdownToken.IsCancellationRequested)
-						return;
-
 					if (Server?.Database?.ServiceRegistry == null ||
 						!Server.Database.ServiceRegistry.TryGet<IAuthTokenService>(out var svc))
 					{
 						return;
 					}
-
-					// One final cancellation check before the DB call.
-					if (ShutdownToken.IsCancellationRequested)
-						return;
 
 					try
 					{
@@ -392,15 +312,11 @@ namespace FishMMO.Server.Implementation
 						await Log.Warning(LogPrefix, $"Exception during client-initiated token revoke: {ex.Message}");
 					}
 				}
-				catch (OperationCanceledException)
-				{
-					/* Server is shutting down — expected, no action needed. */
-				}
 				catch (Exception ex)
 				{
 					await Log.Error(LogPrefix, $"Unhandled exception in token revocation task: {ex.Message}");
 				}
-			}, ShutdownToken);
+			});
 		}
 
 		#endregion
@@ -581,17 +497,9 @@ namespace FishMMO.Server.Implementation
 			/// <inheritdoc/>
 			protected override string? ResolveClientRealIp(NetworkConnection conn)
 			{
-				if (conn == null) return null;
-				// Look up the real IP that was recovered from the connection token
-				// (or stateless HMAC token) during the ClientHandshake.
-				if (outer.Server?.DataContainerRegistry != null &&
-					outer.Server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out var rt) &&
-					rt.ConnectionIpCache != null)
-				{
-					if (rt.ConnectionIpCache.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out string? ip))
-						return ip;
-				}
-				return null;
+				// Real IP recovered from the connection token during ClientHandshake
+				// (authenticator-local cache; works on Login/World/Scene).
+				return outer.ResolveRateLimitKey(conn);
 			}
 
 			/// <inheritdoc/>

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
@@ -50,9 +50,7 @@ namespace FishMMO.Server.Implementation
 		/// warning log; callers must fail closed.
 		/// Uses double-checked locking for thread safety: the outer null check avoids the
 		/// lock cost on the hot path; the inner null check under the lock ensures only one
-		/// thread calls <see cref="TryLoadKekFromDatabase"/>.
-		/// The database (deployment_secrets table) is the ONLY source for the KEK — no
-		/// environment variable or .cfg file fallbacks are supported.
+		/// thread calls <see cref="SigningKeyKekProvider.TryLoad"/>.
 		/// </summary>
 		private byte[] TryGetSigningKeyKek()
 		{
@@ -60,42 +58,13 @@ namespace FishMMO.Server.Implementation
 			lock (signingKeyKekLock)
 			{
 				if (this.signingKeyKek != null) return this.signingKeyKek;
-				byte[] kek = TryLoadKekFromDatabase();
-				if (kek == null)
+				if (!SigningKeyKekProvider.TryLoad(Server.Configuration, out byte[] kek, out string error))
 				{
-					_ = Log.Warning(LogPrefix,
-						"Signing-key KEK unavailable. " +
-						"The KEK must be in the deployment_secrets database table with key='signing_key_kek'. " +
-						"No environment variable or .cfg file fallbacks are supported.");
+					_ = Log.Warning(LogPrefix, $"Signing-key KEK unavailable: {error}");
 					return null;
 				}
 				this.signingKeyKek = kek;
 				return kek;
-			}
-		}
-
-		/// <summary>
-		/// Attempts to load the KEK from the deployment_secrets database table.
-		/// Returns null if the database is unavailable or the key is not found.
-		/// Uses <see cref="SigningKeyKekProvider.TryLoadFromDatabase"/> for the actual lookup.
-		/// </summary>
-		private byte[]? TryLoadKekFromDatabase()
-		{
-			try
-			{
-				var server = Server;
-				if (server?.Database?.ServiceRegistry == null) return null;
-				if (!server.Database.ServiceRegistry.TryGet<IDeploymentSecretService>(out var svc))
-					return null;
-				if (SigningKeyKekProvider.TryLoadFromDatabase(svc, out byte[] kek, out string error))
-					return kek;
-				_ = Log.Warning(LogPrefix, $"Failed to load KEK from deployment_secrets: {error}");
-				return null;
-			}
-			catch (Exception ex)
-			{
-				_ = Log.Warning(LogPrefix, $"Exception loading KEK from deployment_secrets: {ex.Message}");
-				return null;
 			}
 		}
 
@@ -187,16 +156,7 @@ namespace FishMMO.Server.Implementation
 
 		/// <summary>Routes an incoming <see cref="TokenAuthBroadcast"/> to the core token authentication channel.</summary>
 		internal void OnServerTokenAuthBroadcastReceived(NetworkConnection conn, TokenAuthBroadcast msg, Channel channel)
-		{
-			// Validate wire-format bounds before any allocation or crypto work.
-			// Reject oversized payloads on the network thread.
-			if (msg.Token == null || msg.Token.Length > AuthSizeLimits.MaxTokenAuthSize)
-			{
-				conn.Disconnect(true);
-				return;
-			}
-			core?.OnTokenAuthReceived(conn, msg.Token, msg.Seq);
-		}
+			=> core?.OnTokenAuthReceived(conn, msg.Token, msg.Seq);
 
 		#endregion
 
@@ -295,9 +255,8 @@ namespace FishMMO.Server.Implementation
 		/// <param name="accountName">Account name extracted from the verified token.</param>
 		/// <param name="accessLevel">Access level extracted from the verified token.</param>
 		/// <param name="loginServerId">Originating LoginServer ID (used to look up the HMAC signing key).</param>
-		private async Task IssueRenewalTokenCoreAsync(NetworkConnection conn, string accountName, AccessLevel accessLevel, long loginServerId, CancellationToken ct)
+		private async Task IssueRenewalTokenCoreAsync(NetworkConnection conn, string accountName, AccessLevel accessLevel, long loginServerId)
 		{
-			ct.ThrowIfCancellationRequested();
 			if (conn == null || !conn.IsActive)
 				return;
 
@@ -312,12 +271,10 @@ namespace FishMMO.Server.Implementation
 			// during exactly the conditions that caused the blip. Make one short
 			// retry with linear backoff before giving up.
 			var currentSigningKey = await FetchCurrentSigningKeyCoreAsync(loginServerId);
-			ct.ThrowIfCancellationRequested();
 			if (currentSigningKey.Key == null)
 			{
-				await Task.Delay(150, ct);
+				await Task.Delay(150);
 				if (!conn.IsActive) return;
-				ct.ThrowIfCancellationRequested();
 				currentSigningKey = await FetchCurrentSigningKeyCoreAsync(loginServerId);
 			}
 			byte[] signingKey = currentSigningKey.Key;
@@ -332,13 +289,6 @@ namespace FishMMO.Server.Implementation
 			{
 				int expirationMinutes = Math.Max(1, (int)renewalTokenExpirationMinutes);
 
-				// NOTE: accessLevel is from the original token's HMAC payload, not a fresh
-				// DB lookup. If the account's access level changed between original token
-				// issuance and renewal, the renewed token carries the old (possibly higher)
-				// privileges. Mitigated by: short token lifetimes (10 min default), and the
-				// expectation that access-level changes accompany token revocation.
-				// A full fix would require an IAccountManager lookup here, but World/Scene
-				// servers may not have access to the accounts table in all deployments.
 				byte[] encryptedToken = TokenService.GenerateAndEncryptToken(
 					encryptionData,
 					accountName,
@@ -479,19 +429,16 @@ namespace FishMMO.Server.Implementation
 			protected override void StoreClientRealIp(NetworkConnection conn, string realIp)
 			{
 				// Store the real IP recovered from the auth token for rate limiting.
-				// This is essential for World/Scene servers behind an L4 proxy where
-				// conn.GetAddress() returns 127.0.0.1.
-				if (outer.Server?.DataContainerRegistry != null &&
-					outer.Server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out var rt) &&
-					rt.ConnectionIpCache != null)
-				{
-					rt.ConnectionIpCache.Upsert(conn.ClientId, realIp, DateTime.UtcNow);
-				}
+				// Essential for World/Scene behind L4 proxy (conn.GetAddress() is loopback).
+				// Uses authenticator-local cache so World/Scene work without AccountCreation.
+				if (conn == null || string.IsNullOrEmpty(realIp))
+					return;
+				outer.StoreRealIpForConnection(conn.ClientId, realIp);
 			}
 
 			/// <inheritdoc/>
 			protected override Task OnTokenAuthSuccessAsync(NetworkConnection conn, string accountName, AccessLevel accessLevel, long loginServerId) =>
-				outer.IssueRenewalTokenCoreAsync(conn, accountName, accessLevel, loginServerId, outer.ShutdownToken);
+				outer.IssueRenewalTokenCoreAsync(conn, accountName, accessLevel, loginServerId);
 		}
 
 		#endregion

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/FishNetNetworkWrapper.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/FishNetNetworkWrapper.cs
@@ -147,9 +147,25 @@ namespace FishMMO.Server.Implementation
 			if (transport == null) return;
 
 			// Inspector/component overrides take precedence over .cfg file values.
+			// Production: Address must be the LISTEN bind (usually 127.0.0.1), not the
+			// public advertise IP — clients reach the host via DNAT/DNS separately.
 			string address = !string.IsNullOrWhiteSpace(addressOverride) ? addressOverride : config.GetString("Address", "127.0.0.1");
 			ushort port = portOverride.HasValue && portOverride.Value > 0 ? portOverride.Value : config.GetUShort("Port", 7777);
 			int maxClients = config.GetInt("MaximumClients", 100);
+
+			if (string.IsNullOrWhiteSpace(address))
+			{
+				Log.Error("FishNetNetworkWrapper", "Transport Address is empty — defaulting to 127.0.0.1");
+				address = "127.0.0.1";
+			}
+			if (port == 0)
+			{
+				Log.Error("FishNetNetworkWrapper", "Transport Port is 0 — server will not start. Set Port in the role .cfg.");
+			}
+
+			Log.Info("FishNetNetworkWrapper",
+				$"ApplyTransportConfiguration: bind={address} port={port} maxClients={maxClients} " +
+				$"(overrideAddr={!string.IsNullOrWhiteSpace(addressOverride)}, overridePort={portOverride.HasValue && portOverride.Value > 0})");
 
 			// IPv6 dual-stack support: when enabled, binds both IPv4 and IPv6 on the same port.
 			bool enableIPv6 = string.Equals(config.GetString("EnableIPv6", "false"), "true", StringComparison.OrdinalIgnoreCase);
@@ -186,17 +202,6 @@ namespace FishMMO.Server.Implementation
 						// Configure allowed origins for browser WebTransport CORS.
 						// Empty = allow all (dev); production MUST set this via .cfg.
 						string allowedOrigins = config.GetString("AllowedOrigins", "");
-#if !UNITY_EDITOR && !DEVELOPMENT_BUILD
-						if (string.IsNullOrEmpty(allowedOrigins))
-						{
-							Log.Warning("FishNetNetworkWrapper",
-								"AllowedOrigins is not configured. Browser WebTransport CORS " +
-								"validation is DISABLED — any website can open connections to " +
-								"this server. Set AllowedOrigins in the server .cfg file to a " +
-								"comma-separated list of allowed origins " +
-								"(e.g. \"https://play.fishmmo.com\").");
-						}
-#endif
 						wt.SetAllowedOrigins(allowedOrigins);
 						if (!ConfigureWebTransport(wt))
 							Log.Warning("FishNetNetworkWrapper", "WebTransport configuration failed for Multipass child — TLS certificates not loaded.");
@@ -217,15 +222,6 @@ namespace FishMMO.Server.Implementation
 				transport.SetPort(port);
 				transport.SetMaximumClients(maxClients);
 				string allowedOrigins = config.GetString("AllowedOrigins", "");
-#if !UNITY_EDITOR && !DEVELOPMENT_BUILD
-				if (string.IsNullOrEmpty(allowedOrigins))
-				{
-					Log.Warning("FishNetNetworkWrapper",
-						"AllowedOrigins is not configured. Browser WebTransport CORS " +
-						"validation is DISABLED — any website can open connections to " +
-						"this server. Set AllowedOrigins in the server .cfg file.");
-				}
-#endif
 				wt.SetAllowedOrigins(allowedOrigins);
 				if (!ConfigureWebTransport(wt))
 					Log.Warning("FishNetNetworkWrapper", "WebTransport configuration failed -- TLS certificates not loaded.");

--- a/FishMMO-Unity/Assets/Scripts/Shared/FishMMO.Shared.asmdef
+++ b/FishMMO-Unity/Assets/Scripts/Shared/FishMMO.Shared.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "FishMMO.Shared",
     "references": [
         "FishNet.Runtime",
+        "WebTransport",
         "GameKit.Dependencies",
         "KinematicCharacterController",
         "Unity.TextMeshPro",

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Bootstrap/MainBootstrapSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Bootstrap/MainBootstrapSystem.cs
@@ -4,6 +4,10 @@ using FishMMO.Logging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using FishNet.Managing;
+using FishNet.Transporting;
+using FishNet.Transporting.Multipass;
+using FishNet.Transporting.WebTransport;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -72,11 +76,79 @@ namespace FishMMO.Shared
 		/// <param name="state">The play mode state change event.</param>
 		private void OnEditorPlayModeStateChanged(PlayModeStateChange state)
 		{
-			// When exiting Play Mode, initiate shutdown.
 			if (state == PlayModeStateChange.ExitingPlayMode)
 			{
-				Debug.Log("[MainBootstrapSystem] Editor exiting Play Mode. Initiating shutdown...");
-				InitiateShutdown();
+				Debug.Log("[MainBootstrapSystem] Editor exiting Play Mode — force network stop (no blocking Wait).");
+				// Critical: kill WebTransport/FishNet BEFORE Unity tears down native plugins.
+				// Blocking Log.Shutdown().Wait() / Addressables.Release during exit caused
+				// wantsToQuit loops and native mono/msquic crashes while still connected.
+				// Do NOT Release Addressables handles here — Addressables.PlayModeStateChangedCleanup
+				// owns that and double-release throws "invalid operation handle".
+				ForceStopNetworkingForEditorExit();
+				try { UnityLoggerBridge.Shutdown(); } catch { /* ignore */ }
+				isInitiatingShutdown = true;
+				canQuitApplication = true;
+			}
+			else if (state == PlayModeStateChange.EnteredPlayMode)
+			{
+				// Fresh play session — reset static quit flags from last exit.
+				isInitiatingShutdown = false;
+				canQuitApplication = false;
+			}
+		}
+
+		/// <summary>
+		/// Stops all FishNet client/server sockets and WebTransport clients without deinit'ing
+		/// the native library (library stays loaded for the next Play session).
+		/// </summary>
+		private static void ForceStopNetworkingForEditorExit()
+		{
+			try
+			{
+				foreach (var nm in UnityEngine.Object.FindObjectsByType<NetworkManager>(FindObjectsSortMode.None))
+				{
+					if (nm == null) continue;
+					try
+					{
+						if (nm.ClientManager != null && nm.ClientManager.Started)
+							nm.ClientManager.StopConnection();
+					}
+					catch { /* best effort */ }
+					try
+					{
+						if (nm.ServerManager != null && nm.ServerManager.Started)
+							nm.ServerManager.StopConnection(true);
+					}
+					catch { /* best effort */ }
+
+					try
+					{
+						Transport t = nm.TransportManager != null ? nm.TransportManager.Transport : null;
+						if (t is Multipass mp)
+						{
+							foreach (Transport nested in mp.Transports)
+							{
+								if (nested is WebTransport nestedWt)
+									nestedWt.ForceStopClient();
+							}
+						}
+						else if (t is WebTransport wt)
+						{
+							wt.ForceStopClient();
+						}
+					}
+					catch { /* best effort */ }
+				}
+
+				// Any WebTransport components not reached via NetworkManager.
+				foreach (var wt in UnityEngine.Object.FindObjectsByType<WebTransport>(FindObjectsSortMode.None))
+				{
+					try { wt.ForceStopClient(); } catch { /* best effort */ }
+				}
+			}
+			catch (Exception ex)
+			{
+				Debug.LogWarning($"[MainBootstrapSystem] ForceStopNetworkingForEditorExit: {ex.Message}");
 			}
 		}
 #endif
@@ -87,6 +159,18 @@ namespace FishMMO.Shared
 		/// <returns>True if the application should quit, false to defer quitting.</returns>
 		private bool OnApplicationWantsToQuit()
 		{
+#if UNITY_EDITOR
+			// Play Mode Stop uses wantsToQuit in some Unity versions. Never block/defer here —
+			// ExitingPlayMode already force-stopped networking. Returning false re-entered a
+			// quit loop and crashed native code.
+			if (!canQuitApplication)
+			{
+				ForceStopNetworkingForEditorExit();
+				canQuitApplication = true;
+				isInitiatingShutdown = true;
+			}
+			return true;
+#else
 			Debug.Log("[MainBootstrapSystem] OnApplicationWantsToQuit called. (isInitiatingShutdown: " + isInitiatingShutdown + ", canQuitApplication: " + canQuitApplication + ")");
 			if (isInitiatingShutdown)
 			{
@@ -98,6 +182,7 @@ namespace FishMMO.Shared
 			Debug.Log("[MainBootstrapSystem] Application wants to quit. Delaying for asynchronous cleanup...");
 			InitiateShutdown();
 			return false; // Defer quitting
+#endif
 		}
 
 		/// <summary>
@@ -113,6 +198,13 @@ namespace FishMMO.Shared
 			}
 			isInitiatingShutdown = true;
 
+#if UNITY_EDITOR
+			// Editor: never .Wait() on the main thread during Play Mode exit.
+			ForceStopNetworkingForEditorExit();
+			try { UnityLoggerBridge.Shutdown(); } catch { /* ignore */ }
+			canQuitApplication = true;
+			return;
+#else
 			// Perform Graphics Cleanup.
 			Debug.Log("[MainBootstrapSystem] Starting graphics cleanup...");
 			GraphicsCleanup().Wait();
@@ -121,22 +213,6 @@ namespace FishMMO.Shared
 			// Detach UnityLoggerBridge before async shutdown.
 			UnityLoggerBridge.Shutdown();
 
-#if UNITY_EDITOR
-			// Editor-specific shutdown logic
-			if (Log.IsInitialized)
-			{
-				Debug.Log("[MainBootstrapSystem] Editor shutdown: Awaiting synchronous Log.Shutdown().");
-				Log.Shutdown().Wait();
-				Debug.Log("[MainBootstrapSystem] Editor shutdown: Log system synchronously shut down.");
-			}
-			else
-			{
-				Debug.Log("[MainBootstrapSystem] Editor shutdown: Log manager not initialized or already shut down. Skipping synchronous Log.Shutdown().");
-			}
-			canQuitApplication = true;
-			Debug.Log("[MainBootstrapSystem] Editor shutdown: Setting canQuitApplication = true.");
-			return;
-#else
 			// For standalone builds or runtime quits, perform asynchronous shutdown.
 			Debug.Log("[MainBootstrapSystem] Standalone: Performing async shutdown.");
 			_ = PerformAsyncShutdown();

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Constants.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Constants.cs
@@ -138,6 +138,42 @@ namespace FishMMO.Shared
 			/// <remarks>Configuration value baked at compile time; changing requires a rebuild.</remarks>
 			public static readonly string GameHost = GeneratedHostConfig.GameHost;
 
+			/// <summary>
+			/// World server hostname for WebTransport (QUIC) hops.
+			/// Defaults to <see cref="GameHost"/> so single-hostname deploys keep working;
+			/// multi-host deployments can later specialize this independently.
+			/// </summary>
+			public static string WorldGameHost => GameHost;
+
+			/// <summary>
+			/// Scene server hostname for WebTransport (QUIC) hops.
+			/// Defaults to <see cref="GameHost"/> so single-hostname deploys keep working.
+			/// </summary>
+			public static string SceneGameHost => GameHost;
+
+			/// <summary>Default LoginServer listen / public QUIC port band start.</summary>
+			public const int LoginServerPort = 7770;
+
+			/// <summary>Default WorldServer listen / public QUIC port band start.</summary>
+			public const int WorldServerPort = 7780;
+
+			/// <summary>Default SceneServer listen / public QUIC port band start.</summary>
+			public const int SceneServerPort = 7790;
+
+			/// <summary>
+			/// Picks the game hostname for a connection port using standard port bands:
+			/// Login 7770–7779, World 7780–7789, Scene 7790+.
+			/// Used by client Login→World→Scene hops after IPFetch token staging.
+			/// </summary>
+			public static string GetGameHostForPort(ushort port)
+			{
+				if (port >= LoginServerPort && port < WorldServerPort)
+					return GameHost;
+				if (port >= WorldServerPort && port < SceneServerPort)
+					return WorldGameHost;
+				return SceneGameHost;
+			}
+
 				/// <summary>
 				/// Launcher HTML/news page URL.
 				///

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Authentication/AuthenticationBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Authentication/AuthenticationBroadcasts.cs
@@ -1,6 +1,5 @@
 using FishNet.Broadcast;
 using FishMMO.Auth.Core;
-using System.Runtime.InteropServices;
 
 namespace FishMMO.Shared
 {
@@ -64,42 +63,6 @@ namespace FishMMO.Shared
 		/// Maximum allowed size in bytes for any single encrypted field in CreateAccountBroadcast.
 		/// </summary>
 		public const int CreateAccountMaxFieldSize = 2048;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted Username field in SrpVerifyRequestBroadcast.
-		/// AES-GCM overhead (~28 bytes) + encrypted username (max 128 bytes plaintext) = generous cap at 512.
-		/// </summary>
-		public const int MaxSrpUsernameSize = 512;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted PublicEphemeral field (SRP client A or server B).
-		/// SRP-6a 4096-bit ephemeral (512 bytes) + AES-GCM overhead (~28 bytes) = generous cap at 1024.
-		/// </summary>
-		public const int MaxSrpEphemeralSize = 1024;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted Proof field (SrpProofBroadcast).
-		/// SRP-6a client proof M1 = 64 bytes (SHA-512) + AES-GCM overhead (~28 bytes) = generous cap at 256.
-		/// </summary>
-		public const int MaxSrpProofSize = 256;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted Salt field (SrpVerifyResponseBroadcast).
-		/// SRP-6a salt (max 64 bytes) + AES-GCM overhead (~28 bytes) = generous cap at 256.
-		/// </summary>
-		public const int MaxSrpSaltSize = 256;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted Token field in TokenAuthBroadcast.
-		/// AES-GCM encrypted signed auth token = generous cap at 1024.
-		/// </summary>
-		public const int MaxTokenAuthSize = 1024;
-
-		/// <summary>
-		/// Maximum allowed size in bytes for the encrypted Code field in TwoFactorVerifyBroadcast.
-		/// Encrypted 6-digit TOTP code + AES-GCM overhead (~28 bytes) = generous cap at 128.
-		/// </summary>
-		public const int MaxTotpCodeSize = 128;
 	}
 
 	/// <summary>
@@ -184,28 +147,11 @@ namespace FishMMO.Shared
 	/// Broadcast sent by the server to complete the handshake, containing the server's
 	/// X25519 public key for ECDH key agreement and the negotiated protocol version.
 	/// </summary>
-	/// <summary>
-	/// Broadcast sent by the server to complete the handshake, containing the server's
-	/// X25519 public key for ECDH key agreement and the negotiated protocol version.
-	/// </summary>
-	/// <remarks>
-	/// <para><see cref="PublicKey"/> and <see cref="Cookie"/> are mutually exclusive:
-	/// <list type="bullet">
-	/// <item><description>A cookie challenge has <c>PublicKey == null</c> and <c>Cookie != null</c>.
-	/// Use <see cref="IsChallenge"/> to test for this.</description></item>
-	/// <item><description>The final handshake response has <c>PublicKey != null</c> and <c>Cookie == null</c>.
-	/// Use <see cref="IsHandshakeResponse"/> to test for this.</description></item>
-	/// </list>
-	/// Consumers MUST use the helper properties instead of null-checking directly,
-	/// so that any future wire-format changes remain isolated to this struct.
-	/// </para>
-	/// </remarks>
 	public struct ServerHandshake : IBroadcast
 	{
 		/// <summary>
 		/// Server's ephemeral X25519 public key (32 bytes).
 		/// Null when this message is a cookie challenge (proof-of-reachability).
-		/// Use <see cref="IsChallenge"/> or <see cref="IsHandshakeResponse"/> to discriminate.
 		/// </summary>
 		public byte[] PublicKey;
 
@@ -213,7 +159,6 @@ namespace FishMMO.Shared
 		/// Stateless HMAC challenge cookie. The client must echo this in a subsequent
 		/// <see cref="ClientHandshake"/> to prove it can receive replies from the server.
 		/// Null when this message contains the final handshake response.
-		/// Use <see cref="IsChallenge"/> or <see cref="IsHandshakeResponse"/> to discriminate.
 		/// </summary>
 		public byte[] Cookie;
 
@@ -222,18 +167,6 @@ namespace FishMMO.Shared
 		/// Both sides use this version in AAD and HKDF labels for all subsequent messages.
 		/// </summary>
 		public ushort AgreedVersion;
-
-		/// <summary>
-		/// Gets whether this message is a cookie challenge (proof-of-reachability).
-		/// Mutually exclusive with <see cref="IsHandshakeResponse"/>.
-		/// </summary>
-		public bool IsChallenge => PublicKey == null && Cookie != null;
-
-		/// <summary>
-		/// Gets whether this message is the final handshake response (ECDH key exchange).
-		/// Mutually exclusive with <see cref="IsChallenge"/>.
-		/// </summary>
-		public bool IsHandshakeResponse => PublicKey != null && Cookie == null;
 	}
 
 	/// <summary>
@@ -371,16 +304,15 @@ namespace FishMMO.Shared
 	/// <para><b>WARNING: Wire-protocol-dependent field order.</b>
 	/// FishNet serializes struct fields in declaration order regardless of CLR layout.
 	/// The actual order guarantee comes from FishNet's serializer, not the CLR.
-	/// <c>[StructLayout(LayoutKind.Sequential)]</c> is present for documentation purposes only:
-	/// for non-blittable structs (those with <c>byte[]</c> fields), the CLR ignores
-	/// Sequential layout and IL2CPP may reorder fields anyway. The attribute
-	/// would be misleading at runtime. See the file-level doc comment for details.
+	/// <!-- No [StructLayout(LayoutKind.Sequential)] here intentionally: for
+	///      non-blittable structs (those with byte[] fields), the CLR ignores
+	///      Sequential layout and IL2CPP may reorder fields anyway. The attribute
+	///      would be misleading. See the file-level doc comment for details. -->
 	/// The nonce-derivation protocol is therefore fragile and should ideally use an
 	/// explicit tagging scheme rather than declaration order.
 	/// TODO: Migrate to an explicit tagging scheme (e.g., a tagged union or per-field
 	/// nonce labels) to eliminate the declaration-order dependency.
 	/// Reordering these fields WILL break TOTP setup. DO NOT reorder.</para>
-	[StructLayout(LayoutKind.Sequential)] // Documentation only -- actual ordering is enforced by FishNet declaration-order serializer
 	public struct TwoFactorSetupBroadcast : IBroadcast
 	{
 		/// <summary>
@@ -393,7 +325,6 @@ namespace FishMMO.Shared
 		/// WARNING: Declaration order IS the wire protocol (see struct remarks).
 		/// This field MUST remain declared before <see cref="RecoveryCodes"/>.
 		/// </summary>
-		// WARNING: Field order is wire-protocol critical. DO NOT reorder.
 		public byte[] OtpauthUri;
 		/// <summary>
 		/// Encrypted newline-delimited plaintext recovery codes (AES-GCM, server->client).
@@ -401,7 +332,6 @@ namespace FishMMO.Shared
 		/// WARNING: Declaration order IS the wire protocol (see struct remarks).
 		/// This field MUST remain declared after <see cref="OtpauthUri"/>.
 		/// </summary>
-		// WARNING: Field order is wire-protocol critical. DO NOT reorder.
 		public byte[] RecoveryCodes;
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/AddressableLoadProcessor/AddressableLoadProcessor.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/AddressableLoadProcessor/AddressableLoadProcessor.cs
@@ -715,35 +715,68 @@ namespace FishMMO.Shared
 				helper.StopAllCoroutines();
 			}
 
+			// During Editor Play Mode exit, Addressables also disposes handles — releasing
+			// here races PlayModeStateChangedCleanup ("invalid operation handle") and can
+			// contribute to native crashes. Clear bookkeeping only; let Addressables own dispose.
+#if UNITY_EDITOR
+			if (!Application.isPlaying)
+			{
+				loadedScenes.Clear();
+				loadedAssets.Clear();
+				loadedPrefabs.Clear();
+				return;
+			}
+#endif
+
 			foreach (var sceneHandle in loadedScenes.Values)
 			{
-				if (sceneHandle.IsValid())
+				try
 				{
-					OnSceneUnloaded?.Invoke(sceneHandle.Result.Scene.name);
-
-					Addressables.Release(sceneHandle);
+					if (sceneHandle.IsValid())
+					{
+						OnSceneUnloaded?.Invoke(sceneHandle.Result.Scene.name);
+						Addressables.Release(sceneHandle);
+					}
+				}
+				catch (System.Exception)
+				{
+					// Invalid/disposed handle during teardown — ignore.
 				}
 			}
 			loadedScenes.Clear();
 
 			foreach (var assetList in loadedAssets.Values)
 			{
-				if (assetList.IsValid())
+				try
 				{
-					foreach (var asset in assetList.Result)
+					if (assetList.IsValid())
 					{
-						OnAddressableUnloaded?.Invoke(asset);
+						foreach (var asset in assetList.Result)
+						{
+							OnAddressableUnloaded?.Invoke(asset);
+						}
+						Addressables.Release(assetList);
 					}
-					Addressables.Release(assetList);
+				}
+				catch (System.Exception)
+				{
+					// Invalid/disposed handle during teardown — ignore.
 				}
 			}
 			loadedAssets.Clear();
 
 			foreach (var prefabHandle in loadedPrefabs.Values)
 			{
-				if (prefabHandle.IsValid())
+				try
 				{
-					Addressables.Release(prefabHandle);
+					if (prefabHandle.IsValid())
+					{
+						Addressables.Release(prefabHandle);
+					}
+				}
+				catch (System.Exception)
+				{
+					// Invalid/disposed handle during teardown — ignore.
 				}
 			}
 			loadedPrefabs.Clear();


### PR DESCRIPTION
## Summary

Selective batch **PR-3 of 7** from UnityEQ `fishmmo-pr-dev` (tip `7a6e677c`).

Dual-track **connection hop + authentication** so Login handshake is race-safe and Login→World→Scene can open a new WebTransport session with a re-staged IPFetch connection token.

**15 files** — intentional single merge of dual-track files (do not split).

## Depends on

| PR | Why |
|----|-----|
| **[#80 PR-1](https://github.com/jimdroberts/FishMMO/pull/80)** | `ForceStopClient` / sessionGeneration on WebTransport — hop + Editor exit call into the plugin |
| **[#81 PR-2](https://github.com/jimdroberts/FishMMO/pull/81)** | Recommended for WebGL auth tests (Reliable framing); not required to compile this PR |

Merge after #80 (or stack). Until #80 lands, Shared bootstrap references `WebTransport.ForceStopClient` which only exists on the PR-1 plugin.

## Must-pair (this PR is atomic)

- `ClientConnectionManager.ForceStopTransportForHop` + plugin `ForceStopClient` (PR-1)
- `ClientLoginAuthenticator` Started-gate + ConnectionManager Started signal
- `BaseServerAuthenticator` cookie-echo + `Client.ConnectToServerWithConnectionToken`
- `ClientAuthenticatorCore` credentials survive Stop→Start (every connect stops first)

## What's included

| Area | Paths |
|------|--------|
| Client hop | `Client.cs`, `ClientConnectionManager.cs` |
| Client auth | `ClientLoginAuthenticator.cs`, `ClientAuthenticatorCore.cs` |
| Server auth | `BaseServerAuthenticator.cs`, `ServerAuthenticator.cs`, `TokenServerAuthenticator.cs`, `SrpAuthenticatorCore.cs`, `SrpService.cs` |
| Broadcasts | `AuthenticationBroadcasts.cs` |
| Server bind | `FishNetNetworkWrapper.cs` (listen address vs advertise) |
| Editor exit | `MainBootstrapSystem.cs`, `AddressableLoadProcessor.cs`, `FishMMO.Shared.asmdef` (+WebTransport ref) |
| Hosts (MANUAL) | `Constants.cs` — **only** `GetGameHostForPort` + port bands; **keeps** jimd `GeneratedHostConfig` for `APIHost`/`GameHost`; World/Scene host default to `GameHost` |

## Explicitly not in this PR

- Native WT / plugin (**PR-1** / #80)
- TransportManager WebGL Reliable / AddressableSceneProcessor (**PR-2** / #81)
- DB SceneService / WorldSceneSystem / ObjectSpawner (**PR-4**)
- PrefabId / NetworkAnimator / layer indices (**PR-5**)
- Character create/select systems + IPFetch controller (**PR-6**)
- TLS pins / nginx / eqbrowser hostnames (**PR-7**)
- Server `.unity` scene YAML (code-only auth path)

## Micro-test

1. Editor: connect Login → complete handshake → **LoginSuccess without session drop**.
2. Editor: Stop Play while connected — **no native crash** (with PR-1 plugin).
3. Optional: World connect with staged connection token — no cookieLen=0 reject when IPFetch available (full IPFetch API in PR-6).
4. Does **not** require character create DB, Ready matchmaking, or correct race PrefabIds.

## Test plan

- [ ] Diff is limited to the dual-track / auth set above (15 files)
- [ ] No `eqbrowser.com` host hardcoding in Constants
- [ ] Compile after PR-1 plugin is present (`ForceStopClient`, WebTransport asmdef ref)
- [ ] Login handshake smoke in Editor