### PR TITLE
Fix gameserver Login Totp init, cfg recursive lock, connection_token_keys query

### DIFF
--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/ConnectionTokenKeyService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/ConnectionTokenKeyService.cs
@@ -18,28 +18,6 @@ namespace FishMMO.Database.Npgsql.Services
 	/// </summary>
 	public sealed class ConnectionTokenKeyService : BaseService<ConnectionTokenKeyEntity>, IConnectionTokenKeyService
 	{
-#pragma warning disable CS8619
-		/// <summary>
-		/// Compiled query for fetching all active keys without tracking, ordered by TimeCreated descending.
-		/// </summary>
-		private static readonly Func<NpgsqlDbContext, CancellationToken, Task<List<ConnectionTokenKeyEntity>>> getAllActiveQuery =
-			EF.CompileAsyncQuery((NpgsqlDbContext context, CancellationToken ct) =>
-				context.ConnectionTokenKeys
-					.AsNoTracking()
-					.Where(k => k.IsActive)
-					.OrderByDescending(k => k.TimeCreated)
-					.ToList());
-
-		/// <summary>
-		/// Compiled query for fetching a single key by its logical key ID without tracking.
-		/// </summary>
-		private static readonly Func<NpgsqlDbContext, string, CancellationToken, Task<ConnectionTokenKeyEntity?>> getByKeyIdQuery =
-			EF.CompileAsyncQuery((NpgsqlDbContext context, string keyId, CancellationToken ct) =>
-				context.ConnectionTokenKeys
-					.AsNoTracking()
-					.FirstOrDefault(k => k.KeyId == keyId));
-#pragma warning restore CS8619
-
 		/// <summary>
 		/// Initializes a new instance of ConnectionTokenKeyService.
 		/// </summary>
@@ -54,9 +32,18 @@ namespace FishMMO.Database.Npgsql.Services
 		public async Task<DatabaseResult<ConnectionTokenKeyData[]>> FetchAllActiveAsync(
 			CancellationToken cancellationToken = default)
 		{
+			// Do not use EF.CompileAsyncQuery with OrderByDescending(TimeCreated): on some
+			// EF Core / Npgsql versions the compiled form fails translation at runtime even
+			// though the same LINQ works via normal IQueryable, breaking World/Scene token
+			// key load while rows exist in connection_token_keys.
 			return await ExecuteReadAsync(async dbContext =>
 			{
-				var entities = await getAllActiveQuery(dbContext, cancellationToken).ConfigureAwait(false);
+				List<ConnectionTokenKeyEntity> entities = await dbContext.ConnectionTokenKeys
+					.AsNoTracking()
+					.Where(k => k.IsActive)
+					.OrderByDescending(k => k.TimeCreated)
+					.ToListAsync(cancellationToken)
+					.ConfigureAwait(false);
 				return entities.Select(MapEntityToDto).ToArray();
 			}, cancellationToken: cancellationToken).ConfigureAwait(false);
 		}
@@ -75,7 +62,10 @@ namespace FishMMO.Database.Npgsql.Services
 
 			return await ExecuteReadAsync(async dbContext =>
 			{
-				var entity = await getByKeyIdQuery(dbContext, keyId, cancellationToken).ConfigureAwait(false);
+				ConnectionTokenKeyEntity? entity = await dbContext.ConnectionTokenKeys
+					.AsNoTracking()
+					.FirstOrDefaultAsync(k => k.KeyId == keyId, cancellationToken)
+					.ConfigureAwait(false);
 				if (entity == null)
 				{
 					throw new DatabaseEntityNotFoundException("ConnectionTokenKey", keyId);

--- a/FishMMO-SharedUtility/FishMMO-SharedUtility/Configuration.cs
+++ b/FishMMO-SharedUtility/FishMMO-SharedUtility/Configuration.cs
@@ -425,10 +425,15 @@ namespace FishMMO.Shared
 
 					// Synchronize the entire dictionary replacement under a single write lock
 					// to avoid nested locking with Set() and to keep the replacement atomic.
+					// IMPORTANT: assign the private field fileName here — do NOT call the
+					// FileName property setter, which acquires EnterWriteLock again.
+					// ReaderWriterLockSlim defaults to non-recursive mode; nested write locks
+					// threw: "Recursive write lock acquisitions not allowed in this mode"
+					// when loading LoginServer.cfg / WorldServer.cfg / SceneServer.cfg.
 					settingsLock.EnterWriteLock();
 					try
 					{
-						FileName = Path.GetFileNameWithoutExtension(fullFileName); // Stores only the base name of the file (without its extension).
+						fileName = Path.GetFileNameWithoutExtension(fullFileName); // Stores only the base name of the file (without its extension).
 
 						// Clears all existing settings before populating with new ones from the file.
 						this.settings.Clear();

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/LoginServer/LoginServerSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/LoginServer/LoginServerSystem.cs
@@ -166,7 +166,21 @@ namespace FishMMO.Server.Implementation.LoginServer
 				return ServerComponentInitializationStatus.FailedToGetDbContext;
 			}
 
-			byte[] hmacKey = CryptoHelper.GenerateKey(CryptoHelper.HmacKeyLength);
+			// Prefer the process-local signing key pre-bootstrapped in Server.OnFinalizeSetup
+			// (required so TotpMasterKey exists before InitializeWorkers). Only generate a
+			// fresh key if one was not already assigned.
+			byte[] hmacKey;
+			if (Server.NetworkWrapper.NetworkManager.ServerManager.GetAuthenticator() is ServerAuthenticator existingAuth
+				&& existingAuth.TokenSigningKey != null
+				&& existingAuth.TokenSigningKey.Length == CryptoHelper.HmacKeyLength)
+			{
+				hmacKey = existingAuth.TokenSigningKey;
+				Log.Debug("LoginServerSystem", "Reusing pre-bootstrapped TokenSigningKey for persistence.");
+			}
+			else
+			{
+				hmacKey = CryptoHelper.GenerateKey(CryptoHelper.HmacKeyLength);
+			}
 
 			// Load the deployment-shared KEK from the deployment_secrets database table.
 			// The database is the ONLY source — no environment variable or .cfg file fallbacks.

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Server.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Server.cs
@@ -15,6 +15,7 @@ using FishMMO.Logging;
 using FishMMO.Server.Core;
 using FishMMO.Shared;
 using FishMMO.Auth.Core;
+using FishMMO.Auth.Implementation;
 using FishNet.Connection;
 
 namespace FishMMO.Server.Implementation
@@ -305,6 +306,23 @@ namespace FishMMO.Server.Implementation
 			else
 				throw new InvalidOperationException(
 					"Server: Authenticator does not implement IServerAuthenticator.");
+
+			// SrpAuthenticatorCore.InitializeWorkersCore hard-throws if TotpMasterKey is null /
+			// wrong length. LoginServerSystem historically assigned TotpMasterKey only during
+			// BehaviourRegistry.InitializeAll — which runs AFTER AttachLoginAuthenticator
+			// starts workers. Pre-bootstrap a process-local signing key + derived TotpMasterKey
+			// here so Login can open the transport. LoginServerSystem reuses TokenSigningKey
+			// when already set (no second generate) and re-derives Totp after DB registration.
+			if (authenticator is ServerAuthenticator srpAuth)
+			{
+				byte[] signingKey = CryptoHelper.GenerateKey(CryptoHelper.HmacKeyLength);
+				srpAuth.TokenSigningKey = signingKey;
+				using (var localKms = new LocalDeriveKmsProvider(signingKey))
+				{
+					srpAuth.TotpMasterKey = localKms.DeriveKey("fishmmo-totp-master-key-v1");
+				}
+				Log.Debug("Server", "Pre-bootstrapped TokenSigningKey + TotpMasterKey before InitializeWorkers.");
+			}
 
 			NetworkWrapper.ApplyTransportConfiguration(AddressOverride, PortOverride > 0 ? PortOverride : null);
 			NetworkWrapper.AttachLoginAuthenticator(this);


### PR DESCRIPTION
## Summary

Source fixes for production Linux GameServer issues seen under systemd (Login / World / Scene).

| Symptom | Role | Fix |
|---------|------|-----|
| `TotpMasterKey is null … before calling InitializeWorkers` — Login never binds **7770** | Login | Pre-bootstrap Totp + signing key before workers |
| `Recursive write lock acquisitions not allowed` reading `*.cfg` | All three | Stop nested write lock in `Configuration.Load` |
| EF can’t translate `OrderByDescending(TimeCreated)` on `connection_token_keys` | World / Scene | Drop broken compiled query; normal async LINQ |
| Empty `login_servers` / `world_servers` / `scene_servers` | Follow-on | Login registration never completed after Totp throw; restart after this build |

## Context from ops

- World **UDP 7780** and Scene **UDP 7790** WebTransport were already up.
- Login process alive but authenticator init failed → no game port.
- DB had `connection_token_keys` + `deployment_secrets` seeded; key **query** still failed on World/Scene.

## Changes

### 1. Login Totp / signing key init order

**`Server.OnFinalizeSetup`** (before `AttachLoginAuthenticator` → `InitializeWorkers`):

- Generate process-local `TokenSigningKey`
- Derive `TotpMasterKey` via `LocalDeriveKmsProvider` (`fishmmo-totp-master-key-v1`)
- Assign both on `ServerAuthenticator`

**`LoginServerSystem`**: reuse pre-bootstrapped `TokenSigningKey` when present for DB signing-key persistence instead of always generating a second key.

### 2. Configuration.cfg recursive write lock

**`FishMMO-SharedUtility/Configuration.cs` `Load`:**

While already holding `settingsLock` write lock, code assigned `FileName = …`, and the **property setter** called `EnterWriteLock` again. `ReaderWriterLockSlim` is non-recursive by default → exception when loading `LoginServer.cfg` / `WorldServer.cfg` / `SceneServer.cfg`.

Fix: set private field `fileName` under the existing lock.

### 3. `ConnectionTokenKeyService` EF query

Remove `EF.CompileAsyncQuery` for active-keys + by-key-id. Use normal `ToListAsync` / `FirstOrDefaultAsync` so World/Scene can load verification keys that already exist in Postgres.

## Out of scope

- RAM / thrashing on ~1.9 GiB hosts (ops sizing)
- Deploy path / systemd unit wiring
- Rebuild/redeploy of `GameServer.exe` + Managed `FishMMO-DB.dll` (required after merge)

## Test plan

- [ ] Login dedicated build: no TotpMasterKey exception; UDP **7770** listens; row appears in `login_servers`
- [ ] All three: load `*.cfg` without recursive write lock warning
- [ ] World/Scene: `connection_token_keys` active keys load; connection token verify works
- [ ] After clean Login start: world/scene server tables register on pulse

## Files

- `FishMMO-Unity/.../Server.cs`
- `FishMMO-Unity/.../LoginServerSystem.cs`
- `FishMMO-SharedUtility/.../Configuration.cs`
- `FishMMO-Database/.../ConnectionTokenKeyService.cs`
