### PR TITLE
Fix LoginServer hang: never GetResult EF tasks on the Unity main thread

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/README.md
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/README.md
@@ -77,6 +77,10 @@ Network Thread (UDP Gates)              Worker Threads (Async)              Main
 | **Worker Threads** | AES decryption, StrictUtf8 decode, database I/O, SRP math, ZeroMemory | **Yes** (async/await) |
 | **Main Thread** | `Broadcast()`, `Disconnect()`, `OnAuthenticationResult` | N/A (Unity main loop) |
 
+**Do not call `task.GetAwaiter().GetResult()` / `.Result` / `.Wait()` on the Unity main thread** for EF/Npgsql work. Unity's `SynchronizationContext` posts async completions back to that thread; blocking it deadlocks the continuation. `LoginServerSystem.InitializeOnce` used to hang this way inside `SigningKeyKekProvider.TryLoadFromDatabase` — the process stayed alive, `login_servers.last_pulse` froze after the persist, and WebTransport never bound `:7770`. Use `UnitySyncOverAsync.Run(...)` (or `Task.Run(...).Wait(timeout)` as Login/World/Scene registration already does) so the async method starts on a thread-pool thread with a null sync context.
+
+`DeploymentSecretService.FetchAsync` already uses `ConfigureAwait(false)` internally. That is not enough when the *first* `await` in the EF/Npgsql stack still captured the Unity context, which is what happened at login startup.
+
 Workers enqueue `Action` delegates into a `ConcurrentQueue<Action>` held by `BaseServerAuthenticator`, drained each frame by `Update()` → `DrainMainThreadQueue()`. A per-frame cap (`maxMainThreadActionsPerUpdate = 100`, Inspector-configurable) time-slices draining to avoid frame spikes, with back-pressure logging when the queue is not fully drained.
 
 ## Supported Platforms
@@ -267,6 +271,8 @@ authenticator.OnClientAuthenticationResult += (conn, authenticated) =>
 
 | Check | How to Verify |
 |-------|---------------|
+| LoginServer bound `:7770` after boot | Log: `[wt:INFO] Server started on 127.0.0.1:7770`. If the process is alive but this line never appears and `login_servers.last_pulse` is stale, KEK load deadlocked on the Unity main thread |
+| Signing-key KEK loaded | No `"Signing-key KEK not provisioned — persisting raw HMAC key"` warning. That warning means World/Scene cannot unwrap tokens |
 | Workers started | Log output: `"Workers initialized (Verify=2, Proof=2)"` or `"Workers initialized (Token=2)"` |
 | Handshake completing | Client receives `ServerHandshake` with X25519 public key and agreed version |
 | SRP verify processing | Client receives `SrpVerifyResponseBroadcast` with encrypted salt and server ephemeral |
@@ -499,7 +505,8 @@ Server/
 │   ├── IServerAuthenticator.cs                # Interface: Server ref + worker lifecycle
 │   ├── BaseServerAuthenticator.cs             # Composition host: owns Core, routes FishNet events to core
 │   ├── ServerAuthenticator.cs                 # SRP wrapper: inner ServerAuthenticatorCore : SrpAuthenticatorCore<NetworkConnection>
-│   └── TokenServerAuthenticator.cs            # Token wrapper: inner TokenCore : TokenAuthenticatorCore<NetworkConnection>
+│   ├── TokenServerAuthenticator.cs            # Token wrapper: inner TokenCore : TokenAuthenticatorCore<NetworkConnection>
+│   └── SigningKeyKekProvider.cs               # Loads signing_key_kek via UnitySyncOverAsync (never GetResult on main thread)
 │
 └── Implementation/World/
     ├── WorldServer/Authentication/

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/SigningKeyKekProvider.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/SigningKeyKekProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using FishMMO.Auth.Implementation;
 using FishMMO.Database.Npgsql.Services.Interfaces;
 using FishMMO.Server.Core;
