### PR TITLE
Fix black-screen hang on world entry, reconnect mislabeling, and ignored frame cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,34 @@ core.[0-9]*
 [Mm]igrations/
 
 # Native WebTransport CMake build directories and cache.
+FishMMO-WebTransport/build/
+FishMMO-WebTransport/build_win_schannel/
 FishMMO-WebTransport/openssl_cache.cmake
+
+# --- Unity build-generated (not source) ---
+# Dependency DLLs copied in by "Build all C# Projects" (see README).
+FishMMO-Unity/Assets/Dependencies/
+FishMMO-Unity/Assets/Dependencies.meta
+# Platform-specific native WebTransport binaries built locally. Per README, only the
+# Linux binary is committed — Windows/macOS binaries must be built on their own platform.
+FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Plugins/windows_x86_64/
+FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Plugins/windows_x86_64.meta
+FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Plugins/mac_x86_64/
+FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Plugins/mac_x86_64.meta
+
+# --- FishMMO build/deploy output ---
+# Client/server build output produced by the FishMMO Dashboard build panel.
+/Builds/
+# Per-deployment server config copied to the deploy root at build/install time —
+# the tracked source templates live under FishMMO-Setup/Development|Production/.
+/LoginServer.cfg
+/WorldServer.cfg
+/SceneServer.cfg
+# Runtime appsettings.json copied into each web server's output directory from the
+# FishMMO-Setup/ templates. These hold real DB credentials at runtime and must never
+# be committed — only the FishMMO-Setup/ templates are tracked.
+FishMMO-WebServers/**/appsettings.json
+FishMMO-CMS/**/appsettings.json
 
 # --- API Documentation (docfx) ---
 # docfx.json, toc.yml, docs/, publish.sh, etc. are tracked; only the

--- a/FishMMO-Unity/Assets/Scripts/Client/Client.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Client.cs
@@ -1143,11 +1143,35 @@ namespace FishMMO.Client
 
 		private void OnCharacterStartLocal(IPlayerCharacter c)
 		{
-			UIManager.SetCharacter(c);
-			var input = c.GameObject.GetComponent<PlayerInputController>() ?? c.GameObject.AddComponent<PlayerInputController>();
-			input.Initialize(c);
-			PlayerInputController.MouseMode = false;
-			DismissLoadingScreen(true);
+			/* World entry must always complete. Each step is isolated and the loading-screen
+			 * dismissal is in a finally: a throw while binding UI or input propagated straight
+			 * out of this handler, so DismissLoadingScreen never ran and the player was left
+			 * on a black screen with the overlay up and no input controller — unrecoverable
+			 * without restarting the client. Losing a HUD panel is recoverable; never
+			 * reaching the world is not. */
+			try
+			{
+				UIManager.SetCharacter(c);
+			}
+			catch (Exception ex)
+			{
+				Log.Error("Client", $"OnCharacterStartLocal: UIManager.SetCharacter failed: {ex}");
+			}
+
+			try
+			{
+				var input = c.GameObject.GetComponent<PlayerInputController>() ?? c.GameObject.AddComponent<PlayerInputController>();
+				input.Initialize(c);
+				PlayerInputController.MouseMode = false;
+			}
+			catch (Exception ex)
+			{
+				Log.Error("Client", $"OnCharacterStartLocal: input controller setup failed: {ex}");
+			}
+			finally
+			{
+				DismissLoadingScreen(true);
+			}
 		}
 		/// <summary>
 		/// Called when the local character stops. Cleans up input, UI, fog, and destroys the character object.

--- a/FishMMO-Unity/Assets/Scripts/Client/Connection/ClientConnectionManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Connection/ClientConnectionManager.cs
@@ -204,7 +204,13 @@ namespace FishMMO.Client
 				{
 					ReconnectsAttempted++;
 					OnReconnectAttempt?.Invoke(ReconnectsAttempted, MaxReconnectAttempts);
-					ConnectToServer(lastWorldAddress, lastWorldPort);
+					/* isWorldServer: true — lastWorldAddress/lastWorldPort are by definition the
+					 * world server, so the reconnect must be typed as one. Omitting it left
+					 * CurrentConnectionType at whatever the dropped connection was (Scene, after
+					 * a world->scene hop), so a reconnect to the world server was recorded as a
+					 * scene connection and the cached world address no longer matched the state
+					 * describing it. */
+					ConnectToServer(lastWorldAddress, lastWorldPort, isWorldServer: true);
 				}
 			}
 			else

--- a/FishMMO-Unity/Assets/Scripts/Client/UI/UIManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/UI/UIManager.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FishMMO.Shared;
 using FishMMO.Shared.Core;
+using FishMMO.Logging;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.EnhancedTouch;
 
@@ -69,14 +71,33 @@ namespace FishMMO.Client
 		/// <param name="character">Player character to inject.</param>
 		internal static void SetCharacter(IPlayerCharacter character)
 		{
+			/* Each control is isolated. This runs inside Client.OnCharacterStartLocal, which
+			 * also dismisses the loading screen and wires up the player input controller — so
+			 * an exception from any single panel aborted world entry entirely, leaving the
+			 * player on a black screen with the loading overlay never dismissed and no input.
+			 * A misconfigured panel must cost only that panel. */
 			foreach (UICharacterControl control in characterControls.Values)
 			{
-				control.SetCharacter(character);
+				try
+				{
+					control.SetCharacter(character);
+				}
+				catch (Exception ex)
+				{
+					Log.Error("UIManager", $"SetCharacter failed for control '{control?.Name}': {ex}");
+				}
 			}
 
 			foreach (UITKCharacterControl control in tkCharacterControls.Values)
 			{
-				control.SetCharacter(character);
+				try
+				{
+					control.SetCharacter(character);
+				}
+				catch (Exception ex)
+				{
+					Log.Error("UIManager", $"SetCharacter failed for UIToolkit control '{control?.Name}': {ex}");
+				}
 			}
 		}
 
