### PR TITLE
LOG LEVEL ONLY: quiet expected hop/teardown warnings (WebGL console paints them red)

### DIFF
--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ClientSocket.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ClientSocket.cs
@@ -478,7 +478,8 @@ namespace FishNet.Transporting.WebTransport.Client
 		/// </summary>
 		internal void ForceStopAndReset()
 		{
-			LogTransportWarning(
+			// Expected on every Login→World→Scene hop. Warning paints red in the WebGL console.
+			LogTransportDebug(
 				$"[FishWT] ForceStopAndReset priorState={base.GetConnectionState()} target={lastConnectTarget}");
 			// Clear guard so StopConnection can run even if a prior stop stalled.
 			System.Threading.Interlocked.Exchange(ref stopGuard, 0);
@@ -738,7 +739,8 @@ namespace FishNet.Transporting.WebTransport.Client
 			string url = socket.webglConnectUrl;
 			socket.incomingEvents.Enqueue(() =>
 			{
-				socket.LogTransportWarning($"[FishWT] close index={index} url={url}");
+				// Expected socket close on hop/teardown — not a transport failure.
+				socket.LogTransportDebug($"[FishWT] close index={index} url={url}");
 				socket.SetConnectionState(LocalConnectionState.Stopped, false);
 			});
 		}

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/CommonSocket.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/CommonSocket.cs
@@ -103,6 +103,20 @@ namespace FishNet.Transporting.WebTransport
 		}
 
 		/// <summary>
+		/// Debug-level transport log. Use for expected hop teardown (ForceStop, close).
+		/// WebGL maps Unity LogWarning to the browser error console, so these look like
+		/// failures even though Login→World→Scene always tears the prior socket down.
+		/// Review before relying on these as operational alerts on server/editor.
+		/// </summary>
+		protected void LogTransportDebug(string message)
+		{
+			if (transport?.NetworkManager != null)
+				transport.NetworkManager.Log(message);
+			else
+				UnityEngine.Debug.Log(message);
+		}
+
+		/// <summary>
 		/// Logs an error message, routing through FishNet's NetworkManager when
 		/// the transport is initialized, falling back to UnityEngine.Debug.
 		/// </summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/Client.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Client.cs
@@ -287,7 +287,8 @@ namespace FishMMO.Client
 			{
 				if (this.loginServerPorts != null)
 				{
-					Log.Info("Client", "Login server connection attempt failed — invalidating cached server list.");
+					// Also fires on hop teardown (login/world socket stop), not only a failed login.
+					Log.Debug("Client", "Login/world socket stopped — invalidating cached server list if this was not a hop.");
 					this.loginServerPorts = null;
 					this.cachedConnectionToken = null;
 				}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
@@ -752,7 +752,7 @@ namespace FishMMO.Server.Implementation
 			}
 			else
 			{
-				_ = Log.Warning(LogPrefix,
+				_ = Log.Debug(LogPrefix,
 					$"Hop token minted for conn={conn.ClientId} len={token.Length} " +
 					$"ip={ResolveRateLimitKey(conn) ?? "?"} keys={s_dbConnectionTokenKeyMap?.Count ?? 0}.");
 			}
@@ -908,7 +908,7 @@ namespace FishMMO.Server.Implementation
 			// The token bridges the real IP from the HTTP layer into the QUIC layer.
 			// We await resolution because rate limiting requires a verified real IP —
 			// falling back to proxy IP or ClientId is not acceptable for DoS protection.
-			_ = Log.Warning(LogPrefix,
+			_ = Log.Debug(LogPrefix,
 				$"ClientHandshake conn={clientId} cookie={(msg.Cookie != null && msg.Cookie.Length > 0)} " +
 				$"connectionToken={(string.IsNullOrEmpty(msg.ConnectionToken) ? "missing" : $"present len={msg.ConnectionToken.Length}")} " +
 				$"keysLoaded={s_dbConnectionTokenKeyMap?.Count ?? 0}.");
@@ -1138,7 +1138,7 @@ namespace FishMMO.Server.Implementation
 					{
 						s_dbConnectionTokenKeyMap = map;
 					}
-					await Log.Warning(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
+					await Log.Debug(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
 				}
 				else if (result.IsSuccess)
 				{

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Ability/Cooldown/CooldownController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Ability/Cooldown/CooldownController.cs
@@ -463,7 +463,7 @@ namespace FishMMO.Shared
 			{
 				if (!hasSeenFirstReplicate && !resolveAuthoritativeWarningLogged)
 				{
-					Log.Warning("CooldownController",
+					Log.Debug("CooldownController",
 						$"ResolveAuthoritativeTick called before first OnReplicate. serverTick={serverTick} returned untranslated. StartTick will be corrected by reconcile.");
 					resolveAuthoritativeWarningLogged = true;
 				}

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Buff/BuffController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Buff/BuffController.cs
@@ -683,7 +683,7 @@ namespace FishMMO.Shared
 			{
 				if (!hasSeenFirstReplicate && !resolveAuthoritativeWarningLogged)
 				{
-					Log.Warning("BuffController",
+					Log.Debug("BuffController",
 						$"ResolveAuthoritativeTick called before first OnReplicate. serverTick={serverTick} returned untranslated. ExpiryTick will be corrected by reconcile.");
 					resolveAuthoritativeWarningLogged = true;
 				}


### PR DESCRIPTION
## This is a log-level change only. No gameplay / handshake / transport behavior.

**Why:** a successful WebGL Login → World → Scene hop currently dumps a pile of **red browser-console errors**. Those lines are `Log.Warning` / `LogTransportWarning` for things that **always happen** on a good hop (tear down the previous socket, mint/receive handshake, resolve ticks before the first replicate). Unity WebGL maps `LogWarning` to the browser error console, so they look fatal when they are not.

**We do not know how this affects intended logging in other contexts.** Dropping these to Debug will also hide them from:

- Unity Editor console (unless Debug is enabled)
- Dedicated login/world/scene server logs, if those pipelines filter below Warning
- Any ops/alerting that keys off Warning for hop mint / handshake / key-load

If any of those Warnings were meant as operational breadcrumbs, this PR is the wrong fix — say so and we can split client-only vs server, or keep server at Warning.

## What changed (level only)

| Site | Was | Now | Why it fires on a good path |
|---|---|---|---|
| `ClientSocket.ForceStopAndReset` | Warning | Debug | Every hop force-stops the prior WT socket |
| `ClientSocket` WebGL close | Warning | Debug | Expected close after hop/teardown |
| `Client` login/world socket stopped | Info | Debug | Same handler runs on hop, not only a failed login |
| `BaseServerAuthenticator` hop token minted | Warning | Debug | Success path after mint |
| `BaseServerAuthenticator` ClientHandshake recv | Warning | Debug | Every accepted handshake |
| `BaseServerAuthenticator` keys loaded | Warning | Debug | Startup key load success |
| `BuffController` / `CooldownController` ResolveAuthoritativeTick before first OnReplicate | Warning | Debug | Expected until the first replicate arrives |

**Left at Warning:** mint **failed**, handshake reject, HMAC fail, timeout, missing token, queue-full, drain exceptions, revoke send fail.

`LogTransportDebug` is a new helper (same as `LogTransportWarning` but `Log` / `Debug.Log`). No WebGL jslib / `_free` changes — that is #97.

## Test plan

- [ ] WebGL hop: browser console should no longer show ForceStop / close / pre-replicate as red errors
- [ ] Real failures still Warning (empty hop token, HMAC fail, handshake reject)
- [ ] Editor play and dedicated server: confirm you still see whatever hop/handshake visibility you actually want