@@ -49,8 +50,14 @@ namespace FishMMO.Server.Implementation
 
 			try
 			{
-				var result = secretService.FetchAsync(DatabaseKey, System.Threading.CancellationToken.None)
-					.GetAwaiter().GetResult();
+				// MUST leave the Unity SynchronizationContext. LoginServerSystem.InitializeOnce
+				// calls this on the main thread, then StartServer() only runs after it returns.
+				// A raw FetchAsync(...).GetResult() deadlocks: EF/Npgsql completions post back
+				// to the blocked main thread, last_pulse freezes, and UDP :7770 never binds.
+				// UnitySyncOverAsync.Run is the same Task.Run + timeout pattern used for
+				// Login/World/Scene DB registration.
+				var result = UnitySyncOverAsync.Run(
+					() => secretService.FetchAsync(DatabaseKey, CancellationToken.None));
 
 				if (!result.IsSuccess || string.IsNullOrEmpty(result.Data))
 				{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/UnitySyncOverAsync.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/UnitySyncOverAsync.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FishMMO.Server.Implementation
+{
+	/// <summary>
+	/// Blocks the caller on an async operation after dispatching it to the thread pool.
+	/// <para>
+	/// Unity's <c>SynchronizationContext</c> posts async completions back to the main thread.
+	/// Calling <c>task.GetAwaiter().GetResult()</c> (or <c>.Result</c> / <c>.Wait()</c>) on that
+	/// thread while the task still needs the same context deadlocks: the continuation can never
+	/// run, and LoginServer never reaches <c>NetworkWrapper.StartServer()</c>.
+	/// </para>
+	/// <para>
+	/// <c>Task.Run</c> starts the work with a null sync context (thread-pool thread). That is
+	/// the same pattern <c>LoginServerSystem</c>, <c>WorldServerSystem</c>, and
+	/// <c>SceneServerSystem</c> already use for DB registration. Prefer this helper over a raw
+	/// <c>GetResult()</c> at any Unity main-thread sync-over-async boundary.
+	/// </para>
+	/// </summary>
+	public static class UnitySyncOverAsync
+	{
+		/// <summary>
+		/// Default wait used by server startup DB calls. Matches
+		/// <c>LoginServerSystem</c>'s registration timeout.
+		/// </summary>
+		public const int DefaultTimeoutMilliseconds = 30_000;
+
+		/// <summary>
+		/// Runs <paramref name="operation"/> on the thread pool and blocks until it completes
+		/// or <paramref name="timeoutMilliseconds"/> elapses.
+		/// </summary>
+		/// <typeparam name="T">Result type of the async operation.</typeparam>
+		/// <param name="operation">Async work to run off the Unity sync context.</param>
+		/// <param name="timeoutMilliseconds">Maximum wait. 30 seconds if omitted.</param>
+		/// <returns>The operation result.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="operation"/> is null.</exception>
+		/// <exception cref="TimeoutException">The wait exceeded <paramref name="timeoutMilliseconds"/>.</exception>
+		public static T Run<T>(Func<Task<T>> operation, int timeoutMilliseconds = DefaultTimeoutMilliseconds)
+		{
+			if (operation == null)
+			{
+				throw new ArgumentNullException(nameof(operation));
+			}
+
+			// Task.Run(Func<Task<T>>) unwraps to Task<T> and runs the delegate on the pool.
+			Task<T> task = Task.Run(operation);
+			if (!task.Wait(timeoutMilliseconds))
+			{
+				throw new TimeoutException(
+					$"UnitySyncOverAsync.Run timed out after {timeoutMilliseconds}ms.");
+			}
+
+			return task.GetAwaiter().GetResult();
+		}
+
+		/// <summary>
+		/// Runs a non-generic async operation on the thread pool and blocks until it completes
+		/// or <paramref name="timeoutMilliseconds"/> elapses.
+		/// </summary>
+		/// <param name="operation">Async work to run off the Unity sync context.</param>
+		/// <param name="timeoutMilliseconds">Maximum wait. 30 seconds if omitted.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="operation"/> is null.</exception>
+		/// <exception cref="TimeoutException">The wait exceeded <paramref name="timeoutMilliseconds"/>.</exception>
+		public static void Run(Func<Task> operation, int timeoutMilliseconds = DefaultTimeoutMilliseconds)
+		{
+			if (operation == null)
+			{
+				throw new ArgumentNullException(nameof(operation));
+			}
+
+			Task task = Task.Run(operation);
+			if (!task.Wait(timeoutMilliseconds))
+			{
+				throw new TimeoutException(
+					$"UnitySyncOverAsync.Run timed out after {timeoutMilliseconds}ms.");
+			}
+
+			task.GetAwaiter().GetResult();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/UnitySyncOverAsync.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/UnitySyncOverAsync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ad769fb96cd4c8ab319ff75de670580

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Chat/ChatSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Chat/ChatSystem.cs
@@ -849,7 +849,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 
 				if (batch.Count > 0)
 				{
-					DatabaseResult result = chatService.PersistBatchAsync(batch).GetAwaiter().GetResult();
+					// Shutdown flush runs on the Unity main thread. Do not GetResult() the
+					// EF task in-place — same SynchronizationContext deadlock as KEK load.
+					DatabaseResult result = UnitySyncOverAsync.Run(
+						() => chatService.PersistBatchAsync(batch));
 					if (!result.IsSuccess)
 					{
 						Log.Warning("ChatSystem", $"FlushPersistQueueSync DB error ({batch.Count} messages): {result.ErrorCode} - {result.ErrorMessage}");


### PR DESCRIPTION
## Summary

LoginServer can boot, stay alive, and never listen on UDP 7770. `LoginServerSystem.InitializeOnce()` deadlocks on the Unity main thread while loading `signing_key_kek` from `deployment_secrets`.

This was reproduced on a live GameServer built from `dev`. After this source change (and a matching IL patch on the already-built `FishMMO.Server.dll`), Login/World/Scene all reached WebTransport bind and started updating heartbeats.

## The deadlock

`InitializeOnce()` runs on the **Unity main thread** and must finish before `NetworkWrapper.StartServer()`. After it registered the login row (that path already used `Task.Run().Wait()`), it called:

```csharp
secretService.FetchAsync("signing_key_kek", …).GetAwaiter().GetResult();
```

Unity's `SynchronizationContext` posts EF/Npgsql completions back to that same thread. The main thread was blocked in `GetResult()`, so the continuation never ran.

```
Unity main thread                         EF / Npgsql
─────────────────                         ───────────
InitializeOnce()
  PersistAsync via Task.Run().Wait()      completes, last_pulse written
  SigningKeyKekProvider.TryLoadFromDatabase()
    FetchAsync(...).GetAwaiter().GetResult()
         blocked in GetResult()           completion posted to Unity SyncContext
         never runs                       cannot drain — deadlock
  StartServer() never reached
  UDP :7770 never binds
```

That matches the live symptoms:

- Process stayed alive (not a crash)
- `login_servers.last_pulse` froze immediately after persist
- Postgres sat in `idle` / `ClientRead` on `deployment_secrets`
- WebTransport never bound `:7770`
- World/Scene started fine (they do not load the KEK during `InitializeOnce`)

`DeploymentSecretService.FetchAsync` already uses `ConfigureAwait(false)` internally. That is **not sufficient**: the first `await` in the EF/Npgsql stack can still capture the Unity context before that `ConfigureAwait` is reached.

## Fix

Use `UnitySyncOverAsync.Run(...)` — `Task.Run` + timeout — so the async work starts on a thread-pool thread with a **null** sync context. This is the same pattern Login/World/Scene already use for DB registration.

Also wrap `ChatSystem`'s shutdown `PersistBatchAsync` flush, which had the same main-thread `GetResult()`.

## Files

| File | Change |
|---|---|
| `UnitySyncOverAsync.cs` | New helper (`Task.Run` + 30s timeout) |
| `SigningKeyKekProvider.cs` | KEK fetch goes through the helper |
| `ChatSystem.cs` | Shutdown persist flush goes through the helper |
| `Authentication/README.md` | Documents the deadlock and the operational check |

## How to confirm after rebuild

After a new GameServer build:

1. Login log should contain `[wt:INFO] Server started on 127.0.0.1:7770` (or whatever bind address is configured).
2. `login_servers.last_pulse` should keep advancing.
3. If the process is alive, `:7770` never binds, and `last_pulse` is stale right after persist — this deadlock is back.

## Test plan

- [ ] Rebuild GameServer from this branch
- [ ] Start Login only: confirm UDP 7770 binds and `last_pulse` updates
- [ ] Start World + Scene: confirm 7780/7790 bind and heartbeats update
- [ ] Confirm no `"Signing-key KEK not provisioned"` warning when `deployment_secrets.signing_key_kek` is present
- [ ] Scene shutdown still flushes pending chat (no hang on stop)
