### PR TITLE
Fix: Development builds blocked by TLS pin production security gate

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/Security/Editor/ClientSecurityBuildValidator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Security/Editor/ClientSecurityBuildValidator.cs
@@ -26,7 +26,17 @@ namespace FishMMO.Client.Security.Editor
 		public void OnPreprocessBuild(BuildReport report)
 		{
 			// Only enforce for non-development client builds.
+			//
+			// Check both signals:
+			// 1) EditorUserBuildSettings.development — Player Settings / Build Window toggle
+			// 2) BuildOptions.Development on this BuildPlayer request — CustomBuildTool sets
+			//    this when Working Environment is Development, without always flipping the
+			//    EditorUser flag. Skipping only (1) incorrectly blocked Dashboard "Development"
+			//    builds that still had sentinel TLS pins (BuildFailedException pin gate).
 			if (EditorUserBuildSettings.development)
+				return;
+
+			if (report != null && (report.summary.options & BuildOptions.Development) != 0)
 				return;
 
 			int realPinCount = ClientSecurityBootstrap.DefaultPinCount;

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Execution/BuildExecutor.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Execution/BuildExecutor.cs
@@ -54,8 +54,21 @@ namespace FishMMO.Shared.CustomBuildTool.Execution
 			folderName = folderName.Trim();
 			string buildPath = Path.Combine(rootPath, folderName);
 
+			// Align EditorUserBuildSettings.development with this build request.
+			// ClientSecurityBuildValidator gates TLS pins / secrets / hosts when
+			// development is false. CustomBuildTool may pass BuildOptions.Development
+			// and/or WorkingEnvironment=Development without flipping the EditorUser flag
+			// (and WebGL Development intentionally omits BuildOptions.Development).
+			// Without this sync, Development Dashboard builds still hit the production pin gate.
+			bool previousDevelopment = EditorUserBuildSettings.development;
+			bool isDevelopmentBuild =
+				(buildOptions & BuildOptions.Development) != 0 ||
+				WorkingEnvironmentOptions.GetWorkingEnvironmentState() == WorkingEnvironmentState.Development;
+
 			try
 			{
+				EditorUserBuildSettings.development = isDevelopmentBuild;
+
 				BuildPlayerOptions options = new BuildPlayerOptions()
 				{
 					locationPathName = Path.Combine(buildPath, executableName + ".exe"),
@@ -75,6 +88,7 @@ namespace FishMMO.Shared.CustomBuildTool.Execution
 					Log.Debug("BuildExecutor", $"Scenes Included: {string.Join(", ", bootstrapScenes)}");
 					Log.Debug("BuildExecutor", $"Build Target: {buildTarget}");
 					Log.Debug("BuildExecutor", $"Build Subtarget: {subTarget}");
+					Log.Debug("BuildExecutor", $"Development build (security gate skip): {isDevelopmentBuild}");
 					LogBuildSteps(report);
 
 					string root = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
@@ -104,6 +118,7 @@ namespace FishMMO.Shared.CustomBuildTool.Execution
 			}
 			finally
 			{
+				EditorUserBuildSettings.development = previousDevelopment;
 				Log.Debug("BuildExecutor", "Build finished.");
 			}
 		}


### PR DESCRIPTION
## Summary

Development / Dashboard local client builds were incorrectly failing with:

```
BuildFailedException: Production build blocked: TLS certificate pins not configured.
  Only 0 real pin(s) found in CertificatePins.generated.cs.
```

even when the FishMMO Dashboard **Working Environment** was set to **Development**.

## Root cause

`ClientSecurityBuildValidator` only skipped enforcement when:

```csharp
EditorUserBuildSettings.development == true
```

`CustomBuildTool` marks development builds via:

- `BuildOptions.Development` (standalone Development environment), and/or  
- `WorkingEnvironmentState.Development` (including **WebGL**, which intentionally does **not** set `BuildOptions.Development`)

It did **not** set `EditorUserBuildSettings.development` for the duration of `BuildPipeline.BuildPlayer`. Those two signals were out of sync, so Development Dashboard builds still hit the **production** pin/secret/host gate while `CertificatePins.generated.cs` still had sentinels.

## Fix

1. **`BuildExecutor`** — before `BuildPlayer`, set `EditorUserBuildSettings.development` when:
   - `(buildOptions & BuildOptions.Development) != 0`, **or**
   - Working Environment is `Development`  
   Restore the previous value in `finally`.

2. **`ClientSecurityBuildValidator`** — also skip when the active `BuildReport` has `BuildOptions.Development`.

## What is unchanged

- **Production** Working Environment still requires ≥2 real TLS pins, non-sentinel client gate secret, non-sentinel hosts, and no obsolete `StreamingAssets/client-security.json`.
- Real production releases still need **Game Settings → Fetch/Write Pins** (and secrets) before shipping.

## Test plan

- [ ] Dashboard **Development** + build client (standalone): no pin `BuildFailedException` with sentinel pins
- [ ] Dashboard **Development** + WebGL client: same
- [ ] Dashboard **Production** + sentinel pins: still blocked
- [ ] Dashboard **Production** + real pins/secret/hosts: allowed

## Files

- `FishMMO-Unity/Assets/Scripts/Shared/.../CustomBuildTool/Execution/BuildExecutor.cs`
- `FishMMO-Unity/Assets/Scripts/Client/Security/Editor/ClientSecurityBuildValidator.cs`