### PR TITLE
Launcher: unblock startup, stop leaking requests, fix version-check watchdog

### DIFF
--- a/FishMMO-Unity/Assets/Scenes/Client/ClientLauncher.unity
+++ b/FishMMO-Unity/Assets/Scenes/Client/ClientLauncher.unity
@@ -545,7 +545,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   webRequestService: {fileID: 468852881}
-  maxRetries: 3
+  maxRetries: 0
   retryDelay: 1
   webRequestTimeout: 10
   htmlPxToTmpSizeFactor: 1.5

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Minimap/UITKMinimap.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Minimap/UITKMinimap.cs
@@ -81,9 +81,15 @@ namespace FishMMO.Client
 		public override void OnPostSetCharacter()
 		{
 			base.OnPostSetCharacter();
-			if (Character == null || Character.MeshRoot == null)
+			/* MinimapCamera is checked here for the same reason OnStarting and the Update
+			 * paths check it: it is an inspector reference that is legitimately null when the
+			 * panel is placed without a minimap camera. Omitting it from this guard threw a
+			 * NullReferenceException out of SetCharacter, which runs during world entry — so
+			 * an unassigned minimap camera aborted the whole entry sequence rather than just
+			 * disabling the minimap. */
+			if (Character == null || Character.MeshRoot == null || MinimapCamera == null)
 			{
-				Log.Warning("UITKMinimap", "Character or Character.MeshRoot is null on OnPostSetCharacter.");
+				Log.Warning("UITKMinimap", $"Skipping camera placement: Character null={Character == null}, MeshRoot null={Character?.MeshRoot == null}, MinimapCamera null={MinimapCamera == null}.");
 				return;
 			}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/ClientLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/ClientLauncher.cs
@@ -409,34 +409,63 @@ namespace FishMMO.Client
 				this.QuitButton.onClick.AddListener(Quit);
 			}
 
-			SetLauncherState(LauncherState.LoadingNews);
-
 			// Catch-all so no async failure can leave the player on a dead button.
 			StartCoroutine(TransientStateWatchdog());
 
-			// Delegate HTML fetching to the dedicated service
-			StartCoroutine(this.htmlContentFetcher.FetchAndProcessHtml(
-				this.HtmlViewURL,
-				this.DivClass,
-				onHtmlReady: (htmlContent) =>
+			/* News and the version check run concurrently.
+			 *
+			 * The news pane is cosmetic, but it used to sit on the critical path: the version
+			 * check only began once this request settled, so every startup paid the full news
+			 * round trip — and, when the host was unreachable, its timeout as well. Against a
+			 * host that drops packets rather than refusing, that was the request timeout in
+			 * front of every launch with the Play button disabled and nothing to look at.
+			 *
+			 * Neither depends on the other, so neither waits for the other. The fetch now only
+			 * writes into the news pane whenever it lands, and startup proceeds immediately. */
+			/* No feed configured is a valid deployment, not a failure. Dispatching the fetch
+			 * anyway reaches UnityWebRequestService's empty-URL branch, which logs an error and
+			 * raises OnFailure — so a launcher with news deliberately switched off reported a
+			 * fetch failure to the player and left "Could not display news content" sitting in
+			 * the pane. Hide the pane instead and never issue the request. */
+			if (string.IsNullOrWhiteSpace(this.HtmlViewURL))
+			{
+				Log.Debug("ClientLauncher", "No launcher news URL configured; skipping the news fetch.");
+				if (this.HTMLView != null)
 				{
-					this.HtmlText.text = htmlContent;
-					ContinueAfterNews();
-				},
-				onError: (error) =>
+					this.HTMLView.SetActive(false);
+				}
+			}
+			else
+			{
+				if (this.HtmlText != null)
 				{
-					// News is cosmetic. Failing to fetch it must not block the version
-					// check — and reporting it as "Connection Failed" misleads the player
-					// into thinking the game servers are down. Show it in the news pane and
-					// carry on; if the network really is down, the version check reports
-					// that accurately a moment later.
-					Log.Warning("ClientLauncher", $"{UIText.ErrorLoadingNews}{error}");
-					if (this.HtmlText != null)
+					this.HtmlText.text = UIText.StatusLoadingNews;
+				}
+
+				StartCoroutine(this.htmlContentFetcher.FetchAndProcessHtml(
+					this.HtmlViewURL,
+					this.DivClass,
+					onHtmlReady: (htmlContent) =>
 					{
-						this.HtmlText.text = UIText.ErrorNoNewsContent;
-					}
-					ContinueAfterNews();
-				}));
+						if (this.HtmlText != null)
+						{
+							this.HtmlText.text = htmlContent;
+						}
+					},
+					onError: (error) =>
+					{
+						// Reporting this as "Connection Failed" would also mislead the player into
+						// thinking the game servers are down. If the network really is down, the
+						// version check reports that accurately on its own.
+						Log.Warning("ClientLauncher", $"{UIText.ErrorLoadingNews}{error}");
+						if (this.HtmlText != null)
+						{
+							this.HtmlText.text = UIText.ErrorNoNewsContent;
+						}
+					}));
+			}
+
+			BeginStartupFlow();
 
 			// Construct the full path to the updater executable
 			this.updaterPath = Path.Combine(Constants.GetWorkingDirectory(), Constants.Configuration.UpdaterExecutable);
