### PR TITLE
Update FishMMO-DB-Migrator.csproj

### DIFF
--- a/FishMMO-Database/FishMMO-DB-Migrator/FishMMO-DB-Migrator.csproj
+++ b/FishMMO-Database/FishMMO-DB-Migrator/FishMMO-DB-Migrator.csproj
@@ -21,7 +21,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.18" />
       <PackageReference Include="StackExchange.Redis" Version="2.7.4" />
     </ItemGroup>
 


### PR DESCRIPTION
Npgsql high vulnerability on version 5.0.10, bump version to 5.0.18.