### PR TITLE
Embed real IP in login and world/scene auth tokens

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
@@ -747,6 +747,14 @@ namespace FishMMO.Server.Implementation
 				// waiting on this before it hops, and a reply lets it fail fast instead of
 				// blocking until its own timeout.
 				token = string.Empty;
+				_ = Log.Warning(LogPrefix,
+					$"Hop token mint FAILED for conn={conn.ClientId} — sending empty token.");
+			}
+			else
+			{
+				_ = Log.Warning(LogPrefix,
+					$"Hop token minted for conn={conn.ClientId} len={token.Length} " +
+					$"ip={ResolveRateLimitKey(conn) ?? "?"} keys={s_dbConnectionTokenKeyMap?.Count ?? 0}.");
 			}
 
 			Server?.NetworkWrapper?.Broadcast(conn, new ConnectionTokenBroadcast()
@@ -900,12 +908,19 @@ namespace FishMMO.Server.Implementation
 			// The token bridges the real IP from the HTTP layer into the QUIC layer.
 			// We await resolution because rate limiting requires a verified real IP —
 			// falling back to proxy IP or ClientId is not acceptable for DoS protection.
+			_ = Log.Warning(LogPrefix,
+				$"ClientHandshake conn={clientId} cookie={(msg.Cookie != null && msg.Cookie.Length > 0)} " +
+				$"connectionToken={(string.IsNullOrEmpty(msg.ConnectionToken) ? "missing" : $"present len={msg.ConnectionToken.Length}")} " +
+				$"keysLoaded={s_dbConnectionTokenKeyMap?.Count ?? 0}.");
+
 			if (!string.IsNullOrEmpty(msg.ConnectionToken))
 			{
 				try
 				{
 					if (!await ProcessConnectionTokenAsync(clientId, msg.ConnectionToken))
 					{
+						_ = Log.Warning(LogPrefix,
+							$"Connection {clientId} connection-token verify FAILED (len={msg.ConnectionToken.Length}) — disconnecting before world/login auth.");
 						if (TryResolveConnection(clientId, out conn))
 							conn.Disconnect(true);
 						return;
@@ -991,14 +1006,16 @@ namespace FishMMO.Server.Implementation
 			CancellationToken ct = shutdownToken;
 			if (ct.IsCancellationRequested) return false;
 
-			var server = Server;
-			if (server?.DataContainerRegistry == null ||
-				!server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out _))
+			// Do not require IAccountCreationSystemRuntimeData. That container is
+			// registered only by AccountCreationSystem on the Login Server. World/Scene
+			// sit behind the same L4 proxy and need this path most — gating on it
+			// silently rejected every hop token (handshake saw len=74, HMAC never ran).
+			if (Server == null)
 				return false;
 
 			// Try stateless HMAC verification (format: payloadB64.sigB64).
 			// Uses the database-backed key map — no environment variable or .cfg file fallbacks.
-			string? realIp = TryVerifyStatelessConnectionToken(rawToken);
+			string? realIp = TryVerifyStatelessConnectionToken(rawToken, out string verifyFail);
 			if (realIp != null)
 			{
 				// Single-use per connection: the signature is authentic, but a bearer token
@@ -1023,7 +1040,8 @@ namespace FishMMO.Server.Implementation
 
 			// Legacy DB-backed token path removed (IConnectionTokenService deleted
 			// when connection tokens migrated to stateless HMAC).
-			await Log.Warning(LogPrefix, $"Legacy connection token not supported for {clientId}.");
+			await Log.Warning(LogPrefix,
+				$"Connection {clientId} connection-token rejected: {verifyFail} (len={rawToken.Length}).");
 			return false;
 		}
 
@@ -1120,7 +1138,7 @@ namespace FishMMO.Server.Implementation
 					{
 						s_dbConnectionTokenKeyMap = map;
 					}
-					await Log.Debug(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
+					await Log.Warning(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
 				}
 				else if (result.IsSuccess)
 				{
@@ -1186,11 +1204,20 @@ namespace FishMMO.Server.Implementation
 		/// Returns the real IP on success, null if the token is invalid/expired
 		/// or the HMAC key is not available.
 		/// </summary>
-		private static string? TryVerifyStatelessConnectionToken(string rawToken)
+		private static string? TryVerifyStatelessConnectionToken(string rawToken, out string failReason)
 		{
-			if (string.IsNullOrEmpty(rawToken)) return null;
+			failReason = "unknown";
+			if (string.IsNullOrEmpty(rawToken))
+			{
+				failReason = "empty token";
+				return null;
+			}
 			int dotIdx = rawToken.LastIndexOf('.');
-			if (dotIdx <= 0 || dotIdx >= rawToken.Length - 1) return null;
+			if (dotIdx <= 0 || dotIdx >= rawToken.Length - 1)
+			{
+				failReason = "not payload.sig format";
+				return null;
+			}
 
 			try
 			{
@@ -1205,7 +1232,11 @@ namespace FishMMO.Server.Implementation
 
 				var payloadStr = Encoding.UTF8.GetString(payload);
 				int pipeIdx = payloadStr.LastIndexOf('|');
-				if (pipeIdx <= 0) return null;
+				if (pipeIdx <= 0)
+				{
+					failReason = "payload missing |expiry";
+					return null;
+				}
 
 				// Determine token format by checking for a keyId prefix.
 				// Format: "keyId:realIp|expiryUnix" - first colon separates
@@ -1253,12 +1284,22 @@ namespace FishMMO.Server.Implementation
 						? defaultKey : null;
 				}
 
-				if (hmacKey == null) return null;
+				if (hmacKey == null)
+				{
+					int keyCount = s_dbConnectionTokenKeyMap?.Count ?? 0;
+					failReason = keyCount == 0
+						? "no connection-token keys loaded from DB"
+						: $"no HMAC key for payload '{payloadStr}' (keys={keyCount})";
+					return null;
+				}
 
 				using var hmac = new HMACSHA256(hmacKey);
 				var computedSig = hmac.ComputeHash(payload);
 				if (!CryptographicOperations.FixedTimeEquals(computedSig, expectedSig))
+				{
+					failReason = $"HMAC mismatch payload='{payloadStr}' keys={s_dbConnectionTokenKeyMap?.Count ?? 0}";
 					return null;
+				}
 
 				// Extract the real IP from the payload.
 				string realIp;
@@ -1272,7 +1313,10 @@ namespace FishMMO.Server.Implementation
 				}
 
 				if (!long.TryParse(payloadStr.Substring(pipeIdx + 1), out long expiryUnix))
+				{
+					failReason = "expiry not an integer";
 					return null;
+				}
 
 				long nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 				if (nowUnix > expiryUnix)
@@ -1289,8 +1333,9 @@ namespace FishMMO.Server.Implementation
 
 				return realIp;
 			}
-			catch
+			catch (Exception ex)
 			{
+				failReason = $"parse exception: {ex.GetType().Name}: {ex.Message}";
 				return null;
 			}
 		}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/ServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/ServerAuthenticator.cs
@@ -595,13 +595,17 @@ namespace FishMMO.Server.Implementation
 			protected override string? ResolveClientRealIp(NetworkConnection conn)
 			{
 				if (conn == null) return null;
-				// Look up the real IP that was recovered from the connection token
-				// (or stateless HMAC token) during the ClientHandshake.
+				// Authenticator-owned cache is the source of truth (written during
+				// ClientHandshake token verify). The account-creation cache is a
+				// Login-only mirror and can miss after ClientId reuse.
+				string? ip = outer.ResolveRateLimitKey(conn);
+				if (!string.IsNullOrEmpty(ip))
+					return ip;
 				if (outer.Server?.DataContainerRegistry != null &&
 					outer.Server.DataContainerRegistry.TryGet<IAccountCreationSystemRuntimeData>(out var rt) &&
 					rt.ConnectionIpCache != null)
 				{
-					if (rt.ConnectionIpCache.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out string? ip))
+					if (rt.ConnectionIpCache.TryGetAndTouch(conn.ClientId, DateTime.UtcNow, out ip))
 						return ip;
 				}
 				return null;

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/TokenServerAuthenticator.cs
@@ -339,6 +339,16 @@ namespace FishMMO.Server.Implementation
 				// expectation that access-level changes accompany token revocation.
 				// A full fix would require an IAccountManager lookup here, but World/Scene
 				// servers may not have access to the accounts table in all deployments.
+				// Scene TokenAuth requires RealIp (v4+). A renewal without it is
+				// TokenInvalid even after a successful world hop. Use the IP recovered
+				// from the hop connection token (authenticator store), not loopback.
+				string? realIp = ResolveRateLimitKey(conn);
+				if (string.IsNullOrEmpty(realIp))
+				{
+					await Log.Warning(LogPrefix,
+						$"Renewal token for '{accountName}' has no stored real IP — scene hop will TokenInvalid.");
+				}
+
 				byte[] encryptedToken = TokenService.GenerateAndEncryptToken(
 					encryptionData,
 					accountName,
@@ -347,7 +357,8 @@ namespace FishMMO.Server.Implementation
 					expirationMinutes,
 					signingKey,
 					accessLevel,
-					out rawTokenForHashing);
+					out rawTokenForHashing,
+					realIp);
 
 				if (encryptedToken == null || rawTokenForHashing == null)
 				{


### PR DESCRIPTION
## Summary

World → scene hop fails with **TokenInvalid** after a successful world login, and (without `BaseServerAuthenticator`) the world hop itself never got past connection-token verify.

Three files:

1. **`BaseServerAuthenticator.cs`** — `ProcessConnectionTokenAsync` required `IAccountCreationSystemRuntimeData` (Login-only). World dropped every hop handshake (`token present, len=74, keysLoaded=1`) without HMAC. Also logs mint/handshake/HMAC fail reason.
2. **`ServerAuthenticator.cs`** — `ResolveClientRealIp` only read the Login-only account-creation cache. Handshake now stores the hop-recovered IP on the authenticator; use that first so the SRP token includes `RealIp`.
3. **`TokenServerAuthenticator.cs`** — World renewal called `GenerateAndEncryptToken` without `realIp`. Scene `TokenCore` (v4+) then returned TokenInvalid.

```
[WorldServerAuthenticator] connection-token verify FAILED (len=74)
[TokenCore] Token for 'test67' missing real IP — rejecting.
```

## Test plan

- [ ] Login → world hop: handshake cookie-echo succeeds (connection-token HMAC runs on World)
- [ ] World → scene hop no longer returns TokenInvalid when a real IP was recovered
- [ ] If no real IP is stored, world logs the renewal warning and scene still rejects