@@ -454,10 +483,10 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
-		/// Advances out of the news-loading state once the news fetch has settled, whether
-		/// it succeeded or not.
+		/// Starts the version check that gates launching. Runs immediately at startup,
+		/// independently of the news fetch.
 		/// </summary>
-		private void ContinueAfterNews()
+		private void BeginStartupFlow()
 		{
 #if !UNITY_EDITOR
 			PlayButtonConnect();
@@ -1133,6 +1162,30 @@ namespace FishMMO.Client
 					string host = candidates[i];
 					bool callbackFired = false;
 					string attemptError = null;
+
+					/* Heartbeat, and the only feedback this state offers.
+					 *
+					 * Each candidate costs up to the request timeout times its retry count
+					 * before the next is tried, so a check across several unreachable hosts
+					 * runs for minutes. Nothing here refreshed lastStateActivityTime, so the
+					 * transient watchdog measured the whole sweep as a single stall and could
+					 * abort a check that was still working through its candidates. Marking
+					 * activity per attempt scopes that to one host's budget.
+					 *
+					 * The player otherwise sees a frozen "Checking Version..." for the whole
+					 * sweep, which is indistinguishable from a hang; the counter shows it is
+					 * still working through hosts. */
+					this.lastStateActivityTime = Time.realtimeSinceStartup;
+
+					/* Written to the button label rather than through SetStatus: that falls back
+					 * to ProgressText when StatusText is unassigned (it is), and ProgressText
+					 * sits inside ProgressBarGroup, which this state deactivates — so the
+					 * message would render to a hidden object. The button label is the one
+					 * status surface guaranteed to be visible here. */
+					if (candidates.Count > 1 && this.PlayButtonText != null)
+					{
+						this.PlayButtonText.text = $"{UIText.StatusCheckingVersion} ({i + 1}/{candidates.Count})";
+					}
 
 					yield return StartCoroutine(this.patchServerService.GetLatestVersion(
 						host,

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/HttpPatchServerService.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/HttpPatchServerService.cs
@@ -238,7 +238,12 @@ namespace FishMMO.Client
 				// WebGL runs under Emscripten's MEMFS (in-memory virtual FS); the
 				// file is lost when the tab closes and may silently fail on large
 				// writes. Fall back to DownloadHandlerBuffer + manual write below.
-				DownloadHandlerFactory = () => new DownloadHandlerFile(destinationFilePath),
+				// removeFileOnAbort: the handler leaves whatever it has already written on disk
+				// when the request is aborted rather than completed. The launcher aborts any
+				// in-flight request when it is torn down, which happens the moment the player
+				// launches the game — so without this a quit mid-download strands a truncated
+				// archive at the exact path the next run treats as its patch file.
+				DownloadHandlerFactory = () => new DownloadHandlerFile(destinationFilePath) { removeFileOnAbort = true },
 #else
 				DownloadHandlerFactory = () => new DownloadHandlerBuffer(),
 #endif

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityHtmlContentFetcher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityHtmlContentFetcher.cs
@@ -32,9 +32,19 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Maximum number of retries for each web request.
 		/// </summary>
-		[Tooltip("Maximum number of retries for each web request.")]
+		/// <remarks>
+		/// Defaults to 0 (a single attempt) because this fetcher serves the launcher's news
+		/// pane, which is purely cosmetic but sits on the critical path: the version check and
+		/// launch only begin once this request settles. Retrying stacked the per-attempt
+		/// timeout and the inter-attempt delay in front of every startup — with the previous
+		/// value of 3 and an unreachable host that times out rather than refusing, that is
+		/// 4 x 10s + 3 x 1s of the player watching "Loading News..." before the game even
+		/// checks its version. A decorative panel is not worth retrying; the news pane simply
+		/// shows an error and startup continues.
+		/// </remarks>
+		[Tooltip("Maximum number of retries for each web request. 0 = a single attempt (news is cosmetic and blocks startup).")]
 		[SerializeField]
-		private int maxRetries = 3;
+		private int maxRetries = 0;
 		/// <summary>
 		/// Maximum number of retries for each web request.
 		/// </summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityWebRequestService.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityWebRequestService.cs
@@ -12,6 +12,69 @@ namespace FishMMO.Client
 	public class UnityWebRequestService : MonoBehaviour
 	{
 		/// <summary>
+		/// The request currently in flight, or null when idle.
+		/// </summary>
+		/// <remarks>
+		/// Tracked so <see cref="OnDestroy"/> can abort and dispose it. The request is created
+		/// inside a <c>using</c> in <see cref="SendWebRequestWithRetries"/>, which disposes it
+		/// on every path the coroutine actually runs to — but a coroutine killed by its
+		/// GameObject being destroyed is abandoned rather than disposed, so <c>using</c> never
+		/// executes and the native handle (and its socket) leaks until finalization.
+		/// <para>
+		/// That is reachable in normal play: the launcher scene unloads the moment the player
+		/// launches the game, which can happen while the news fetch or a patch download is
+		/// still in flight.
+		/// </para>
+		/// </remarks>
+		private UnityWebRequest inFlightRequest;
+
+		/// <summary>
+		/// Aborts and disposes any request still in flight when this service is destroyed.
+		/// </summary>
+		private void OnDestroy()
+		{
+			DisposeInFlightRequest();
+		}
+
+		/// <summary>
+		/// Aborts and disposes <see cref="inFlightRequest"/> if set, then clears it.
+		/// Safe to call when idle.
+		/// </summary>
+		private void DisposeInFlightRequest()
+		{
+			UnityWebRequest request = this.inFlightRequest;
+			this.inFlightRequest = null;
+			if (request == null)
+			{
+				return;
+			}
+
+			try
+			{
+				// Abort first so an in-progress transfer stops rather than running to its
+				// timeout after nothing is left to receive the result.
+				request.Abort();
+			}
+			catch (System.Exception ex)
+			{
+				Log.Warning("UnityWebRequestService", $"Abort of in-flight request failed during teardown: {ex.Message}");
+			}
+
+			try
+			{
+				request.Dispose();
+			}
+			catch (System.ObjectDisposedException)
+			{
+				// Already disposed by the using block; nothing to do.
+			}
+			catch (System.Exception ex)
+			{
+				Log.Warning("UnityWebRequestService", $"Dispose of in-flight request failed during teardown: {ex.Message}");
+			}
+		}
+
+		/// <summary>
 		/// Configuration object for web requests.
 		/// </summary>
 		public class WebRequestConfig
@@ -125,6 +188,10 @@ namespace FishMMO.Client
 						request.downloadHandler = new DownloadHandlerBuffer();
 					}
 
+					// Publish for teardown. Cleared on every path that leaves this using block,
+					// so OnDestroy never sees a request the using has already disposed.
+					this.inFlightRequest = request;
+
 					UnityWebRequestAsyncOperation operation = request.SendWebRequest();
 					while (!operation.isDone)
 					{
@@ -139,6 +206,7 @@ namespace FishMMO.Client
 
 					if (request.result == UnityWebRequest.Result.Success)
 					{
+						this.inFlightRequest = null;
 						config.OnComplete?.Invoke(request);
 						yield break;
 					}
@@ -147,10 +215,15 @@ namespace FishMMO.Client
 						Log.Warning("UnityWebRequestService", $"Request failed ({config.URL}). Attempt {i + 1}/{config.MaxRetries + 1}. Error: {request.error}");
 						if (i < config.MaxRetries)
 						{
+							// Cleared before the retry delay: this request is disposed by the
+							// using block as the loop iterates, so it must not remain published
+							// across the wait where teardown could reach it.
+							this.inFlightRequest = null;
 							yield return new WaitForSeconds(config.RetryDelay);
 						}
 						else
 						{
+							this.inFlightRequest = null;
 							config.OnFailure?.Invoke(request);
 							yield break;
 						}


### PR DESCRIPTION
Six independent launcher fixes, found while investigating a **measured 12 second startup delay** on a local deployment. Happy to split these if you'd rather take them separately.

Separate from #99 (world-entry resilience) — no overlapping files.

## 1. News no longer gates startup

`ContinueAfterNews` (renamed `BeginStartupFlow`) was the only route to the version check, so every launch paid the full news round trip before the game checked its version — and the request timeout as well when the host was unreachable. Neither depends on the other, so they now run concurrently.

Measured on a local run: launcher scene loaded at `14:24:38`, four failed news attempts ran until `14:24:50`, and only then did the version check start.

## 2. News retries reduced from 3 to 0

Each retry stacked a timeout plus a delay in front of startup. Against a host that drops packets rather than refusing, four attempts is `4x10s + 3x1s` before launch. A decorative panel isn't worth retrying.

Changed in the **serialized scene value** as well as the code default, since the scene value is what actually runs. The patch downloader deliberately keeps its retries — retrying an interrupted download is correct.

## 3. An unconfigured news URL is "no feed", not a failure

A blank `LauncherHtmlUrl` reached `UnityWebRequestService`'s empty-URL branch, which logs an error and raises `OnFailure` — so news deliberately switched off was indistinguishable from news broken, leaving "Could not display news content" in the pane. The pane is now hidden and no request is issued.

## 4. `UnityWebRequestService` disposes its in-flight request on teardown

The request lives in a `using` block inside a coroutine, and a coroutine killed by GameObject destruction is abandoned rather than disposed — so `using` never executes and the native handle leaks.

This is reachable in normal play: the launcher scene unloads the moment the player launches, which can happen while a request is still in flight.

## 5. `DownloadHandlerFile` sets `removeFileOnAbort`

Required by (4). Adding `Abort()` means quitting mid-patch would otherwise strand a truncated archive at exactly the path the next run treats as its patch file.

## 6. The version check marks activity per candidate

Nothing refreshed `lastStateActivityTime` during the host sweep, so the 120s transient watchdog measured the whole sweep as a single stall and could **abort a version check that was still working through its candidates** — each host costs up to 4 attempts x 10s plus retry delays, so three hosts exceeds the budget.

The button also shows progress (`n/total`) instead of a frozen "Checking Version...". That text goes to the button label rather than through `SetStatus`, which falls back to `ProgressText` — a child of `ProgressBarGroup`, which this state deactivates, so it would have rendered to a hidden object.

## Also: `UITKMinimap` null check

`OnPostSetCharacter` dereferenced `MinimapCamera` without a null check, unlike `OnStarting` and both Update paths in the same file. It's an inspector reference that is legitimately null when the panel is placed without a minimap camera, and the resulting `NullReferenceException` propagates out of `UIManager.SetCharacter` during world entry.

## Testing

Branched from current `dev`. `FishMMO.Client` builds clean (0 errors). Verified against a full local deployment — Login/World/Scene servers, IPFetch, Patcher and nginx — through launcher startup, login, world entry, and a portal scene transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)