### PR TITLE
Fix WebGL WebTransport first-send handshake and Unity 6 _free link

### DIFF
--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/WebGL/WebTransportJSLib.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/WebGL/WebTransportJSLib.cs
@@ -93,11 +93,18 @@ namespace FishNet.Transporting.WebTransport.WebGL
 
 		/// <summary>
 		/// Frees a pointer previously allocated on the WASM heap.
-		/// Maps to Emscripten's built-in _free() via EntryPoint.
+		/// Calls the jslib <c>WTFree</c> wrapper (which uses Emscripten's
+		/// JS-side <c>_free</c>). Do not DllImport <c>_free</c> directly:
+		/// Unity 6 / modern Emscripten exports the libc symbol as <c>free</c>,
+		/// so <c>EntryPoint = "_free"</c> fails the WebGL link with
+		/// <c>undefined symbol: _free</c>.
 		/// Required to release memory returned by <see cref="WTGetLastErrorMessage"/>.
 		/// </summary>
-		[DllImport("__Internal", EntryPoint = "_free")]
-		internal static extern void WASMFree(IntPtr ptr);
+		[DllImport("__Internal")]
+		internal static extern void WTFree(IntPtr ptr);
+
+		/// <summary>Alias used by <see cref="ClientSocket"/>.</summary>
+		internal static void WASMFree(IntPtr ptr) => WTFree(ptr);
 	}
 #else
 	/// <summary>

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/WebGL/plugin/WebTransport.jslib
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/WebGL/plugin/WebTransport.jslib
@@ -44,6 +44,88 @@ var LibraryFishWebTransport = {
                 return dc(sig, fn, args);
               },
 
+        /** True when the session can send/receive. Do not require
+         *  wt.readyState === 'connected': that property is missing on some
+         *  Chromium builds and can still be 'connecting' after ready()
+         *  resolves. WebGL was returning false on the first handshake
+         *  (WIRE SEND FAIL, server prefill=0) while desktop native send worked. */
+        _isLive: function(session) {
+            if (!session || !session.wt || session._closed) return false;
+            var rs = session.wt.readyState;
+            if (rs === 'closed' || rs === 'failed') return false;
+            if (session._ready) return true;
+            return rs === 'connected';
+        },
+
+        /** Open (or reuse) the persistent outgoing bidi stream and optionally
+         *  write payload. Returns false only if the session is not live. */
+        _writeReliable: function(session, payload) {
+            if (!FishWebTransport._isLive(session)) return false;
+
+            if (session._streamWriter) {
+                try {
+                    if (session._streamWriter.desiredSize === null) {
+                        try { session._streamWriter.releaseLock(); } catch (_) {}
+                        session._streamWriter = null;
+                    }
+                } catch (_) {
+                    session._streamWriter = null;
+                }
+            }
+
+            if (session._streamWriter) {
+                if (payload) {
+                    var writer = session._streamWriter;
+                    writer.write(payload).catch(function(e) {
+                        console.warn('[FishWT] stream write error: ' + e.message);
+                        if (session._streamWriter === writer) {
+                            try { writer.releaseLock(); } catch (_) {}
+                            session._streamWriter = null;
+                        }
+                    });
+                }
+                return true;
+            }
+
+            if (session._streamWriterPending) {
+                if (payload) {
+                    if (!session._sendQueue) session._sendQueue = [];
+                    session._sendQueue.push(payload);
+                }
+                return true;
+            }
+
+            session._streamWriterPending = true;
+            session.wt.createBidirectionalStream().then(function(stream) {
+                var writer = stream.writable.getWriter();
+                session._streamWriter = writer;
+                session._streamWriterPending = false;
+                FishWebTransport._pumpStreamReadable(
+                    session, stream.readable, 'local-stream');
+                var queue = session._sendQueue || [];
+                session._sendQueue = [];
+                for (var i = 0; i < queue.length; i++) {
+                    writer.write(queue[i]).catch(function(e) {
+                        console.warn('[FishWT] queued stream write error: ' + e.message);
+                    });
+                }
+                if (payload) {
+                    writer.write(payload).catch(function(e) {
+                        console.warn('[FishWT] stream write error: ' + e.message);
+                        if (session._streamWriter === writer) {
+                            try { writer.releaseLock(); } catch (_) {}
+                            session._streamWriter = null;
+                        }
+                    });
+                }
+            }).catch(function(err) {
+                console.warn('[FishWT] createBidirectionalStream failed: ' + err.message);
+                session._streamWriterPending = false;
+                session._sendQueue = [];
+            });
+            return true;
+        },
+
         /* ── Reliable-channel message framing ──────────────────────────
          * A WebTransport stream is an ordered BYTE stream: consecutive
          * writer.write() calls may be coalesced into one reader.read()
@@ -244,7 +326,7 @@ var LibraryFishWebTransport = {
         _readBidiStreams: function(session) {
             function startPump() {
                 /* Guard: don't start a new pump if the session is already closed. */