@@ -85,14 +106,30 @@ namespace FishMMO.Client
 		/// </summary>
 		internal static void UnsetCharacter()
 		{
+			// Isolated for the same reason as SetCharacter: teardown runs on logout and on
+			// character despawn, and one panel failing there must not strand the rest.
 			foreach (UICharacterControl control in characterControls.Values)
 			{
-				control.UnsetCharacter();
+				try
+				{
+					control.UnsetCharacter();
+				}
+				catch (Exception ex)
+				{
+					Log.Error("UIManager", $"UnsetCharacter failed for control '{control?.Name}': {ex}");
+				}
 			}
 
 			foreach (UITKCharacterControl control in tkCharacterControls.Values)
 			{
-				control.UnsetCharacter();
+				try
+				{
+					control.UnsetCharacter();
+				}
+				catch (Exception ex)
+				{
+					Log.Error("UIManager", $"UnsetCharacter failed for UIToolkit control '{control?.Name}': {ex}");
+				}
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Bootstrap/MainBootstrapSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Bootstrap/MainBootstrapSystem.cs
@@ -257,7 +257,11 @@ namespace FishMMO.Shared
 			/* Cap the client before anything renders. See BootstrapTargetFrameRate:
 			 * without this the launcher and login screens run uncapped.
 			 * Headless servers are excluded — they do not render, and FishNet
-			 * derives the server frame rate from the tick rate instead. */
+			 * derives the server frame rate from the tick rate instead.
+			 * vSyncCount is forced to 0 alongside it: Application.targetFrameRate is ignored
+			 * entirely whenever the active QualitySettings level has vSync enabled, so the
+			 * cap silently did nothing on quality levels that ship with it on. */
+			QualitySettings.vSyncCount = 0;
 			Application.targetFrameRate = BootstrapTargetFrameRate;
 			Debug.Log($"[MainBootstrapSystem] Client frame rate capped to {BootstrapTargetFrameRate} for bootstrap and menus (FishNet raises it on connect).");
 #endif


### PR DESCRIPTION
Four independent client fixes plus a `.gitignore` addition, found while debugging a reproducible black-screen hang when entering the world on a local dev deployment. All are small and self-contained; happy to split them if you'd prefer separate PRs.

## 1. `UIManager.SetCharacter` / `UnsetCharacter` — isolate each control

Both methods iterate every registered character control with no error handling. `SetCharacter` runs inside `Client.OnCharacterStartLocal`, which also dismisses the loading screen and attaches the player input controller — so a **single panel throwing aborted world entry entirely**: the loading overlay was never dismissed, no input controller was attached, and the player was left on a black screen with no way forward short of restarting the client.

Each control is now isolated and the failure logged with the control's name, so a misconfigured panel costs only that panel.

I hit this with a UI Toolkit panel that had an unassigned inspector reference, but the fragility is general — any panel that throws in `OnPostSetCharacter` takes the whole world-entry sequence down with it.

## 2. `Client.OnCharacterStartLocal` — guarantee world entry completes

The same failure mode from the other side: an exception anywhere in this handler propagated out before `DismissLoadingScreen` could run. UI and input setup are now isolated, and the dismissal moved into a `finally` so world entry always completes.

## 3. `ClientConnectionManager.TryReconnect` — pass `isWorldServer: true`

`lastWorldAddress`/`lastWorldPort` are by definition the world server, but the reconnect call omitted the flag. `CurrentConnectionType` therefore kept whatever the dropped connection was — `Scene`, after a world→scene hop — so a reconnect to the world server was recorded as a scene connection while actually dialing the world server. This presented as a connect/disconnect loop between the two.

## 4. `MainBootstrapSystem` — force `vSyncCount = 0` alongside the frame cap

`Application.targetFrameRate` is ignored entirely when the active `QualitySettings` level has vSync enabled, so the bootstrap cap silently did nothing on quality levels that ship with it on (the default quality level here had `vSyncCount: 0`, but others do not). The launcher and login screens rendered uncapped and pegged a CPU core drawing a static UI.

## 5. `.gitignore` — locally-generated build output and runtime appsettings

Files produced by a normal local build/run that are currently untracked and easy to commit by accident. Most notably `FishMMO-WebServers/**/appsettings.json`, which is copied out of `FishMMO-Setup/` at build time and populated with **real database credentials** at runtime — only the `FishMMO-Setup/` templates should be tracked. Also `/Builds/`, the per-deployment `*.cfg` files copied to the repo root, `Assets/Dependencies/`, and the Windows/macOS native WebTransport binaries that per the README are built per-platform rather than committed.

## Testing

Branched from current `dev`. `FishMMO.Client` and `FishMMO.Shared` both build clean (0 errors). Verified against a full local deployment — Login/World/Scene servers, IPFetch, Patcher and nginx — logging in, entering the world, and transitioning between scenes through a portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)