### PR TITLE
Fix CS0122: GeneratedClientSecret inaccessible to Editor build validator

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/Security/ClientApiSecret.generated.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Security/ClientApiSecret.generated.cs
@@ -13,12 +13,18 @@ namespace FishMMO.Client.Security
 	/// IL-embedded client gate secret. The real value is substituted at
 	/// build time by CI from the FISHMMO_CLIENT_GATE_SECRET env var.
 	/// </summary>
-	internal static class GeneratedClientSecret
+	/// <remarks>
+	/// Must be <c>public</c> so the Editor assembly
+	/// (<c>FishMMO.Client.Security.Editor</c> / <see cref="Editor.ClientSecurityBuildValidator"/>)
+	/// can read the sentinel. <c>internal</c> is assembly-scoped only and caused CS0122.
+	/// Matches <see cref="GeneratedPinSet"/> and ClientSecretTool output.
+	/// </remarks>
+	public static class GeneratedClientSecret
 	{
 		/// <summary>
 		/// Shared secret for X-FishMMO-Client HMAC header signing.
 		/// The committed value is a sentinel — CI must replace it.
 		/// </summary>
-		internal const string Secret = "FISHMMO_SENTINEL_PLACEHOLDER_CLIENT_GATE_SECRET";
+		public const string Secret = "FISHMMO_SENTINEL_PLACEHOLDER_CLIENT_GATE_SECRET";
 	}
 }


### PR DESCRIPTION
## Summary

Fixes **CS0122** when compiling the client Editor scripts:

```
ClientSecurityBuildValidator.cs: GeneratedClientSecret is inaccessible due to its protection level
```

## Cause

| Type | Assembly | Access |
|------|----------|--------|
| `ClientSecurityBuildValidator` | `FishMMO.Client.Security.Editor` | needs to read sentinel |
| `GeneratedClientSecret` (was) | `FishMMO.Client` | `internal` — same-assembly only |

`internal` does not cross assembly boundaries, so the Editor validator cannot see the runtime generated secret.

## Fix

Make `GeneratedClientSecret` and `Secret` **`public`** in `ClientApiSecret.generated.cs`, consistent with:

- `GeneratedPinSet` (already public; pin checks already work)
- `ClientSecretTool` output (writes `public static class GeneratedClientSecret`)

## Test plan

- [ ] Open Unity client project; Editor scripts recompile without CS0122
- [ ] Development builds still allowed with sentinel secret
- [ ] Non-dev release preprocess still blocks when sentinel remains (validator path)

## Files

- `FishMMO-Unity/Assets/Scripts/Client/Security/ClientApiSecret.generated.cs`