-                if (!session.wt || session.wt.readyState !== 'connected') return;
+                if (!FishWebTransport._isLive(session)) return;
 
                 var reader;
                 try {
@@ -298,7 +380,7 @@ var LibraryFishWebTransport = {
 
         _readDatagrams: function(session) {
             function startPump() {
-                if (!session.wt || session.wt.readyState !== 'connected') return;
+                if (!FishWebTransport._isLive(session)) return;
 
                 var reader;
                 try {
@@ -432,6 +514,12 @@ var LibraryFishWebTransport = {
         }
 
         session.wt.ready.then(function() {
+            session._ready = true;
+            /* Open the outgoing bidi stream before telling C# we are Started.
+             * Otherwise the first ClientHandshake races createBidirectionalStream
+             * (or is refused by a stale readyState check) and the server sees
+             * prefill=0 / no handshake. */
+            FishWebTransport._writeReliable(session, null);
             FishWebTransport._dynCall('vi', onOpen, [index]);
             FishWebTransport._readBidiStreams(session);
             FishWebTransport._readDatagrams(session);
@@ -472,8 +560,17 @@ var LibraryFishWebTransport = {
     WTSendStream__deps: ['$FishWebTransport'],
     WTSendStream: function(index, dataPtr, length) {
         var session = FishWebTransport._get(index);
-        if (!session || !session.wt) return false;
-        if (session.wt.readyState !== 'connected') return false;
+        if (!session || !session.wt) {
+            console.error('[FishWT] SendStream refuse: no session index=' + index);
+            return false;
+        }
+        if (!FishWebTransport._isLive(session)) {
+            console.error('[FishWT] SendStream refuse: not live index=' + index +
+                          ' readyState=' + session.wt.readyState +
+                          ' _ready=' + !!session._ready +
+                          ' closed=' + !!session._closed);
+            return false;
+        }
 
         if (length <= 0 || length > FishWebTransport._MAX_MESSAGE) {
             console.error('[FishWT] SendStream rejected: length ' + length +
@@ -488,96 +585,14 @@ var LibraryFishWebTransport = {
         data.set(lenHdr, 0);
         data.set(HEAPU8.subarray(dataPtr, dataPtr + length), lenHdr.length);
 
-        /* Check cached writer — desiredSize is null when the
-         * underlying stream is closed or errored. */
-        if (session._streamWriter) {
-            try {
-                if (session._streamWriter.desiredSize === null) {
-                    try { session._streamWriter.releaseLock(); } catch (_) {}
-                    session._streamWriter = null;
-                    session._streamWriterPending = false;
-                }
-            } catch (_) {
-                session._streamWriter = null;
-                session._streamWriterPending = false;
-            }
-        }
-
-        if (session._streamWriter) {
-            /* Reuse the existing writer — no new stream created. */
-            var writer = session._streamWriter;
-            writer.write(data).catch(function(e) {
-                console.warn('[FishWT] stream write error: ' + e.message);
-                if (session._streamWriter === writer) {
-                    try { writer.releaseLock(); } catch (_) {}
-                    session._streamWriter = null;
-                }
-            });
-            return true;
-        }
-
-        /* If a createBidirectionalStream promise is already in-flight
-         * (e.g. from a rapid previous send before the promise resolved),
-         * queue this data to be flushed once the stream becomes available.
-         * This prevents exhausting the browser's stream limit (~100-200)
-         * by creating a new bidi stream on every rapid send. */
-        if (session._streamWriterPending) {
-            if (!session._sendQueue) session._sendQueue = [];
-            session._sendQueue.push(data);
-            return true;
-        }
-
-        /* No valid cached writer and no pending creation:
-         * start creating a new persistent bidirectional stream. */
-        session._streamWriterPending = true;
-        try {
-            session.wt.createBidirectionalStream().then(function(stream) {
-                var writer = stream.writable.getWriter();
-                session._streamWriter = writer;
-                session._streamWriterPending = false;
-
-                /* Drain this stream's readable half. The server replies on the
-                 * stream the client opened, so without this pump every reply
-                 * (login result, spawns, RPCs) is silently discarded. */
-                FishWebTransport._pumpStreamReadable(
-                    session, stream.readable, 'local-stream');
-
-                /* Flush any data that was queued while the stream was
-                 * being created. */
-                var queue = session._sendQueue || [];
-                session._sendQueue = [];
-                for (var i = 0; i < queue.length; i++) {
-                    writer.write(queue[i]).catch(function(e) {
-                        console.warn('[FishWT] queued stream write error: ' + e.message);
-                    });
-                }
-
-                /* Write the current data. */
-                writer.write(data).catch(function(e) {
-                    console.warn('[FishWT] stream write error: ' + e.message);
-                    if (session._streamWriter === writer) {
-                        try { writer.releaseLock(); } catch (_) {}
-                        session._streamWriter = null;
-                    }
-                });
-            }).catch(function(err) {
-                console.warn('[FishWT] createBidirectionalStream failed: ' + err.message);
-                session._streamWriterPending = false;
-                session._sendQueue = [];
-            });
-            return true;
-        } catch (e) {
-            console.error('[FishWT] SendStream create error: ' + e.message);
-            session._streamWriterPending = false;
-            return false;
-        }
+        return FishWebTransport._writeReliable(session, data);
     },
 
     WTSendDatagram__deps: ['$FishWebTransport'],
     WTSendDatagram: function(index, dataPtr, length) {
         var session = FishWebTransport._get(index);
         if (!session || !session.wt) return false;
-        if (session.wt.readyState !== 'connected') return false;
+        if (!FishWebTransport._isLive(session)) return false;
 
         var data = new Uint8Array(HEAPU8.slice(dataPtr, dataPtr + length));
         try {
@@ -643,7 +658,7 @@ var LibraryFishWebTransport = {
     WTIsConnected: function(index) {
         var session = FishWebTransport._get(index);
         if (!session || !session.wt) return false;
-        return session.wt.readyState === 'connected';
+        return FishWebTransport._isLive(session);
     },
 
     WTSetStreamThreshold__deps: ['$FishWebTransport'],
@@ -674,6 +689,14 @@ var LibraryFishWebTransport = {
         if (!ptr) return 0;
         stringToUTF8(msg, ptr, msg.length + 1);
         return ptr;
+    },
+
+    /** Free a WASM-heap pointer returned to C# (e.g. from WTGetLastErrorMessage).
+     *  JS libraries must call Emscripten's _free here. C# must DllImport this
+     *  wrapper — not _free — because IL2CPP on Unity 6 looks up the libc
+     *  symbol as "free", and EntryPoint="_free" fails the wasm-ld step. */
+    WTFree: function(ptr) {
+        if (ptr) _free(ptr);
     }
 };
 


### PR DESCRIPTION
## Summary

WebGL WebTransport clients could not send the first `ClientHandshake` (browser `WIRE SEND FAIL`, server `prefill=0`) while the desktop native path worked. Two transport-only fixes:

1. **`WebTransport.jslib`** — Chromium can omit `wt.readyState` or leave it at `connecting` after `ready()` resolves. `SendStream` / `WTIsConnected` / stream pumps treated that as not connected and refused the first packet. Treat `_ready` as live unless the session is `closed`/`failed`, extract `_writeReliable`, and open the outgoing bidi stream in `ready()` so the handshake does not race `createBidirectionalStream`.
2. **`WebTransportJSLib.cs`** — Unity 6 / modern Emscripten exports libc `free`, not `_free`. `DllImport(..., EntryPoint = _free)` fails the WebGL link (`undefined symbol: _free`). C# now calls a jslib `WTFree` wrapper that invokes `_free` on the JS side.

No hop/handshake/teardown log-level changes in this PR.

## Test plan

- [ ] WebGL client: first handshake send succeeds (no `SendStream refuse` / `WIRE SEND FAIL`; server sees handshake bytes)
- [ ] WebGL IL2CPP/wasm link succeeds (no `undefined symbol: _free`)
- [ ] Login → world → scene hop still works on WebGL
- [ ] Desktop native WebTransport send/receive unchanged