### PR TITLE
Embed real IP in world/scene renewal tokens

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
@@ -339,6 +339,16 @@ namespace FishMMO.Server.Implementation
 				// expectation that access-level changes accompany token revocation.
 				// A full fix would require an IAccountManager lookup here, but World/Scene
 				// servers may not have access to the accounts table in all deployments.
+				// Scene TokenAuth requires RealIp (v4+). A renewal without it is
+				// TokenInvalid even after a successful world hop. Use the IP recovered
+				// from the hop connection token (authenticator store), not loopback.
+				string? realIp = ResolveRateLimitKey(conn);
+				if (string.IsNullOrEmpty(realIp))
+				{
+					await Log.Warning(LogPrefix,
+						$"Renewal token for '{accountName}' has no stored real IP — scene hop will TokenInvalid.");
+				}
+
 				byte[] encryptedToken = TokenService.GenerateAndEncryptToken(
 					encryptionData,
 					accountName,
@@ -347,7 +357,8 @@ namespace FishMMO.Server.Implementation
 					expirationMinutes,
 					signingKey,
 					accessLevel,
-					out rawTokenForHashing);
+					out rawTokenForHashing,
+					realIp);
 
 				if (encryptedToken == null || rawTokenForHashing == null)
 				{


### PR DESCRIPTION
## Summary

World → scene hop fails with **TokenInvalid** after a successful world login.

Scene `TokenCore` requires `RealIp` on v4+ auth tokens. Login can embed it; world **renewal** called `GenerateAndEncryptToken` without that argument, so the token handed to scene has an empty IP and is rejected.

```
[TokenCore] Token for 'test67' missing real IP — rejecting.
```

This PR changes only `TokenServerAuthenticator.cs`: pass the hop-recovered client IP (`ResolveRateLimitKey`) into renewal mint.

## Test plan

- [ ] Login → world hop still succeeds
- [ ] World → scene hop no longer returns TokenInvalid when the hop connection token recovered a real IP
- [ ] If no real IP is stored, world logs the warning and scene still rejects (same as today)