### PR TITLE
Launcher: UI Toolkit rewrite, transfer stats, settings, configurable patch directory

### DIFF
--- a/FishMMO-Patcher/Updater/Program.cs
+++ b/FishMMO-Patcher/Updater/Program.cs
@@ -12,13 +12,31 @@ class Program
 	private static readonly string WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
 	/// <summary>
-	/// Directory patch archives are read from. This must match
-	/// <c>FishMMO.Shared.Constants.GetPatchesDirectory()</c> on the client, which resolves
-	/// the same "Patches" folder relative to the install root. The launcher downloads into
-	/// that folder; if the two ever disagree, every update silently no-ops and the client
-	/// relaunches at the same version forever.
+	/// Where the install itself lives. Always the updater's own directory — the updater ships
+	/// beside the client binaries it patches, so this is the install root by construction and
+	/// is not configurable. Relocating an install means moving the updater with it.
 	/// </summary>
-	private static readonly string PatchesDirectory = Path.Combine(WorkingDirectory, "Patches");
+	private static string InstallDirectory => WorkingDirectory;
+
+	/// <summary>
+	/// Directory patch archives are read from. Defaults to "Patches" under the install root
+	/// and is overridden by <c>-patches=</c>.
+	/// </summary>
+	/// <remarks>
+	/// This must resolve to the same folder the launcher downloaded into
+	/// (<c>FishMMO.Shared.Constants.GetPatchesDirectory()</c>, which honours the same setting).
+	/// If the two ever disagree the archive is not found, the update silently no-ops, and the
+	/// client relaunches at the same version forever — so the launcher passes its resolved path
+	/// explicitly rather than both sides deriving it and hoping they agree.
+	/// <para>
+	/// Overriding this does not weaken the integrity guarantee: the launcher hashes the archive
+	/// against the server-supplied SHA-256 before invoking the updater at all, and anyone able
+	/// to write the launcher's configuration file could equally write a file into the default
+	/// location. The override changes where a verified archive is read from, not whether it is
+	/// verified.
+	/// </para>
+	/// </remarks>
+	private static string PatchesDirectory = Path.Combine(WorkingDirectory, "Patches");
 
 	private static string Version;
 	private static string LatestVersion;
@@ -48,6 +66,50 @@ class Program
 	/// </summary>
 	[DllImport("libc", SetLastError = true, EntryPoint = "kill")]
 	private static extern int SysKill(int pid, int sig);
+
+	/// <summary>
+	/// Points <see cref="PatchesDirectory"/> at <paramref name="path"/> when it is usable,
+	/// otherwise leaves the default in place.
+	/// </summary>
+	/// <remarks>
+	/// Falling back rather than failing is deliberate. The override is a convenience — it lets
+	/// a player keep patch archives off a small system drive — and an unusable one should cost
+	/// them the convenience, not the update. The default location is where the launcher writes
+	/// when its own setting is unusable, so the two still agree after the fallback.
+	/// </remarks>
+	private static void ApplyPatchesDirectoryOverride(string path)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return;
+		}
+
+		try
+		{
+			// Rooted only. A relative path resolves against the updater's current directory,
+			// which is not guaranteed to be the install root when it is started by the OS
+			// rather than by the launcher — so the same string could mean two places.
+			if (!Path.IsPathRooted(path))
+			{
+				Console.WriteLine($"WARNING: Ignoring -patches='{path}' because it is not an absolute path. Using '{PatchesDirectory}'.");
+				return;
+			}
+
+			string full = Path.GetFullPath(path);
+			if (!Directory.Exists(full))
+			{
+				Console.WriteLine($"WARNING: Ignoring -patches='{full}' because the directory does not exist. Using '{PatchesDirectory}'.");
+				return;
+			}
+
+			PatchesDirectory = full;
+			Console.WriteLine($"Patch archives will be read from '{PatchesDirectory}'.");
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine($"WARNING: Ignoring -patches='{path}' ({ex.Message}). Using '{PatchesDirectory}'.");
+		}
+	}
 
 	/// <summary>
 	/// Helper method for robust file deletion with retries.
@@ -179,6 +241,16 @@ class Program
 			{
 				var splitArg = arg.Split('=');
 				if (splitArg.Length == 2) Executable = splitArg[1];
+			}
+			if (arg.StartsWith("-patches"))
+			{
+				// Split on the first '=' only. A Windows path can contain '=', and
+				// Split('=') would truncate it at the first one.
+				int separator = arg.IndexOf('=');
+				if (separator > 0 && separator < arg.Length - 1)
+				{
+					ApplyPatchesDirectoryOverride(arg.Substring(separator + 1));
+				}
 			}
 		}
 

--- a/FishMMO-Patcher/Updater/README.md
+++ b/FishMMO-Patcher/Updater/README.md
@@ -177,7 +177,7 @@ overridden by editing the source.
 |---|---|---|
 | `MaxFileOperationRetries` | `5` | Retry count for transient file I/O errors. |
 | `FileOperationRetryDelayMs` | `200` | Delay between retries. |
-| `PatchesDirectory` | `Patches` | Directory (relative to the updater's base directory) holding patch ZIPs. |
+| `PatchesDirectory` | `Patches` | Directory (relative to the updater's base directory) holding patch ZIPs. Overridable at runtime with `-patches=`. |
 | `GracefulExitTimeoutMs` | `10000` | How long to wait for the client to exit after the graceful request before forcing a kill. |
 | `ForceKillTimeoutMs` | `5000` | How long to wait for the process to disappear after `Kill()`. |
 | `PostKillSettleMs` | `500` | Settle delay after shutdown, so the OS releases file handles before patching. |
@@ -192,12 +192,29 @@ overridden by editing the source.
 | `-latestversion=<latestVersion>` | Yes | The target version to upgrade to. |
 | `-pid=<launcherPID>` | Yes | Process ID of the launcher; updater will close/kill it before patching. |
 | `-exe=<executablePath>` | Optional | Path to the client executable to start when the updater is done, relative to the updater's base directory. |
+| `-patches=<absoluteDir>` | Optional | Directory to read patch archives from. Defaults to `Patches` under the updater's base directory. |
 
 Arguments are matched by prefix, so `-version` also matches `-versionfoo`; pass
 them exactly as listed. If `-version` and `-latestversion` are equal the updater
 does nothing but restart `-exe`. If the single archive `<version>-<latestversion>.zip`
-is missing from `Patches/`, it reports the missing file and restarts the client
-unchanged.
+is missing from the patches directory, it reports the missing file and restarts the
+client unchanged.
+
+`-patches` must be **absolute**. A relative path resolves against whatever the current
+directory happens to be, which is not guaranteed to be the install root when the updater
+is started by the OS rather than by the launcher — so the same string could name two
+different folders. A path that is relative, missing, or unreadable is ignored with a
+warning and the default is used; the launcher applies the identical rule to its own
+setting, so both sides fall back together rather than to different places.
+
+This argument only changes where a **verified** archive is read from. The launcher hashes
+the download against the server-supplied SHA-256 before the updater is invoked at all, and
+anyone able to write the launcher's configuration file could equally drop a file into the
+default location — so redirecting it does not weaken the integrity check.
+
+**It does not relocate the install.** The updater patches files relative to its own
+directory and ships beside the client binaries, so the install root is fixed by
+construction; moving an install means moving the updater with it.
 
 ---
 

--- a/FishMMO-Unity/Assets/Scenes/Client/ClientLauncher.unity
+++ b/FishMMO-Unity/Assets/Scenes/Client/ClientLauncher.unity
@@ -593,6 +593,7 @@ MonoBehaviour:
   unityWebRequestService: {fileID: 468852881}
   htmlContentFetcher: {fileID: 468852880}
   patchServerService: {fileID: 468852879}
+  launcherViewComponent: {fileID: 771001003}
 --- !u!1 &535781244
 GameObject:
   m_ObjectHideFlags: 0
@@ -1598,7 +1599,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1228319046
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2722,9 +2723,80 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 752fec6daf5f3024fb4d4fd34b572ee2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &771001000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 771001001}
+  - component: {fileID: 771001002}
+  - component: {fileID: 771001003}
+  m_Layer: 5
+  m_Name: LauncherUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &771001001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &771001002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.dll::UnityEngine.UIElements.UIDocument
+  m_PanelSettings: {fileID: 11400000, guid: b4f97f2eb547b52149cd75073347f1af, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: 48da25f64b4a48cfbbf8a53642e2414b,
+    type: 3}
+  m_SortingOrder: 0
+  m_Position: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+  m_PivotReferenceSize: 0
+  m_Pivot: 0
+  m_WorldSpaceCollider: {fileID: 0}
+--- !u!114 &771001003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 423ca935f4bf44f2a5b5adc70f58bad9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Document: {fileID: 771001002}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1228319049}
   - {fileID: 468852877}
+  - {fileID: 771001001}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 998c526e20ce42e9bd98f65b6fe5ac4c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss
@@ -1,0 +1,299 @@
+/*
+    UILauncher.uss
+    Layout for the launcher screen. Colours come from FishMMO-Theme.uss.
+
+    The news block classes at the bottom are applied by UITKHtmlContentRenderer to
+    elements it builds at runtime, so they have no counterpart in UILauncher.uxml.
+*/
+
+/*
+    The window is resizable, so nothing here may assume a size. Every band is either
+    flex-shrink: 0 (chrome that must stay legible) or flex-grow: 1 (the news pane, which
+    absorbs all the slack). The only fixed numbers are minimums.
+*/
+.launcher-screen {
+    flex-grow: 1;
+    padding: 0;
+}
+
+.launcher-panel {
+    flex-grow: 1;
+    flex-direction: column;
+    border-radius: 0;
+    border-width: 0;
+    border-top-width: 2px;
+    min-width: 480px;
+    min-height: 360px;
+}
+
+/* ── Art hooks ──────────────────────────────────────────── */
+
+/*
+    Both of these are empty by design. Point them at art from USS alone — no C# involved:
+
+        .launcher-backdrop { background-image: url("project://database/Assets/.../bg.png"); }
+        .launcher-logo     { background-image: url("project://database/Assets/.../logo.png"); }
+
+    The backdrop sits behind everything at position: absolute so it never participates in
+    layout; giving it a size here would make the panel depend on the artwork's dimensions.
+*/
+.launcher-backdrop {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    -unity-background-scale-mode: scale-and-crop;
+}
+
+.launcher-logo {
+    width: 22px;
+    height: 22px;
+    margin-right: 10px;
+    -unity-background-scale-mode: scale-to-fit;
+    background-color: rgb(255, 107, 26);
+    border-radius: 3px;
+}
+
+/*
+    Hero art band. Collapsed until given a background-image, so the launcher looks
+    deliberate rather than gap-toothed before any art exists:
+
+        .launcher-hero { height: 180px; background-image: url("..."); }
+*/
+.launcher-hero {
+    height: 0;
+    flex-shrink: 0;
+    -unity-background-scale-mode: scale-and-crop;
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+
+.launcher-header {
+    height: 42px;
+    flex-direction: row;
+    align-items: center;
+    padding-left: 12px;
+    flex-shrink: 0;
+}
+
+/* Pushes the header buttons to the right edge without absolute positioning. */
+.launcher-header-spacer {
+    flex-grow: 1;
+}
+
+.launcher-header-btn {
+    height: 24px;
+    min-width: 76px;
+    margin-right: 8px;
+}
+
+/* ── Settings ───────────────────────────────────────────── */
+
+/*
+    Sits between the news pane and the footer rather than overlaying them, so opening it
+    never covers the progress bar or the Play button — the launcher can be mid-download
+    while the player is reading this.
+*/
+/*
+    Allowed to shrink, unlike the rest of the chrome. At the smallest permitted window the
+    footer must stay reachable — losing the bottom of the settings list is recoverable,
+    losing the Play button is not.
+*/
+.launcher-settings {
+    flex-direction: column;
+    padding: 10px 16px;
+    background-color: rgb(28, 31, 34);
+    border-top-color: rgb(46, 51, 59);
+    border-top-width: 1px;
+    flex-shrink: 1;
+    max-height: 45%;
+    overflow: hidden;
+}
+
+.launcher-settings-heading {
+    margin-bottom: 6px;
+    padding-bottom: 2px;
+}
+
+.launcher-setting {
+    margin-bottom: 4px;
+    font-size: 11px;
+    color: rgb(200, 205, 214);
+}
+
+.launcher-setting > .unity-base-field__label {
+    min-width: 180px;
+    color: rgb(138, 147, 162);
+}
+
+.launcher-settings-heading--spaced {
+    margin-top: 10px;
+}
+
+.launcher-settings-note {
+    font-size: 10px;
+    color: rgb(90, 98, 114);
+    white-space: normal;
+    margin-top: 4px;
+}
+
+/* Paths wrap rather than clip — a truncated path is useless for diagnosing anything. */
+.launcher-path {
+    white-space: normal;
+    color: rgb(138, 147, 162);
+}
+
+/* ── News pane ──────────────────────────────────────────── */
+
+/*
+    flex-grow claims the space between header and footer, and min-height:0 lets it
+    shrink below its content size. Without the latter a flex child is floored at its
+    content height, so a long news page pushes the footer — and therefore the Play
+    button — off the bottom of the screen instead of scrolling.
+*/
+.launcher-news-scroll {
+    flex-grow: 1;
+    min-height: 0;
+}
+
+.launcher-news {
+    flex-direction: column;
+    padding: 12px 16px;
+}
+
+/* ── Footer ─────────────────────────────────────────────── */
+
+.launcher-footer {
+    flex-direction: column;
+    padding: 10px 12px;
+    flex-shrink: 0;
+}
+
+.launcher-status {
+    font-size: 11px;
+    color: rgb(138, 147, 162);
+    white-space: normal;
+    -unity-text-align: middle-left;
+    margin-bottom: 6px;
+}
+
+.launcher-progress {
+    flex-direction: column;
+    margin-bottom: 8px;
+}
+
+.launcher-progress-bar {
+    height: 8px;
+    width: 100%;
+}
+
+.launcher-progress-fill {
+    height: 100%;
+    width: 0;
+}
+
+.launcher-progress-text {
+    font-size: 10px;
+    color: rgb(90, 98, 114);
+    -unity-text-align: middle-right;
+    margin-top: 4px;
+}
+
+.launcher-buttons {
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.launcher-btn {
+    height: 34px;
+    min-width: 120px;
+    margin-left: 8px;
+    font-size: 11px;
+}
+
+.launcher-btn--primary {
+    color: rgb(255, 140, 69);
+    border-color: rgba(255, 107, 26, 0.40);
+    background-color: rgba(255, 107, 26, 0.12);
+}
+
+.launcher-btn:disabled {
+    opacity: 0.45;
+    cursor: arrow;
+}
+
+/* ── News content (built at runtime) ────────────────────── */
+
+.launcher-news__block {
+    flex-direction: column;
+    margin-bottom: 6px;
+}
+
+.launcher-news__text {
+    font-size: 12px;
+    color: rgb(200, 205, 214);
+    white-space: normal;
+}
+
+.launcher-news__h1 {
+    font-size: 22px;
+    -unity-font-style: bold;
+    color: rgb(200, 205, 214);
+    white-space: normal;
+    margin-top: 10px;
+    margin-bottom: 4px;
+}
+
+.launcher-news__h2 {
+    font-size: 18px;
+    -unity-font-style: bold;
+    color: rgb(200, 205, 214);
+    white-space: normal;
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+
+.launcher-news__h3 {
+    font-size: 15px;
+    -unity-font-style: bold;
+    color: rgb(255, 173, 118);
+    white-space: normal;
+    margin-top: 6px;
+    margin-bottom: 3px;
+}
+
+.launcher-news__list-item {
+    flex-direction: row;
+    margin-left: 8px;
+    margin-bottom: 2px;
+}
+
+.launcher-news__bullet {
+    font-size: 12px;
+    color: rgb(255, 107, 26);
+    margin-right: 6px;
+}
+
+.launcher-news__rule {
+    height: 1px;
+    background-color: rgb(46, 51, 59);
+    margin-top: 8px;
+    margin-bottom: 8px;
+}
+
+/*
+    Links are Labels rather than Buttons: a Button would inherit centred text and its own
+    box model, which breaks them out of the surrounding flow of text.
+*/
+.launcher-news__link {
+    font-size: 12px;
+    color: rgb(255, 107, 26);
+    white-space: normal;
+    cursor: link;
+}
+
+.launcher-news__link:hover {
+    color: rgb(255, 140, 69);
+    -unity-font-style: bold;
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss
@@ -16,6 +16,11 @@
     padding: 0;
 }
 
+/*
+    overflow: hidden so a band that cannot fit is clipped by the panel rather than spilling
+    over its neighbours. Without it an over-tall child renders on top of the footer, which is
+    how the settings list ended up appearing underneath the Play and Quit buttons.
+*/
 .launcher-panel {
     flex-grow: 1;
     flex-direction: column;
@@ -24,6 +29,7 @@
     border-top-width: 2px;
     min-width: 480px;
     min-height: 360px;
+    overflow: hidden;
 }
 
 /* ── Art hooks ──────────────────────────────────────────── */
@@ -96,19 +102,27 @@
     while the player is reading this.
 */
 /*
-    Allowed to shrink, unlike the rest of the chrome. At the smallest permitted window the
-    footer must stay reachable — losing the bottom of the settings list is recoverable,
-    losing the Play button is not.
+    A ScrollView, capped at a fraction of the window. It previously clipped instead of
+    scrolling, so once the list grew past its cap the bottom entries were simply cut off and
+    read as the footer overlapping them — the settings at the end of the list could not be
+    reached at all. Scrolling keeps every setting available at any window size while the
+    footer stays put.
+
+    flex-shrink: 0 with a max-height means this band never grows past its cap and never
+    squeezes the footer; the news pane above absorbs all remaining space.
 */
 .launcher-settings {
     flex-direction: column;
-    padding: 10px 16px;
     background-color: rgb(28, 31, 34);
     border-top-color: rgb(46, 51, 59);
     border-top-width: 1px;
-    flex-shrink: 1;
-    max-height: 45%;
-    overflow: hidden;
+    flex-shrink: 0;
+    max-height: 38%;
+    margin-bottom: 4px;
+}
+
+.launcher-settings > #unity-content-viewport > #unity-content-container {
+    padding: 10px 16px;
 }
 
 .launcher-settings-heading {
@@ -129,6 +143,24 @@
 
 .launcher-settings-heading--spaced {
     margin-top: 10px;
+}
+
+.launcher-patchdir-row {
+    flex-direction: row;
+    align-items: center;
+}
+
+/* Takes the slack so the Browse button keeps a fixed width at any panel size. */
+.launcher-patchdir-field {
+    flex-grow: 1;
+    margin-bottom: 0;
+}
+
+.launcher-browse-btn {
+    height: 20px;
+    min-width: 74px;
+    margin-left: 6px;
+    font-size: 10px;
 }
 
 .launcher-settings-note {

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b8390063134b401eadabbd7308815475
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml
@@ -1,0 +1,45 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
+    <Style src="../FishMMO-Theme.uss" />
+    <Style src="UILauncher.uss" />
+    <ui:VisualElement name="launcher-root" class="launcher-screen">
+        <ui:VisualElement name="launcher-backdrop" class="launcher-backdrop" />
+        <ui:VisualElement name="launcher-panel" class="fish-panel launcher-panel">
+            <ui:VisualElement name="launcher-header" class="fish-panel__header launcher-header">
+                <ui:VisualElement name="launcher-logo" class="launcher-logo" />
+                <ui:Label name="launcher-title" text="FishMMO" class="fish-panel__title" />
+                <ui:VisualElement class="launcher-header-spacer" />
+                <ui:Button name="launcher-settings-btn" text="Settings" class="fish-tab launcher-header-btn" />
+            </ui:VisualElement>
+            <ui:VisualElement name="launcher-hero" class="launcher-hero" />
+            <ui:ScrollView name="launcher-news-scroll" class="fish-scroll launcher-news-scroll">
+                <ui:VisualElement name="launcher-news" class="launcher-news" />
+            </ui:ScrollView>
+            <ui:VisualElement name="launcher-settings" class="launcher-settings fish-hidden">
+                <ui:Label text="DOWNLOAD" class="fish-attr-category launcher-settings-heading" />
+                <ui:Toggle name="launcher-setting-autoupdate" label="Download updates automatically" class="launcher-setting" />
+                <ui:SliderInt name="launcher-setting-timeout" label="Request timeout (s)" low-value="5" high-value="300" show-input-field="true" class="launcher-setting" />
+                <ui:SliderInt name="launcher-setting-retries" label="Retry attempts" low-value="0" high-value="10" show-input-field="true" class="launcher-setting" />
+                <ui:Slider name="launcher-setting-retrydelay" label="Retry delay (s)" low-value="0" high-value="30" show-input-field="true" class="launcher-setting" />
+                <ui:Label name="launcher-settings-note" text="" class="launcher-settings-note" />
+                <ui:Label text="STORAGE" class="fish-attr-category launcher-settings-heading launcher-settings-heading--spaced" />
+                <ui:Label name="launcher-install-path" text="" class="launcher-settings-note launcher-path" />
+                <ui:Label name="launcher-disk-size" text="Installation size: measuring..." class="launcher-settings-note" />
+                <ui:TextField name="launcher-setting-patchdir" label="Patch download folder" class="launcher-setting" />
+                <ui:Label name="launcher-patchdir-note" text="" class="launcher-settings-note" />
+            </ui:VisualElement>
+            <ui:VisualElement name="launcher-footer" class="fish-panel__footer launcher-footer">
+                <ui:Label name="launcher-status" text="" class="launcher-status" />
+                <ui:VisualElement name="launcher-progress" class="launcher-progress fish-hidden">
+                    <ui:VisualElement name="launcher-progress-bar" class="fish-bar launcher-progress-bar">
+                        <ui:VisualElement name="launcher-progress-fill" class="fish-bar__fill launcher-progress-fill" />
+                    </ui:VisualElement>
+                    <ui:Label name="launcher-progress-text" text="" class="launcher-progress-text" />
+                </ui:VisualElement>
+                <ui:VisualElement name="launcher-buttons" class="launcher-buttons">
+                    <ui:Button name="launcher-play-btn" text="Connect" class="fish-tab launcher-btn launcher-btn--primary" />
+                    <ui:Button name="launcher-quit-btn" text="Quit" class="fish-tab launcher-btn" />
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml
@@ -14,7 +14,7 @@
             <ui:ScrollView name="launcher-news-scroll" class="fish-scroll launcher-news-scroll">
                 <ui:VisualElement name="launcher-news" class="launcher-news" />
             </ui:ScrollView>
-            <ui:VisualElement name="launcher-settings" class="launcher-settings fish-hidden">
+            <ui:ScrollView name="launcher-settings" class="fish-scroll launcher-settings fish-hidden">
                 <ui:Label text="DOWNLOAD" class="fish-attr-category launcher-settings-heading" />
                 <ui:Toggle name="launcher-setting-autoupdate" label="Download updates automatically" class="launcher-setting" />
                 <ui:SliderInt name="launcher-setting-timeout" label="Request timeout (s)" low-value="5" high-value="300" show-input-field="true" class="launcher-setting" />
@@ -24,9 +24,12 @@
                 <ui:Label text="STORAGE" class="fish-attr-category launcher-settings-heading launcher-settings-heading--spaced" />
                 <ui:Label name="launcher-install-path" text="" class="launcher-settings-note launcher-path" />
                 <ui:Label name="launcher-disk-size" text="Installation size: measuring..." class="launcher-settings-note" />
-                <ui:TextField name="launcher-setting-patchdir" label="Patch download folder" class="launcher-setting" />
+                <ui:VisualElement name="launcher-patchdir-row" class="launcher-patchdir-row">
+                    <ui:TextField name="launcher-setting-patchdir" label="Patch download folder" class="launcher-setting launcher-patchdir-field" />
+                    <ui:Button name="launcher-patchdir-browse" text="Browse..." class="fish-tab launcher-browse-btn" />
+                </ui:VisualElement>
                 <ui:Label name="launcher-patchdir-note" text="" class="launcher-settings-note" />
-            </ui:VisualElement>
+            </ui:ScrollView>
             <ui:VisualElement name="launcher-footer" class="fish-panel__footer launcher-footer">
                 <ui:Label name="launcher-status" text="" class="launcher-status" />
                 <ui:VisualElement name="launcher-progress" class="launcher-progress fish-hidden">

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UILauncher.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 48da25f64b4a48cfbbf8a53642e2414b
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs
@@ -1,0 +1,567 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+using HtmlAgilityPack;
+using FishMMO.Shared;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Renders the launcher through a UI Toolkit <see cref="UIDocument"/>.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately a plain <see cref="MonoBehaviour"/> rather than a <see cref="UITKControl"/>,
+	/// matching <see cref="ClientLauncher"/> itself, which is not a <c>UIControl</c>.
+	/// <c>UITKControl</c> exists to be a game UI panel: it registers with the static
+	/// <c>UIManager</c> in Awake, takes an injected <c>Client</c>, and responds to
+	/// quit-to-login. None of that applies before a <c>Client</c> exists, and registering the
+	/// launcher into a manager that outlives the launcher scene would leave a stale entry
+	/// behind across the handoff to post-boot.
+	/// <para>
+	/// Every setter records its value whether or not the visual tree has been built yet, and
+	/// the recorded state is re-applied in <see cref="OnEnable"/>. Component initialisation
+	/// order is not guaranteed, so <see cref="ClientLauncher"/> may well set the title before
+	/// this component's <c>UIDocument</c> has produced a root — without buffering, those early
+	/// calls would silently go nowhere and the launcher would come up blank.
+	/// </para>
+	/// </remarks>
+	public class UITKClientLauncher : MonoBehaviour, ILauncherView
+	{
+		private const string TITLE_NAME = "launcher-title";
+		private const string NEWS_NAME = "launcher-news";
+		private const string NEWS_SCROLL_NAME = "launcher-news-scroll";
+		private const string STATUS_NAME = "launcher-status";
+		private const string PROGRESS_NAME = "launcher-progress";
+		private const string PROGRESS_FILL_NAME = "launcher-progress-fill";
+		private const string PROGRESS_TEXT_NAME = "launcher-progress-text";
+		private const string PLAY_BUTTON_NAME = "launcher-play-btn";
+		private const string QUIT_BUTTON_NAME = "launcher-quit-btn";
+		private const string SETTINGS_BUTTON_NAME = "launcher-settings-btn";
+		private const string SETTINGS_PANEL_NAME = "launcher-settings";
+		private const string SETTING_AUTOUPDATE_NAME = "launcher-setting-autoupdate";
+		private const string SETTING_TIMEOUT_NAME = "launcher-setting-timeout";
+		private const string SETTING_RETRIES_NAME = "launcher-setting-retries";
+		private const string SETTING_RETRYDELAY_NAME = "launcher-setting-retrydelay";
+		private const string SETTINGS_NOTE_NAME = "launcher-settings-note";
+		private const string DISK_SIZE_NAME = "launcher-disk-size";
+		private const string INSTALL_PATH_NAME = "launcher-install-path";
+		private const string SETTING_PATCHDIR_NAME = "launcher-setting-patchdir";
+		private const string PATCHDIR_NOTE_NAME = "launcher-patchdir-note";
+
+		/// <summary>USS class that hides an element. Defined in FishMMO-Theme.uss.</summary>
+		private const string HIDDEN_CLASS = "fish-hidden";
+
+		/// <summary>
+		/// The UIDocument that owns the launcher's visual tree. Assign in the Inspector.
+		/// </summary>
+		[Tooltip("UIDocument backing the launcher UI.")]
+		public UIDocument Document;
+
+		private VisualElement root;
+		private Label titleLabel;
+		private VisualElement newsContainer;
+		private ScrollView newsScroll;
+		private Label statusLabel;
+		private VisualElement progressGroup;
+		private VisualElement progressFill;
+		private Label progressTextLabel;
+		private Button playButton;
+		private Button quitButton;
+		private Button settingsButton;
+		private VisualElement settingsPanel;
+		private Toggle autoUpdateToggle;
+		private SliderInt timeoutSlider;
+		private SliderInt retriesSlider;
+		private Slider retryDelaySlider;
+		private Label settingsNote;
+		private Label diskSizeLabel;
+		private Label installPathLabel;
+		private TextField patchDirField;
+		private Label patchDirNote;
+
+		private bool elementsResolved;
+		private bool settingsOpen;
+		private string pendingDiskSizeText = "Installation size: measuring...";
+
+		// Recorded state, applied whenever the visual tree becomes available.
+		private string pendingTitle = string.Empty;
+		private string pendingButtonText = string.Empty;
+		private bool pendingButtonInteractable = true;
+		private Action buttonAction;
+		private Action quitAction;
+		private float pendingProgress;
+		private string pendingProgressText = string.Empty;
+		private bool pendingProgressVisible;
+		private string pendingStatus = string.Empty;
+		private bool pendingNewsVisible = true;
+		private string pendingNewsMessage;
+		private HtmlNode pendingNewsContent;
+
+		private void Awake()
+		{
+			TryResolveElements();
+		}
+
+		private void OnEnable()
+		{
+			if (TryResolveElements())
+			{
+				ApplyAll();
+			}
+		}
+
+		/// <summary>
+		/// Resolves and caches the elements this view drives, wiring the button callbacks once.
+		/// </summary>
+		/// <returns>True when the visual tree is available and elements are cached.</returns>
+		private bool TryResolveElements()
+		{
+			if (this.elementsResolved)
+			{
+				return true;
+			}
+
+			if (this.Document == null)
+			{
+				Log.Error("UITKClientLauncher", "No UIDocument assigned; the launcher cannot render.");
+				return false;
+			}
+
+			this.root = this.Document.rootVisualElement;
+			if (this.root == null)
+			{
+				// Normal before the document's own OnEnable has run. OnEnable retries.
+				return false;
+			}
+
+			this.titleLabel = this.root.Q<Label>(TITLE_NAME);
+			this.newsContainer = this.root.Q<VisualElement>(NEWS_NAME);
+			this.newsScroll = this.root.Q<ScrollView>(NEWS_SCROLL_NAME);
+			this.statusLabel = this.root.Q<Label>(STATUS_NAME);
+			this.progressGroup = this.root.Q<VisualElement>(PROGRESS_NAME);
+			this.progressFill = this.root.Q<VisualElement>(PROGRESS_FILL_NAME);
+			this.progressTextLabel = this.root.Q<Label>(PROGRESS_TEXT_NAME);
+			this.playButton = this.root.Q<Button>(PLAY_BUTTON_NAME);
+			this.quitButton = this.root.Q<Button>(QUIT_BUTTON_NAME);
+			this.settingsButton = this.root.Q<Button>(SETTINGS_BUTTON_NAME);
+			this.settingsPanel = this.root.Q<VisualElement>(SETTINGS_PANEL_NAME);
+			this.autoUpdateToggle = this.root.Q<Toggle>(SETTING_AUTOUPDATE_NAME);
+			this.timeoutSlider = this.root.Q<SliderInt>(SETTING_TIMEOUT_NAME);
+			this.retriesSlider = this.root.Q<SliderInt>(SETTING_RETRIES_NAME);
+			this.retryDelaySlider = this.root.Q<Slider>(SETTING_RETRYDELAY_NAME);
+			this.settingsNote = this.root.Q<Label>(SETTINGS_NOTE_NAME);
+			this.diskSizeLabel = this.root.Q<Label>(DISK_SIZE_NAME);
+			this.installPathLabel = this.root.Q<Label>(INSTALL_PATH_NAME);
+			this.patchDirField = this.root.Q<TextField>(SETTING_PATCHDIR_NAME);
+			this.patchDirNote = this.root.Q<Label>(PATCHDIR_NOTE_NAME);
+
+			BindSettings();
+
+			// Registered once and dispatched through the fields, so replacing an action is a
+			// field assignment. Re-registering per state change would accumulate callbacks and
+			// fire every action the launcher had ever been in.
+			if (this.playButton != null)
+			{
+				this.playButton.clicked += () => this.buttonAction?.Invoke();
+			}
+			if (this.quitButton != null)
+			{
+				this.quitButton.clicked += () => this.quitAction?.Invoke();
+			}
+
+			this.elementsResolved = true;
+			return true;
+		}
+
+		/// <summary>
+		/// Seeds the settings controls from stored values and persists any change.
+		/// </summary>
+		/// <remarks>
+		/// Values are read through <see cref="LauncherSettings"/> rather than from the
+		/// configuration store directly, so the clamping applied to a hand-edited config file
+		/// is the same clamping the sliders enforce. Reading raw would let the UI display an
+		/// out-of-range value that the download path then silently ignores.
+		/// <para>
+		/// Each change is saved immediately. The launcher has no OK button, and it is routinely
+		/// terminated by the updater taking over the process — deferring the write to teardown
+		/// would lose it exactly when an update is happening.
+		/// </para>
+		/// </remarks>
+		private void BindSettings()
+		{
+			if (this.settingsButton != null)
+			{
+				this.settingsButton.clicked += ToggleSettings;
+			}
+
+			if (this.autoUpdateToggle != null)
+			{
+				this.autoUpdateToggle.SetValueWithoutNotify(LauncherSettings.AutoUpdate);
+				this.autoUpdateToggle.RegisterValueChangedCallback(evt =>
+				{
+					LauncherSettings.AutoUpdate = evt.newValue;
+					LauncherSettings.Save();
+					RefreshSettingsNote();
+				});
+			}
+
+			if (this.timeoutSlider != null)
+			{
+				this.timeoutSlider.SetValueWithoutNotify(LauncherSettings.GetRequestTimeout(10));
+				this.timeoutSlider.RegisterValueChangedCallback(evt =>
+				{
+					LauncherSettings.SetRequestTimeout(evt.newValue);
+					LauncherSettings.Save();
+				});
+			}
+
+			if (this.retriesSlider != null)
+			{
+				this.retriesSlider.SetValueWithoutNotify(LauncherSettings.GetMaxRetries(3));
+				this.retriesSlider.RegisterValueChangedCallback(evt =>
+				{
+					LauncherSettings.SetMaxRetries(evt.newValue);
+					LauncherSettings.Save();
+				});
+			}
+
+			if (this.retryDelaySlider != null)
+			{
+				this.retryDelaySlider.SetValueWithoutNotify(LauncherSettings.GetRetryDelay(1.0f));
+				this.retryDelaySlider.RegisterValueChangedCallback(evt =>
+				{
+					LauncherSettings.SetRetryDelay(evt.newValue);
+					LauncherSettings.Save();
+				});
+			}
+
+			if (this.installPathLabel != null)
+			{
+				this.installPathLabel.text = $"Installed at: {Constants.GetWorkingDirectory()}";
+			}
+
+			if (this.patchDirField != null)
+			{
+				this.patchDirField.SetValueWithoutNotify(LauncherSettings.PatchDirectoryOverride);
+				/* Committed on blur or Enter rather than per keystroke. RegisterValueChangedCallback
+				 * fires on every character, so a path typed by hand would be written to disk —
+				 * and validated — dozens of times, most of them against a prefix that is not yet
+				 * a real directory. */
+				this.patchDirField.RegisterCallback<FocusOutEvent>(_ => CommitPatchDirectory());
+				this.patchDirField.RegisterCallback<KeyDownEvent>(evt =>
+				{
+					if (evt.keyCode == KeyCode.Return || evt.keyCode == KeyCode.KeypadEnter)
+					{
+						CommitPatchDirectory();
+					}
+				});
+			}
+
+			RefreshSettingsNote();
+			RefreshPatchDirectoryNote();
+		}
+
+		/// <summary>
+		/// Stores the typed patch directory and reports where patches will actually land.
+		/// </summary>
+		private void CommitPatchDirectory()
+		{
+			if (this.patchDirField == null)
+			{
+				return;
+			}
+
+			LauncherSettings.PatchDirectoryOverride = this.patchDirField.value?.Trim() ?? string.Empty;
+			LauncherSettings.Save();
+			RefreshPatchDirectoryNote();
+		}
+
+		/// <summary>
+		/// Reports the directory patches will actually be written to.
+		/// </summary>
+		/// <remarks>
+		/// Shows the resolved path rather than echoing what was typed. An unusable override
+		/// falls back to the install's own folder, and a player who is not told that will
+		/// reasonably believe their setting took effect.
+		/// </remarks>
+		private void RefreshPatchDirectoryNote()
+		{
+			if (this.patchDirNote == null)
+			{
+				return;
+			}
+
+			string fallback = Constants.GetPatchesDirectory();
+			string resolved = LauncherSettings.ResolvePatchDirectory(fallback);
+
+			this.patchDirNote.text = string.IsNullOrWhiteSpace(LauncherSettings.PatchDirectoryOverride)
+				? $"Leave empty to use the install folder. Currently: {resolved}"
+				: (resolved == fallback
+					? $"That path could not be used — falling back to {resolved}"
+					: $"Patches will download to {resolved}");
+		}
+
+		/// <summary>
+		/// Shows or hides the settings section.
+		/// </summary>
+		private void ToggleSettings()
+		{
+			this.settingsOpen = !this.settingsOpen;
+			SetHidden(this.settingsPanel, !this.settingsOpen);
+		}
+
+		/// <summary>
+		/// Explains the consequence of the current auto-update choice, so the toggle is not
+		/// just a label the player has to guess the meaning of.
+		/// </summary>
+		private void RefreshSettingsNote()
+		{
+			if (this.settingsNote == null)
+			{
+				return;
+			}
+
+			this.settingsNote.text = LauncherSettings.AutoUpdate
+				? "Updates start downloading as soon as one is found."
+				: "The launcher will wait and show an Update button instead.";
+		}
+
+		/// <summary>
+		/// Pushes all recorded state into the visual tree.
+		/// </summary>
+		private void ApplyAll()
+		{
+			ApplyTitle();
+			ApplyButtonText();
+			ApplyButtonInteractable();
+			ApplyProgress();
+			ApplyProgressText();
+			ApplyProgressVisible();
+			ApplyStatus();
+			ApplyNewsVisible();
+			ApplyNewsBody();
+			ApplyDiskSize();
+		}
+
+		private void ApplyDiskSize()
+		{
+			if (this.diskSizeLabel != null)
+			{
+				this.diskSizeLabel.text = this.pendingDiskSizeText;
+			}
+		}
+
+		#region ILauncherView
+
+		/// <inheritdoc />
+		public void SetTitle(string title)
+		{
+			this.pendingTitle = title;
+			ApplyTitle();
+		}
+
+		/// <inheritdoc />
+		public void SetButtonText(string text)
+		{
+			this.pendingButtonText = text;
+			ApplyButtonText();
+		}
+
+		/// <inheritdoc />
+		public void SetButtonInteractable(bool interactable)
+		{
+			this.pendingButtonInteractable = interactable;
+			ApplyButtonInteractable();
+		}
+
+		/// <inheritdoc />
+		public void SetButtonAction(Action action)
+		{
+			this.buttonAction = action;
+		}
+
+		/// <inheritdoc />
+		public void SetQuitAction(Action action)
+		{
+			this.quitAction = action;
+		}
+
+		/// <inheritdoc />
+		public void SetProgress(DownloadStats stats)
+		{
+			this.pendingProgress = Mathf.Clamp01(stats.NormalizedProgress);
+			this.pendingProgressText = stats.ToDisplayString();
+			ApplyProgress();
+			ApplyProgressText();
+		}
+
+		/// <inheritdoc />
+		public void SetProgressVisible(bool visible)
+		{
+			this.pendingProgressVisible = visible;
+			if (!visible)
+			{
+				this.pendingProgress = 0f;
+				this.pendingProgressText = string.Empty;
+			}
+			ApplyProgressVisible();
+			ApplyProgress();
+			ApplyProgressText();
+		}
+
+		/// <inheritdoc />
+		public void ShowStatus(string message)
+		{
+			this.pendingStatus = message;
+			ApplyStatus();
+		}
+
+		/// <inheritdoc />
+		public void ClearStatus()
+		{
+			this.pendingStatus = string.Empty;
+			ApplyStatus();
+		}
+
+		/// <inheritdoc />
+		public void SetNewsVisible(bool visible)
+		{
+			this.pendingNewsVisible = visible;
+			ApplyNewsVisible();
+		}
+
+		/// <inheritdoc />
+		public void SetNewsMessage(string message)
+		{
+			this.pendingNewsMessage = message;
+			this.pendingNewsContent = null;
+			ApplyNewsBody();
+		}
+
+		/// <inheritdoc />
+		public void SetNewsContent(HtmlNode content)
+		{
+			this.pendingNewsContent = content;
+			this.pendingNewsMessage = null;
+			ApplyNewsBody();
+		}
+
+		/// <inheritdoc />
+		public void SetInstallSize(long? sizeBytes)
+		{
+			// "Unavailable" rather than "0 B" when unknown: a zero would read as an empty
+			// installation, which is a different and alarming claim.
+			this.pendingDiskSizeText = sizeBytes.HasValue
+				? $"Installation size: {DownloadStats.FormatBytes((ulong)sizeBytes.Value)}"
+				: "Installation size: unavailable";
+			ApplyDiskSize();
+		}
+
+		/// <inheritdoc />
+		public void Teardown()
+		{
+			// Nothing to release. Every callback this view registers lives on an element owned
+			// by the UIDocument, which is destroyed together with this component.
+		}
+
+		#endregion
+
+		#region Apply
+
+		private void ApplyTitle()
+		{
+			if (this.titleLabel != null)
+			{
+				this.titleLabel.text = this.pendingTitle;
+			}
+		}
+
+		private void ApplyButtonText()
+		{
+			if (this.playButton != null)
+			{
+				this.playButton.text = this.pendingButtonText;
+			}
+		}
+
+		private void ApplyButtonInteractable()
+		{
+			if (this.playButton != null)
+			{
+				this.playButton.SetEnabled(this.pendingButtonInteractable);
+			}
+		}
+
+		private void ApplyProgress()
+		{
+			if (this.progressFill != null)
+			{
+				this.progressFill.style.width = Length.Percent(this.pendingProgress * 100f);
+			}
+		}
+
+		private void ApplyProgressText()
+		{
+			if (this.progressTextLabel != null)
+			{
+				this.progressTextLabel.text = this.pendingProgressText;
+			}
+		}
+
+		private void ApplyProgressVisible()
+		{
+			SetHidden(this.progressGroup, !this.pendingProgressVisible);
+		}
+
+		private void ApplyStatus()
+		{
+			if (this.statusLabel == null)
+			{
+				return;
+			}
+			this.statusLabel.text = this.pendingStatus;
+			// Collapsed rather than merely blank so the footer does not reserve a gap for a
+			// message that is not there.
+			SetHidden(this.statusLabel, string.IsNullOrEmpty(this.pendingStatus));
+		}
+
+		private void ApplyNewsVisible()
+		{
+			SetHidden(this.newsScroll, !this.pendingNewsVisible);
+		}
+
+		private void ApplyNewsBody()
+		{
+			if (this.newsContainer == null)
+			{
+				return;
+			}
+
+			if (this.pendingNewsMessage != null)
+			{
+				this.newsContainer.Clear();
+				Label message = new Label(this.pendingNewsMessage);
+				message.AddToClassList("launcher-news__text");
+				this.newsContainer.Add(message);
+				return;
+			}
+
+			UITKHtmlContentRenderer.Render(this.pendingNewsContent, this.newsContainer, LauncherLinkPolicy.OpenIfSafe);
+		}
+
+		/// <summary>
+		/// Adds or removes the shared hidden class on <paramref name="element"/>.
+		/// </summary>
+		private static void SetHidden(VisualElement element, bool hidden)
+		{
+			if (element == null)
+			{
+				return;
+			}
+			element.EnableInClassList(HIDDEN_CLASS, hidden);
+		}
+
+		#endregion
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.UIElements;
 using HtmlAgilityPack;
@@ -48,6 +49,7 @@ namespace FishMMO.Client
 		private const string INSTALL_PATH_NAME = "launcher-install-path";
 		private const string SETTING_PATCHDIR_NAME = "launcher-setting-patchdir";
 		private const string PATCHDIR_NOTE_NAME = "launcher-patchdir-note";
+		private const string PATCHDIR_BROWSE_NAME = "launcher-patchdir-browse";
 
 		/// <summary>USS class that hides an element. Defined in FishMMO-Theme.uss.</summary>
 		private const string HIDDEN_CLASS = "fish-hidden";
@@ -79,9 +81,19 @@ namespace FishMMO.Client
 		private Label installPathLabel;
 		private TextField patchDirField;
 		private Label patchDirNote;
+		private Button patchDirBrowseButton;
 
 		private bool elementsResolved;
 		private bool settingsOpen;
+		/// <summary>Frames spent waiting for the visual tree before giving up.</summary>
+		private int resolveAttempts;
+		/// <summary>Set once resolution has been abandoned, so the error is logged only once.</summary>
+		private bool resolveFailed;
+		/// <summary>
+		/// How many frames to wait for UIDocument to clone its tree. Generous — this only ever
+		/// needs one or two, and the cost of waiting is a null check per frame.
+		/// </summary>
+		private const int MaxResolveAttempts = 300;
 		private string pendingDiskSizeText = "Installation size: measuring...";
 
 		// Recorded state, applied whenever the visual tree becomes available.
@@ -112,6 +124,40 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
+		/// Keeps retrying resolution until the visual tree exists, then stops.
+		/// </summary>
+		/// <remarks>
+		/// Deliberately not relying on OnEnable being late enough. UIDocument clones the tree in
+		/// its own OnEnable, and which component gets there first depends on their order on the
+		/// GameObject — an ordering the scene can change without anyone noticing. Polling for a
+		/// couple of frames costs nothing and removes the dependency entirely.
+		/// <para>
+		/// Gives up loudly rather than spinning forever, because a permanent failure here means
+		/// a blank launcher, and silence is what made this expensive to diagnose the first time.
+		/// </para>
+		/// </remarks>
+		private void Update()
+		{
+			if (this.elementsResolved || this.resolveFailed)
+			{
+				return;
+			}
+
+			if (TryResolveElements())
+			{
+				ApplyAll();
+				return;
+			}
+
+			this.resolveAttempts++;
+			if (this.resolveAttempts >= MaxResolveAttempts)
+			{
+				this.resolveFailed = true;
+				Log.Error("UITKClientLauncher", $"Gave up resolving the launcher UI after {MaxResolveAttempts} frames; it will not render. Check the UIDocument's Source Asset and Panel Settings.");
+			}
+		}
+
+		/// <summary>
 		/// Resolves and caches the elements this view drives, wiring the button callbacks once.
 		/// </summary>
 		/// <returns>True when the visual tree is available and elements are cached.</returns>
@@ -132,8 +178,31 @@ namespace FishMMO.Client
 			if (this.root == null)
 			{
 				// Normal before the document's own OnEnable has run. OnEnable retries.
+				Log.Debug("UITKClientLauncher", "rootVisualElement is null; will retry.");
 				return false;
 			}
+
+			/* An empty root is "not ready yet", not "nothing to find".
+			 *
+			 * UIDocument allocates rootVisualElement early but only clones the UXML into it in
+			 * its own OnEnable, which runs after every component's Awake. Awake therefore sees a
+			 * real, empty root. Treating that as resolved — which this did — meant every Q<>
+			 * returned null, the resolved flag latched, and the retry in OnEnable took the
+			 * early-out and never looked again. The launcher then ran its entire flow correctly
+			 * against a set of null fields and drew nothing. */
+			if (this.root.childCount == 0)
+			{
+				Log.Debug("UITKClientLauncher", "Visual tree not cloned yet; will retry.");
+				return false;
+			}
+
+			/* Logged unconditionally, not only on failure.
+			 *
+			 * A silent success and a silent failure looked identical from the outside: every
+			 * setter null-checks, so an unresolved tree makes the launcher run perfectly and
+			 * draw nothing, which is indistinguishable from a layout that renders blank. That
+			 * cost a whole build/test round trip to tell apart. */
+			Log.Info("UITKClientLauncher", $"Resolving UI. sourceAsset={(this.Document.visualTreeAsset != null ? this.Document.visualTreeAsset.name : "NULL")} rootChildren={this.root.childCount} panelSettings={(this.Document.panelSettings != null ? this.Document.panelSettings.name : "NULL")}");
 
 			this.titleLabel = this.root.Q<Label>(TITLE_NAME);
 			this.newsContainer = this.root.Q<VisualElement>(NEWS_NAME);
@@ -155,6 +224,34 @@ namespace FishMMO.Client
 			this.installPathLabel = this.root.Q<Label>(INSTALL_PATH_NAME);
 			this.patchDirField = this.root.Q<TextField>(SETTING_PATCHDIR_NAME);
 			this.patchDirNote = this.root.Q<Label>(PATCHDIR_NOTE_NAME);
+			this.patchDirBrowseButton = this.root.Q<Button>(PATCHDIR_BROWSE_NAME);
+
+			// Names the elements that did not resolve, so a UXML/controller mismatch reports
+			// which one rather than silently drawing an incomplete screen.
+			string missing = string.Join(", ", new[]
+			{
+				this.titleLabel == null ? TITLE_NAME : null,
+				this.newsContainer == null ? NEWS_NAME : null,
+				this.newsScroll == null ? NEWS_SCROLL_NAME : null,
+				this.statusLabel == null ? STATUS_NAME : null,
+				this.progressGroup == null ? PROGRESS_NAME : null,
+				this.playButton == null ? PLAY_BUTTON_NAME : null,
+				this.quitButton == null ? QUIT_BUTTON_NAME : null,
+				this.settingsButton == null ? SETTINGS_BUTTON_NAME : null,
+				this.settingsPanel == null ? SETTINGS_PANEL_NAME : null,
+			}.Where(n => n != null));
+
+			if (!string.IsNullOrEmpty(missing))
+			{
+				/* Not latched. A partial resolve means the tree is still being built or the
+				 * UXML genuinely does not match this controller; either way, committing to it
+				 * would bind callbacks to whatever did resolve and permanently give up on the
+				 * rest. Retrying costs nothing and the caller reports if it never succeeds. */
+				Log.Warning("UITKClientLauncher", $"UXML elements not found (will retry): {missing}");
+				return false;
+			}
+
+			Log.Info("UITKClientLauncher", "All launcher UI elements resolved.");
 
 			BindSettings();
 
@@ -258,7 +355,37 @@ namespace FishMMO.Client
 				});
 			}
 
+			if (this.patchDirBrowseButton != null)
+			{
+				// Hidden rather than disabled where no native dialog exists. A permanently
+				// greyed-out button reads as something broken; the text field beside it is the
+				// real control on every platform, so its absence costs nothing.
+				SetHidden(this.patchDirBrowseButton, !NativeFolderPicker.IsSupported);
+				this.patchDirBrowseButton.clicked += BrowseForPatchDirectory;
+			}
+
 			RefreshSettingsNote();
+			RefreshPatchDirectoryNote();
+		}
+
+		/// <summary>
+		/// Opens the OS folder dialog and stores the chosen directory.
+		/// </summary>
+		/// <remarks>
+		/// A cancelled dialog returns null and is left alone rather than clearing the field —
+		/// backing out of a picker should not silently reset the setting to the default.
+		/// </remarks>
+		private void BrowseForPatchDirectory()
+		{
+			string chosen = NativeFolderPicker.PickFolder("Choose where patch downloads are stored");
+			if (string.IsNullOrWhiteSpace(chosen))
+			{
+				return;
+			}
+
+			this.patchDirField?.SetValueWithoutNotify(chosen);
+			LauncherSettings.PatchDirectoryOverride = chosen;
+			LauncherSettings.Save();
 			RefreshPatchDirectoryNote();
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKClientLauncher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 423ca935f4bf44f2a5b5adc70f58bad9

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKHtmlContentRenderer.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKHtmlContentRenderer.cs
@@ -1,0 +1,408 @@
+using System;
+using System.Net;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.UIElements;
+using HtmlAgilityPack;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Renders a parsed launcher news fragment into a tree of <see cref="VisualElement"/>s.
+	/// </summary>
+	/// <remarks>
+	/// The UI Toolkit counterpart to <see cref="HtmlToTmpTextConverter"/>, which produces a
+	/// TextMeshPro rich-text string instead. They cannot share an output format: UI Toolkit
+	/// parses only lowercase rich-text tags, writes alignment differently, and — decisively —
+	/// has no equivalent of TMP's <c>&lt;link&gt;</c> tag, so a news link cannot be a span of
+	/// styled text here. It has to be an element that can receive a click.
+	/// <para>
+	/// Building elements rather than markup also removes an escaping problem. Composing a
+	/// markup string means remote content is concatenated into a string that is then parsed,
+	/// so a news page containing tag-like text can alter the formatting of everything after
+	/// it. Text assigned to a <see cref="Label"/> is never parsed as markup.
+	/// </para>
+	/// </remarks>
+	public static class UITKHtmlContentRenderer
+	{
+		/// <summary>
+		/// Maximum traversal depth. The news document comes from an operator-configured URL,
+		/// so its nesting depth is not something this client controls.
+		/// </summary>
+		private const int MaxRecursionDepth = 100;
+
+		/// <summary>
+		/// Maximum number of elements produced from one document.
+		/// </summary>
+		/// <remarks>
+		/// A depth limit alone does not bound the output: a shallow document with a very large
+		/// number of siblings produces a very large number of elements, and a UI Toolkit panel
+		/// holding tens of thousands of them will stall the launcher on layout. Truncating is
+		/// the right failure for a decorative pane.
+		/// </remarks>
+		private const int MaxElements = 2000;
+
+		/// <summary>Default USS class applied to body text.</summary>
+		private const string TextClass = "launcher-news__text";
+
+		/// <summary>
+		/// Carries formatting inherited from ancestor elements down the traversal.
+		/// </summary>
+		private struct InlineStyle
+		{
+			public bool Bold;
+			public bool Italic;
+			public bool Underline;
+			public Color? TextColor;
+			public int? FontSize;
+			/// <summary>Href of the enclosing anchor, or null when not inside one.</summary>
+			public string Href;
+			/// <summary>USS class for text produced at this point in the tree.</summary>
+			public string TextClass;
+		}
+
+		/// <summary>
+		/// Mutable state shared across the traversal.
+		/// </summary>
+		private class RenderContext
+		{
+			public VisualElement Container;
+			public Action<string> OnLinkActivated;
+			public VisualElement CurrentRow;
+			public int ElementCount;
+			public bool Truncated;
+		}
+
+		/// <summary>
+		/// Clears <paramref name="container"/> and rebuilds it from <paramref name="root"/>.
+		/// </summary>
+		/// <param name="root">The extracted news fragment. Null renders an empty pane.</param>
+		/// <param name="container">The element to populate.</param>
+		/// <param name="onLinkActivated">
+		/// Invoked with the raw href when a link is clicked. Callers must route this through
+		/// <see cref="LauncherLinkPolicy"/> — this renderer deliberately does not open URLs
+		/// itself, so the allowlist stays in one place.
+		/// </param>
+		public static void Render(HtmlNode root, VisualElement container, Action<string> onLinkActivated)
+		{
+			if (container == null)
+			{
+				return;
+			}
+
+			container.Clear();
+
+			if (root == null)
+			{
+				return;
+			}
+
+			RenderContext context = new RenderContext
+			{
+				Container = container,
+				OnLinkActivated = onLinkActivated,
+			};
+
+			InlineStyle rootStyle = new InlineStyle { TextClass = TextClass };
+
+			foreach (HtmlNode child in root.ChildNodes)
+			{
+				Walk(child, context, rootStyle, 0);
+			}
+
+			FlushRow(context);
+
+			if (context.Truncated)
+			{
+				Log.Warning("UITKHtmlContentRenderer", $"News content exceeded {MaxElements} elements and was truncated.");
+			}
+		}
+
+		/// <summary>
+		/// Recursively converts <paramref name="node"/> into elements.
+		/// </summary>
+		private static void Walk(HtmlNode node, RenderContext context, InlineStyle style, int depth)
+		{
+			if (context.ElementCount >= MaxElements)
+			{
+				context.Truncated = true;
+				return;
+			}
+
+			if (depth > MaxRecursionDepth)
+			{
+				Log.Warning("UITKHtmlContentRenderer", $"Maximum recursion depth ({MaxRecursionDepth}) exceeded. Truncating news conversion.");
+				return;
+			}
+
+			if (node.NodeType == HtmlNodeType.Comment)
+			{
+				return;
+			}
+
+			if (node.NodeType == HtmlNodeType.Text)
+			{
+				AppendText(WebUtility.HtmlDecode(node.InnerText), context, style);
+				return;
+			}
+
+			if (node.NodeType != HtmlNodeType.Element)
+			{
+				return;
+			}
+
+			InlineStyle childStyle = ApplyStyleAttribute(node, style);
+			string tag = node.Name.ToLowerInvariant();
+
+			switch (tag)
+			{
+				case "br":
+					FlushRow(context);
+					return;
+
+				case "hr":
+					FlushRow(context);
+					VisualElement rule = new VisualElement();
+					rule.AddToClassList("launcher-news__rule");
+					context.Container.Add(rule);
+					context.ElementCount++;
+					return;
+
+				case "h1":
+				case "h2":
+				case "h3":
+					FlushRow(context);
+					childStyle.TextClass = $"launcher-news__{tag}";
+					WalkChildren(node, context, childStyle, depth);
+					FlushRow(context);
+					return;
+
+				case "h4":
+				case "h5":
+				case "h6":
+					FlushRow(context);
+					childStyle.TextClass = "launcher-news__h3";
+					WalkChildren(node, context, childStyle, depth);
+					FlushRow(context);
+					return;
+
+				case "strong":
+				case "b":
+					childStyle.Bold = true;
+					WalkChildren(node, context, childStyle, depth);
+					return;
+
+				case "em":
+				case "i":
+					childStyle.Italic = true;
+					WalkChildren(node, context, childStyle, depth);
+					return;
+
+				case "u":
+					childStyle.Underline = true;
+					WalkChildren(node, context, childStyle, depth);
+					return;
+
+				case "a":
+					string href = node.GetAttributeValue("href", "");
+					if (!string.IsNullOrEmpty(href))
+					{
+						childStyle.Href = href;
+					}
+					WalkChildren(node, context, childStyle, depth);
+					return;
+
+				case "li":
+					FlushRow(context);
+					VisualElement row = EnsureRow(context);
+					row.AddToClassList("launcher-news__list-item");
+					Label bullet = new Label("•");
+					bullet.AddToClassList("launcher-news__bullet");
+					row.Add(bullet);
+					context.ElementCount++;
+					WalkChildren(node, context, childStyle, depth);
+					FlushRow(context);
+					return;
+
+				case "p":
+				case "div":
+				case "ul":
+				case "ol":
+					FlushRow(context);
+					WalkChildren(node, context, childStyle, depth);
+					FlushRow(context);
+					return;
+
+				default:
+					WalkChildren(node, context, childStyle, depth);
+					return;
+			}
+		}
+
+		/// <summary>
+		/// Walks every child of <paramref name="node"/> at one greater depth.
+		/// </summary>
+		private static void WalkChildren(HtmlNode node, RenderContext context, InlineStyle style, int depth)
+		{
+			foreach (HtmlNode child in node.ChildNodes)
+			{
+				Walk(child, context, style, depth + 1);
+			}
+		}
+
+		/// <summary>
+		/// Reads the node's inline <c>style</c> attribute, returning a style updated with any
+		/// properties it recognises.
+		/// </summary>
+		private static InlineStyle ApplyStyleAttribute(HtmlNode node, InlineStyle style)
+		{
+			string styleAttributes = node.GetAttributeValue("style", "");
+			if (string.IsNullOrEmpty(styleAttributes))
+			{
+				return style;
+			}
+
+			foreach (Match match in Regex.Matches(styleAttributes, @"\s*(?<prop>[\w-]+)\s*:\s*(?<value>[^;]+);?"))
+			{
+				string prop = match.Groups["prop"].Value.ToLowerInvariant();
+				string value = match.Groups["value"].Value.Trim();
+
+				switch (prop)
+				{
+					case "color":
+						if (ColorUtility.TryParseHtmlString(value, out Color parsed))
+						{
+							style.TextColor = parsed;
+						}
+						break;
+
+					case "font-size":
+						if (value.EndsWith("px") && float.TryParse(value.Replace("px", ""), out float px))
+						{
+							style.FontSize = Mathf.Clamp((int)px, 8, 48);
+						}
+						else if (value.EndsWith("%") && float.TryParse(value.Replace("%", ""), out float pct))
+						{
+							// Relative to the 12px body size the news classes use.
+							style.FontSize = Mathf.Clamp((int)(12f * pct / 100f), 8, 48);
+						}
+						break;
+
+					case "font-weight":
+						if (value == "bold" || value == "700" || value == "800" || value == "900")
+						{
+							style.Bold = true;
+						}
+						break;
+				}
+			}
+
+			return style;
+		}
+
+		/// <summary>
+		/// Adds a text run to the current row, as a clickable link when inside an anchor.
+		/// </summary>
+		private static void AppendText(string text, RenderContext context, InlineStyle style)
+		{
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				return;
+			}
+
+			// Collapse runs of whitespace the way HTML does. Without this, source indentation
+			// and newlines survive into the pane as visible gaps.
+			string collapsed = Regex.Replace(text, @"\s+", " ");
+			if (collapsed.Length == 0)
+			{
+				return;
+			}
+
+			Label label = new Label(collapsed);
+			bool isLink = !string.IsNullOrEmpty(style.Href);
+
+			label.AddToClassList(isLink ? "launcher-news__link" : (style.TextClass ?? TextClass));
+
+			if (style.Bold && style.Italic)
+			{
+				label.style.unityFontStyleAndWeight = FontStyle.BoldAndItalic;
+			}
+			else if (style.Bold)
+			{
+				label.style.unityFontStyleAndWeight = FontStyle.Bold;
+			}
+			else if (style.Italic)
+			{
+				label.style.unityFontStyleAndWeight = FontStyle.Italic;
+			}
+
+			if (style.Underline)
+			{
+				// UI Toolkit has no underline style property; a bottom border on the label is
+				// the closest equivalent that does not involve re-introducing markup parsing.
+				label.style.borderBottomWidth = 1;
+				label.style.borderBottomColor = style.TextColor ?? new Color(0.78f, 0.80f, 0.84f);
+			}
+
+			// An explicit colour must not override link colouring, or links stop looking
+			// clickable whenever the page styles its own text.
+			if (style.TextColor.HasValue && !isLink)
+			{
+				label.style.color = style.TextColor.Value;
+			}
+
+			if (style.FontSize.HasValue)
+			{
+				label.style.fontSize = style.FontSize.Value;
+			}
+
+			if (isLink)
+			{
+				string href = style.Href;
+				label.RegisterCallback<ClickEvent>(_ => context.OnLinkActivated?.Invoke(href));
+			}
+
+			EnsureRow(context).Add(label);
+			context.ElementCount++;
+		}
+
+		/// <summary>
+		/// Returns the row currently accumulating inline content, creating one if needed.
+		/// </summary>
+		private static VisualElement EnsureRow(RenderContext context)
+		{
+			if (context.CurrentRow == null)
+			{
+				context.CurrentRow = new VisualElement();
+				context.CurrentRow.AddToClassList("launcher-news__block");
+				context.CurrentRow.style.flexDirection = FlexDirection.Row;
+				context.CurrentRow.style.flexWrap = Wrap.Wrap;
+				context.Container.Add(context.CurrentRow);
+				context.ElementCount++;
+			}
+			return context.CurrentRow;
+		}
+
+		/// <summary>
+		/// Ends the current inline row so the next content starts on a new line. Discards the
+		/// row when nothing was added to it, so consecutive block tags do not stack up empty
+		/// containers and open a visible gap.
+		/// </summary>
+		private static void FlushRow(RenderContext context)
+		{
+			if (context.CurrentRow == null)
+			{
+				return;
+			}
+
+			if (context.CurrentRow.childCount == 0)
+			{
+				context.CurrentRow.RemoveFromHierarchy();
+				context.ElementCount--;
+			}
+
+			context.CurrentRow = null;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKHtmlContentRenderer.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Launcher/UITKHtmlContentRenderer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ca31a44f35a49c383306c17f9b42daf

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/ClientLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/ClientLauncher.cs
@@ -242,6 +242,23 @@ namespace FishMMO.Client
 		/// </summary>
 		public HttpPatchServerService PatchServerService => patchServerService;
 		/// <summary>
+		/// Optional view component that renders this launcher. Must implement
+		/// <see cref="ILauncherView"/>.
+		/// </summary>
+		/// <remarks>
+		/// Typed as <see cref="MonoBehaviour"/> because Unity cannot serialize an interface
+		/// reference. Leave unassigned to render through the legacy uGUI elements above; assign
+		/// a UI Toolkit view component to render through that instead. The fallback is what
+		/// keeps every existing scene working untouched.
+		/// </remarks>
+		[Tooltip("Optional. A component implementing ILauncherView. Leave empty to use the uGUI elements above.")]
+		[SerializeField]
+		private MonoBehaviour launcherViewComponent;
+		/// <summary>
+		/// The active view. Never null after <see cref="Awake"/>.
+		/// </summary>
+		private ILauncherView view;
+		/// <summary>
 		/// The updater launcher used to start the external updater process.
 		/// </summary>
 		private IUpdaterLauncher updaterLauncher;
@@ -282,6 +299,42 @@ namespace FishMMO.Client
 		/// supply one; in that case the download is not integrity-checked.
 		/// </summary>
 		private string expectedPatchSha256;
+		/// <summary>
+		/// Size in bytes of the patch for the current client version, as reported by the patch
+		/// server, or 0 when it did not supply one.
+		/// </summary>
+		/// <remarks>
+		/// Captured from the version check so the download can show a total from its first
+		/// frame instead of waiting on response headers.
+		/// </remarks>
+		private long expectedPatchSize;
+		/// <summary>
+		/// Guards the install-size measurement so it runs at most once per launcher session.
+		/// </summary>
+		private bool installSizeRequested;
+		/// <summary>
+		/// Window dimensions observed on the previous frame, used to detect a resize.
+		/// </summary>
+		private int lastKnownWidth;
+		private int lastKnownHeight;
+		/// <summary>
+		/// False until the first observed window size has been discarded as the one the
+		/// launcher itself requested rather than one the player chose.
+		/// </summary>
+		private bool windowSizeInitialised;
+		/// <summary>
+		/// True when a resize has been observed but not yet written to settings.
+		/// </summary>
+		private bool windowSizeDirty;
+		/// <summary>
+		/// <see cref="Time.realtimeSinceStartup"/> of the most recent resize.
+		/// </summary>
+		private float lastResizeTime;
+		/// <summary>
+		/// Seconds a window size must hold steady before it is persisted, so one drag-resize
+		/// costs one write rather than one per frame.
+		/// </summary>
+		private const float WindowSizeSaveDelay = 0.75f;
 		/// <summary>
 		/// Base URL of the APIHost candidate that responded successfully during the
 		/// most recent version check. Used so that the subsequent patch download
@@ -365,6 +418,14 @@ namespace FishMMO.Client
 		/// </summary>
 		private void Awake()
 		{
+			// Before anything reads a setting. The launcher is the first thing to run, so
+			// nothing else has loaded the configuration file by this point.
+			LauncherSettings.EnsureLoaded();
+
+			// Resolved first so that even the fatal-dependency path below has somewhere to
+			// report to. A player who hits that path has no access to the log file.
+			this.view = ResolveView();
+
 			// SystemUpdaterLauncher is a plain C# class, directly instantiate it
 			this.updaterLauncher = new SystemUpdaterLauncher();
 
@@ -376,38 +437,18 @@ namespace FishMMO.Client
 				this.htmlContentFetcher.WebRequestService == null || this.patchServerService.WebRequestService == null)
 			{
 				Log.Error("ClientLauncher", "One or more required service dependencies are not assigned in the Inspector or are missing!");
-				if (this.PlayButtonText != null)
-				{
-					this.PlayButtonText.text = "Fatal Error";
-				}
-				if (this.PlayButton != null)
-				{
-					this.PlayButton.interactable = false;
-				}
-				// Surface the reason rather than only logging it — a player hitting this
-				// has no access to the log file.
-				if (this.ProgressSlider != null)
-				{
-					this.ProgressSlider.gameObject.SetActive(false);
-				}
-				ShowStatusPanel("The launcher is missing required components and cannot start. Please reinstall the client.");
+				this.view.SetButtonText("Fatal Error");
+				this.view.SetButtonInteractable(false);
+				this.view.SetProgressVisible(false);
+				this.view.ShowStatus("The launcher is missing required components and cannot start. Please reinstall the client.");
 				enabled = false; // Disable this script if dependencies aren't met
 				return;
-			}
-
-			if (this.HtmlTextLinkHandler != null)
-			{
-				this.HtmlTextLinkHandler.OnLinkClicked += HandleHtmlLinkClicked;
 			}
 
 			// Wire Quit in code. The scene's persistent UnityEvent listener had a null
 			// target, so the button silently did nothing; a code-side listener cannot be
 			// broken by a scene re-save.
-			if (this.QuitButton != null)
-			{
-				this.QuitButton.onClick.RemoveAllListeners();
-				this.QuitButton.onClick.AddListener(Quit);
-			}
+			this.view.SetQuitAction(Quit);
 
 			// Catch-all so no async failure can leave the player on a dead button.
 			StartCoroutine(TransientStateWatchdog());
@@ -430,27 +471,19 @@ namespace FishMMO.Client
 			if (string.IsNullOrWhiteSpace(this.HtmlViewURL))
 			{
 				Log.Debug("ClientLauncher", "No launcher news URL configured; skipping the news fetch.");
-				if (this.HTMLView != null)
-				{
-					this.HTMLView.SetActive(false);
-				}
+				this.view.SetNewsVisible(false);
 			}
 			else
 			{
-				if (this.HtmlText != null)
-				{
-					this.HtmlText.text = UIText.StatusLoadingNews;
-				}
+				this.view.SetNewsVisible(true);
+				this.view.SetNewsMessage(UIText.StatusLoadingNews);
 
-				StartCoroutine(this.htmlContentFetcher.FetchAndProcessHtml(
+				StartCoroutine(this.htmlContentFetcher.FetchAndExtract(
 					this.HtmlViewURL,
 					this.DivClass,
-					onHtmlReady: (htmlContent) =>
+					onContentReady: (content) =>
 					{
-						if (this.HtmlText != null)
-						{
-							this.HtmlText.text = htmlContent;
-						}
+						this.view.SetNewsContent(content);
 					},
 					onError: (error) =>
 					{
@@ -458,10 +491,7 @@ namespace FishMMO.Client
 						// thinking the game servers are down. If the network really is down, the
 						// version check reports that accurately on its own.
 						Log.Warning("ClientLauncher", $"{UIText.ErrorLoadingNews}{error}");
-						if (this.HtmlText != null)
-						{
-							this.HtmlText.text = UIText.ErrorNoNewsContent;
-						}
+						this.view.SetNewsMessage(UIText.ErrorNoNewsContent);
 					}));
 			}
 
@@ -469,15 +499,13 @@ namespace FishMMO.Client
 			this.updaterPath = Path.Combine(Constants.GetWorkingDirectory(), Constants.Configuration.UpdaterExecutable);
 
 #if !UNITY_EDITOR
-			// Set screen resolution for non-editor builds
-			try { Screen.SetResolution(this.DefaultScreenWidth, this.DefaultScreenHeight, FullScreenMode.Windowed, Screen.currentResolution.refreshRateRatio); }
-			catch { Screen.SetResolution(this.DefaultScreenWidth, this.DefaultScreenHeight, FullScreenMode.Windowed, new RefreshRate() { numerator = 60, denominator = 1 }); }
+			ApplyWindowSize();
 #endif
 			string versionString = !string.IsNullOrEmpty(MainBootstrapSystem.GameVersion)
 				? MainBootstrapSystem.GameVersion
 				: "0.0.0-unknown";
-			this.Title.text = $"{Constants.Configuration.ProjectName} v{versionString}";
-			this.ProgressBarGroup.SetActive(false); // Ensure progress bar is hidden initially.
+			this.view.SetTitle($"{Constants.Configuration.ProjectName} v{versionString}");
+			this.view.SetProgressVisible(false); // Ensure progress bar is hidden initially.
 
 			/* Last, so the version check never observes a half-initialised launcher.
 			 *
@@ -489,6 +517,132 @@ namespace FishMMO.Client
 			 * decoupling it from the news fetch was to stop waiting on a network round trip, not
 			 * to run before Awake has finished. */
 			BeginStartupFlow();
+		}
+
+		/// <summary>
+		/// Smallest window the launcher layout stays usable at. Mirrors the min-width and
+		/// min-height in UILauncher.uss — below this the footer buttons start to be squeezed.
+		/// </summary>
+		private const int MinWindowWidth = 480;
+		private const int MinWindowHeight = 360;
+
+		/// <summary>
+		/// Opens the launcher at the size the player last used, or the configured default the
+		/// first time.
+		/// </summary>
+		/// <remarks>
+		/// The window is resizable, so pinning it to a fixed size on every launch would undo
+		/// the player's choice each time. The stored size is clamped against the current
+		/// display by <see cref="LauncherSettings.GetWindowSize"/>, which matters when a window
+		/// saved on a larger monitor is restored on a smaller one.
+		/// </remarks>
+		private void ApplyWindowSize()
+		{
+			Vector2Int stored = LauncherSettings.GetWindowSize(MinWindowWidth, MinWindowHeight);
+			int width = stored.x > 0 ? stored.x : this.DefaultScreenWidth;
+			int height = stored.y > 0 ? stored.y : this.DefaultScreenHeight;
+
+			try
+			{
+				Screen.SetResolution(width, height, FullScreenMode.Windowed, Screen.currentResolution.refreshRateRatio);
+			}
+			catch
+			{
+				// Some display configurations report a refresh rate SetResolution rejects.
+				Screen.SetResolution(width, height, FullScreenMode.Windowed, new RefreshRate() { numerator = 60, denominator = 1 });
+			}
+		}
+
+		/// <summary>
+		/// Records the window size when the player changes it, so the next launch reopens at
+		/// the same dimensions.
+		/// </summary>
+		/// <remarks>
+		/// Written shortly after the resize settles rather than on quit: the updater terminates
+		/// this process to apply a patch, so a launcher that is killed rather than closed would
+		/// never persist anything saved at shutdown.
+		/// <para>
+		/// Debounced because a drag-resize changes the window size every frame, and writing the
+		/// configuration file per frame would mean hundreds of disk writes for one gesture.
+		/// </para>
+		/// </remarks>
+		private void Update()
+		{
+			if (Screen.width != this.lastKnownWidth || Screen.height != this.lastKnownHeight)
+			{
+				this.lastKnownWidth = Screen.width;
+				this.lastKnownHeight = Screen.height;
+
+				// The first observed size is the one this launcher just asked for, not one the
+				// player chose. Recording it would overwrite a stored size with the default.
+				if (!this.windowSizeInitialised)
+				{
+					this.windowSizeInitialised = true;
+					return;
+				}
+
+				this.windowSizeDirty = true;
+				this.lastResizeTime = Time.realtimeSinceStartup;
+				return;
+			}
+
+			if (!this.windowSizeDirty)
+			{
+				return;
+			}
+			if (Time.realtimeSinceStartup - this.lastResizeTime < WindowSizeSaveDelay)
+			{
+				return;
+			}
+
+			this.windowSizeDirty = false;
+
+			// Only windowed dimensions are worth remembering; a maximised or full-screen size
+			// is the display's, not a size the player picked for this window.
+			if (Screen.fullScreenMode != FullScreenMode.Windowed)
+			{
+				return;
+			}
+
+			LauncherSettings.SetWindowSize(this.lastKnownWidth, this.lastKnownHeight);
+			LauncherSettings.Save();
+		}
+
+		/// <summary>
+		/// Returns the view this launcher should render through: the assigned view component
+		/// when one implements <see cref="ILauncherView"/>, otherwise an adapter over the
+		/// legacy uGUI elements serialized on this component.
+		/// </summary>
+		private ILauncherView ResolveView()
+		{
+			if (this.launcherViewComponent is ILauncherView assigned)
+			{
+				return assigned;
+			}
+
+			if (this.launcherViewComponent != null)
+			{
+				Log.Error("ClientLauncher", $"Assigned launcher view '{this.launcherViewComponent.GetType().Name}' does not implement ILauncherView. Falling back to the uGUI view.");
+			}
+
+			// The size factor lives on the fetcher so the scene keeps its configured value.
+			// Guarded because this runs before the dependency check, on the path where the
+			// fetcher may be exactly what is missing.
+			float pxToTmpSizeFactor = this.htmlContentFetcher != null ? this.htmlContentFetcher.HtmlPxToTmpSizeFactor : 1.5f;
+
+			return new UGUILauncherView(
+				this.title,
+				this.htmlView,
+				this.progressBarGroup,
+				this.progressSlider,
+				this.progressText,
+				this.quitButton,
+				this.playButton,
+				this.playButtonText,
+				this.htmlText,
+				this.htmlTextLinkHandler,
+				this.statusText,
+				pxToTmpSizeFactor);
 		}
 
 		/// <summary>
@@ -509,41 +663,23 @@ namespace FishMMO.Client
 		/// </summary>
 		private void OnDestroy()
 		{
-			if (this.HtmlTextLinkHandler != null)
-			{
-				this.HtmlTextLinkHandler.OnLinkClicked -= HandleHtmlLinkClicked;
-			}
-			if (this.QuitButton != null)
-			{
-				this.QuitButton.onClick.RemoveListener(Quit);
-			}
+			// Null when Awake bailed before resolving a view.
+			this.view?.Teardown();
 		}
 		#endregion
 
 		#region UI STATE MANAGEMENT
 		/// <summary>
-		/// True when status messages have to borrow <see cref="ProgressText"/> because no
-		/// dedicated <see cref="StatusText"/> element is assigned. In that case the
-		/// containing progress group must be made visible for the message to be seen.
-		/// </summary>
-		private bool UsesProgressTextForStatus => this.StatusText == null && this.ProgressText != null;
-
-		/// <summary>
-		/// Writes a human-readable status or error message to the player-facing UI.
-		/// Prefers <see cref="StatusText"/> when assigned; falls back to
-		/// <see cref="ProgressText"/> so messages are visible even without a
-		/// dedicated status element. Also logs the message.
+		/// Logs a human-readable status or error message and hands it to the view to display.
 		/// </summary>
 		/// <remarks>
-		/// When falling back to <see cref="ProgressText"/>, this also forces
-		/// <see cref="ProgressBarGroup"/> active. That element is the progress text's
-		/// parent, and the state machine hides the group for every non-download state — so
-		/// without this every error detail was written to an inactive object and the player
-		/// saw nothing but a two-word button label.
+		/// Always logs so operators can correlate what the player saw with the log file. How
+		/// the message is made visible is the view's problem — that used to be decided here,
+		/// which meant one view's quirk (no dedicated status element, so the progress label
+		/// gets borrowed and its parent group forced active) was baked into shared logic.
 		/// </remarks>
 		private void SetStatus(string message, LogLevel level = LogLevel.Info)
 		{
-			// Always log so operators can correlate.
 			switch (level)
 			{
 				case LogLevel.Warning:
@@ -558,49 +694,7 @@ namespace FishMMO.Client
 					break;
 			}
 
-			ShowStatusPanel(message);
-		}
-
-		/// <summary>
-		/// Displays <paramref name="message"/> on the player-facing status element and
-		/// ensures whatever container it lives in is visible. Does not log — callers that
-		/// want logging use <see cref="SetStatus"/>.
-		/// </summary>
-		private void ShowStatusPanel(string message)
-		{
-			TMP_Text target = this.StatusText != null ? this.StatusText : this.ProgressText;
-			if (target == null)
-			{
-				return;
-			}
-
-			target.text = message;
-
-			if (this.StatusText != null)
-			{
-				this.StatusText.gameObject.SetActive(true);
-				return;
-			}
-
-			// Borrowing the progress text: reveal its group, but keep the slider hidden so
-			// a message is not mistaken for a stalled progress bar. The slider is
-			// re-enabled by SetLauncherState for genuine progress states.
-			if (this.ProgressBarGroup != null)
-			{
-				this.ProgressBarGroup.SetActive(true);
-			}
-		}
-
-		/// <summary>
-		/// Clears the status text so stale error messages don't linger.
-		/// </summary>
-		private void ClearStatus()
-		{
-			TMP_Text target = this.StatusText != null ? this.StatusText : this.ProgressText;
-			if (target != null)
-			{
-				target.text = string.Empty;
-			}
+			this.view.ShowStatus(message);
 		}
 
 		/// <summary>
@@ -636,7 +730,6 @@ namespace FishMMO.Client
 		{
 			this.currentLauncherState = newState;
 			this.lastStateActivityTime = Time.realtimeSinceStartup;
-			this.PlayButton.onClick.RemoveAllListeners(); // Always clear to ensure only one listener.
 
 			bool isButtonInteractable = false;
 			string buttonText = "";
@@ -654,6 +747,11 @@ namespace FishMMO.Client
 					break;
 				case LauncherState.CheckingVersion:
 					buttonText = UIText.StatusCheckingVersion;
+					break;
+				case LauncherState.UpdateAvailable:
+					buttonText = UIText.ButtonUpdate;
+					isButtonInteractable = true;
+					buttonAction = PlayButtonUpdate;
 					break;
 				case LauncherState.DownloadingPatch:
 					buttonText = UIText.StatusDownloadingPatch;
@@ -738,28 +836,16 @@ namespace FishMMO.Client
 					break;
 			}
 
-			this.PlayButtonText.text = buttonText;
-			this.PlayButton.interactable = isButtonInteractable;
+			this.view.SetButtonText(buttonText);
+			this.view.SetButtonInteractable(isButtonInteractable);
+			// Replaces whatever the previous state attached, so the button never carries more
+			// than the action belonging to the state currently displayed.
+			this.view.SetButtonAction(buttonAction);
 
 			// Fall back to a standard explanation so no state can present a bare label.
 			string detail = !string.IsNullOrEmpty(errorDetail) ? errorDetail : GetDefaultDetail(newState);
 
-			// The progress group has to stay visible whenever it is carrying a status
-			// message, not only during a download — otherwise the message is written to an
-			// inactive object. The slider inside it is shown only for real progress.
-			bool groupVisible = progressBarVisible || (UsesProgressTextForStatus && !string.IsNullOrEmpty(detail));
-			if (this.ProgressBarGroup != null)
-			{
-				this.ProgressBarGroup.SetActive(groupVisible);
-			}
-			if (this.ProgressSlider != null)
-			{
-				this.ProgressSlider.gameObject.SetActive(progressBarVisible);
-				if (!progressBarVisible)
-				{
-					this.ProgressSlider.value = 0f;
-				}
-			}
+			this.view.SetProgressVisible(progressBarVisible);
 
 			// Display error/status detail to the player when available.
 			if (!string.IsNullOrEmpty(detail))
@@ -768,13 +854,37 @@ namespace FishMMO.Client
 			}
 			else
 			{
-				ClearStatus();
+				this.view.ClearStatus();
 			}
 
-			if (buttonAction != null)
+			MeasureInstallSizeWhenIdle(newState);
+		}
+
+		/// <summary>
+		/// Kicks off the install-size measurement once the launcher has settled.
+		/// </summary>
+		/// <remarks>
+		/// Deliberately not started in Awake. Walking a full client install is tens of
+		/// thousands of stat calls, and doing it while the version check or a patch download is
+		/// in flight puts it in direct contention with them for disk — slowing the thing the
+		/// player is actually waiting on to populate a readout they are not yet looking at.
+		/// Idle states only, and only once per run.
+		/// </remarks>
+		private void MeasureInstallSizeWhenIdle(LauncherState state)
+		{
+			if (this.installSizeRequested)
 			{
-				this.PlayButton.onClick.AddListener(() => buttonAction.Invoke());
+				return;
 			}
+			if (state != LauncherState.ReadyToPlay && state != LauncherState.UpdateAvailable)
+			{
+				return;
+			}
+
+			this.installSizeRequested = true;
+			StartCoroutine(InstallSizeProbe.Measure(
+				Constants.GetWorkingDirectory(),
+				sizeBytes => this.view.SetInstallSize(sizeBytes)));
 		}
 
 		/// <summary>
@@ -841,34 +951,6 @@ namespace FishMMO.Client
 
 		#region UI INTERACTION HANDLERS (Delegate actions to services)
 		/// <summary>
-		/// Handles clicks on links embedded within the HTML news text.
-		/// Opens external URLs in the default web browser.
-		/// </summary>
-		/// <param name="link">The URL string extracted from the clicked link.</param>
-		private void HandleHtmlLinkClicked(string link)
-		{
-			// Strict URI parsing + scheme allowlist. The previous substring check would
-			// happily open "javascript:...", "file://...", or anything containing the
-			// literal string "http" (e.g. "chrome-http-pwn://...") through the OS URL
-			// handler. Restrict to absolute http(s) URIs only.
-			if (string.IsNullOrWhiteSpace(link))
-			{
-				return;
-			}
-			if (!Uri.TryCreate(link, UriKind.Absolute, out Uri uri))
-			{
-				Log.Warning("ClientLauncher", $"Refusing to open non-absolute link: {link}");
-				return;
-			}
-			if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
-			{
-				Log.Warning("ClientLauncher", $"Refusing to open link with disallowed scheme '{uri.Scheme}': {link}");
-				return;
-			}
-			Application.OpenURL(uri.AbsoluteUri);
-		}
-
-		/// <summary>
 		/// Initiates the connection process to check for game updates.
 		/// All requests go through the unified API gateway (Constants.Configuration.APIHost).
 		/// </summary>
@@ -890,10 +972,9 @@ namespace FishMMO.Client
 			{
 				this.isLaunching = true;
 				SetLauncherState(LauncherState.ReadyToPlay);
-				if (this.PlayButton != null)
-				{
-					this.PlayButton.interactable = false;
-				}
+				// ReadyToPlay leaves the button enabled; disable it now that the launch is
+				// actually under way so it cannot be pressed twice.
+				this.view.SetButtonInteractable(false);
 
 				// A retry after a failed launch would otherwise dead-end: EnqueueLoad
 				// silently no-ops when the scene is already tracked as loaded, so
@@ -1036,13 +1117,15 @@ namespace FishMMO.Client
 
 			SetLauncherState(LauncherState.DownloadingPatch);
 
-			/* The patch must land where the Updater will look for it. The Updater resolves
-			 * <install root>/Patches/<from>-<to>.zip from its own base directory and will
-			 * not search anywhere else — if the archive is not at exactly this path it
-			 * reports "patch file not found", relaunches the client unchanged, and the
-			 * launcher detects the same version mismatch again on the next run. */
+			/* The patch must land where the Updater will look for it. Both sides used to
+			 * derive <install root>/Patches independently and agree only by convention; the
+			 * directory is now resolved once here and handed to the Updater explicitly,
+			 * because a disagreement fails silently — the Updater reports "patch file not
+			 * found", relaunches the client unchanged, and the launcher detects the same
+			 * version mismatch again on the next run, forever. */
+			string patchesDirectory = LauncherSettings.ResolvePatchDirectory(Constants.GetPatchesDirectory());
 			string patchFilePath = Path.Combine(
-				Constants.GetPatchesDirectory(),
+				patchesDirectory,
 				Constants.GetPatchFileName(MainBootstrapSystem.GameVersion, this.latestVersionString));
 
 			// Use the APIHost that succeeded during the version check so the patch we
@@ -1058,6 +1141,7 @@ namespace FishMMO.Client
 				$"{patchApiHost}{MainBootstrapSystem.GameVersion}",
 				patchFilePath,
 				this.expectedPatchSha256,
+				this.expectedPatchSize,
 				onComplete: (patchWritten) =>
 				{
 					if (!patchWritten)
@@ -1080,6 +1164,7 @@ namespace FishMMO.Client
 						this.updaterPath,
 						MainBootstrapSystem.GameVersion,
 						this.latestVersionString,
+						patchesDirectory,
 						onComplete: () =>
 						{
 							// The updater is running and owns the install; it will terminate
@@ -1102,20 +1187,13 @@ namespace FishMMO.Client
 					// Attempt to clean up any partially downloaded file if an error occurs.
 					TryDeletePatchFile(patchFilePath);
 				},
-				onProgress: (progress, progressString) =>
+				onProgress: (stats) =>
 				{
 					// Heartbeat: a large patch on a slow link must not trip the transient
 					// state watchdog while it is genuinely still downloading.
 					this.lastStateActivityTime = Time.realtimeSinceStartup;
 
-					if (this.ProgressSlider != null)
-					{
-						this.ProgressSlider.value = progress;
-					}
-					if (this.ProgressText != null)
-					{
-						this.ProgressText.text = progressString;
-					}
+					this.view.SetProgress(stats);
 				}));
 		}
 
@@ -1186,14 +1264,14 @@ namespace FishMMO.Client
 					 * still working through hosts. */
 					this.lastStateActivityTime = Time.realtimeSinceStartup;
 
-					/* Written to the button label rather than through SetStatus: that falls back
-					 * to ProgressText when StatusText is unassigned (it is), and ProgressText
-					 * sits inside ProgressBarGroup, which this state deactivates — so the
-					 * message would render to a hidden object. The button label is the one
-					 * status surface guaranteed to be visible here. */
-					if (candidates.Count > 1 && this.PlayButtonText != null)
+					/* Written to the button label rather than through SetStatus. On the uGUI
+					 * view a status message falls back to the progress label, which sits inside
+					 * the progress group this state hides — so the message would render to a
+					 * hidden object. The button label is the one status surface every view is
+					 * guaranteed to be showing here. */
+					if (candidates.Count > 1)
 					{
-						this.PlayButtonText.text = $"{UIText.StatusCheckingVersion} ({i + 1}/{candidates.Count})";
+						this.view.SetButtonText($"{UIText.StatusCheckingVersion} ({i + 1}/{candidates.Count})");
 					}
 
 					yield return StartCoroutine(this.patchServerService.GetLatestVersion(
@@ -1240,6 +1318,7 @@ namespace FishMMO.Client
 				this.selectedApiHost = successfulHost;
 				this.latestVersionString = serverVersion.FullVersion; // Store for updater launch
 				this.expectedPatchSha256 = patchInfo.Sha256; // May be null/empty when not provided.
+				this.expectedPatchSize = patchInfo.Size; // May be 0 when not provided.
 				Log.Debug("ClientLauncher", string.Format(UIText.LogDebugLatestServerVersion, latestVersionString));
 
 				// VersionConfig.Parse returns null for malformed input rather than throwing,
@@ -1278,7 +1357,21 @@ namespace FishMMO.Client
 						yield break;
 					}
 
-					PlayButtonUpdate();
+					if (LauncherSettings.AutoUpdate)
+					{
+						PlayButtonUpdate();
+					}
+					else
+					{
+						// The player asked to be consulted. Park on an Update button rather
+						// than starting a download they have not agreed to — which on a metered
+						// connection is the difference between a convenience and a cost.
+						string sizeNote = this.expectedPatchSize > 0
+							? $" ({DownloadStats.FormatBytes((ulong)this.expectedPatchSize)})"
+							: string.Empty;
+						SetLauncherState(LauncherState.UpdateAvailable,
+							$"Version {this.latestVersionString} is available{sizeNote}. Press Update to download it.");
+					}
 #endif
 				}
 				else if (clientVersion > serverVersion)

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadRateTracker.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadRateTracker.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Measures transfer rate over a trailing time window and estimates remaining time.
+	/// </summary>
+	/// <remarks>
+	/// A sliding window rather than a cumulative average. Dividing total bytes by total elapsed
+	/// time keeps reporting a healthy rate for minutes after a transfer has actually stalled,
+	/// because the historical average drags the number up — which is exactly when the player
+	/// most needs to be told something is wrong. A trailing window converges on zero within
+	/// <see cref="windowSeconds"/> of the last byte arriving.
+	/// <para>
+	/// Time is supplied by the caller rather than read from <c>UnityEngine.Time</c> so this
+	/// class stays independent of the engine clock and can be exercised directly.
+	/// </para>
+	/// </remarks>
+	public class DownloadRateTracker
+	{
+		/// <summary>
+		/// One observation of cumulative bytes at a point in time.
+		/// </summary>
+		private readonly struct RateSample
+		{
+			public readonly float Time;
+			public readonly ulong Bytes;
+
+			public RateSample(float time, ulong bytes)
+			{
+				this.Time = time;
+				this.Bytes = bytes;
+			}
+		}
+
+		/// <summary>
+		/// Length of the trailing window, in seconds.
+		/// </summary>
+		/// <remarks>
+		/// Long enough to smooth the per-frame jitter of a chunked HTTP transfer, short enough
+		/// that a stall shows up while the player is still looking at it.
+		/// </remarks>
+		private readonly float windowSeconds;
+
+		/// <summary>
+		/// Observations inside the window, oldest first.
+		/// </summary>
+		private readonly Queue<RateSample> samples = new Queue<RateSample>();
+
+		/// <summary>
+		/// Most recent rate in bytes per second, or 0 before enough samples exist.
+		/// </summary>
+		public double BytesPerSecond { get; private set; }
+
+		public DownloadRateTracker(float windowSeconds = 3f)
+		{
+			this.windowSeconds = windowSeconds > 0f ? windowSeconds : 3f;
+		}
+
+		/// <summary>
+		/// Discards all history. Call before starting a new transfer so a previous download's
+		/// rate cannot be attributed to it.
+		/// </summary>
+		public void Reset()
+		{
+			this.samples.Clear();
+			this.BytesPerSecond = 0;
+		}
+
+		/// <summary>
+		/// Records an observation and recomputes the rate.
+		/// </summary>
+		/// <param name="time">Monotonic timestamp in seconds.</param>
+		/// <param name="bytesDownloaded">Cumulative bytes received so far.</param>
+		public void Sample(float time, ulong bytesDownloaded)
+		{
+			this.samples.Enqueue(new RateSample(time, bytesDownloaded));
+
+			// Retain one sample older than the window so the span always covers the full
+			// window. Dropping everything outside it would shrink the measured interval to the
+			// gap between the two newest samples, which on a fast frame is near zero and
+			// produces an absurd rate.
+			while (this.samples.Count > 2 && time - this.samples.Peek().Time > this.windowSeconds)
+			{
+				this.samples.Dequeue();
+			}
+
+			if (this.samples.Count < 2)
+			{
+				this.BytesPerSecond = 0;
+				return;
+			}
+
+			RateSample oldest = this.samples.Peek();
+			float elapsed = time - oldest.Time;
+			if (elapsed <= 0f)
+			{
+				return;
+			}
+
+			// Unsigned arithmetic: a server that restarts a transfer can report fewer bytes
+			// than a previous sample, and the wraparound would otherwise produce an enormous
+			// rate rather than zero.
+			ulong delta = bytesDownloaded >= oldest.Bytes ? bytesDownloaded - oldest.Bytes : 0UL;
+			this.BytesPerSecond = delta / elapsed;
+		}
+
+		/// <summary>
+		/// Estimates seconds until completion, or null when it cannot be estimated.
+		/// </summary>
+		/// <param name="bytesDownloaded">Cumulative bytes received so far.</param>
+		/// <param name="totalBytes">Expected total, or 0 when unknown.</param>
+		/// <remarks>
+		/// Returns null rather than a large number when the rate is zero. An estimate derived
+		/// from a stalled transfer is not a long estimate, it is no estimate — and showing one
+		/// implies progress that is not happening.
+		/// </remarks>
+		public double? EstimateSecondsRemaining(ulong bytesDownloaded, long totalBytes)
+		{
+			if (totalBytes <= 0 || this.BytesPerSecond <= 0)
+			{
+				return null;
+			}
+
+			ulong total = (ulong)totalBytes;
+			if (bytesDownloaded >= total)
+			{
+				return 0;
+			}
+
+			return (total - bytesDownloaded) / this.BytesPerSecond;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadRateTracker.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadRateTracker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6915947b0ab406e8e5bfbed0b7aedaf

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadStats.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadStats.cs
@@ -1,0 +1,153 @@
+using System;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// A snapshot of an in-progress download, passed to the active
+	/// <see cref="ILauncherView"/> so it can present transfer state.
+	/// </summary>
+	/// <remarks>
+	/// Structured rather than a preformatted string. The download path used to hand the UI
+	/// <c>"42% (12.1 MB)"</c>, which forced every view to display exactly what the service had
+	/// decided to say and made anything richer — a rate, a remaining time, a total — impossible
+	/// without changing the service.
+	/// <para>
+	/// <see cref="TotalBytes"/> and <see cref="BytesPerSecond"/> are both optional, and callers
+	/// must treat them as such: the total is only known when the server supplied one, and no
+	/// rate exists until enough samples have accumulated to measure it.
+	/// </para>
+	/// </remarks>
+	public readonly struct DownloadStats
+	{
+		/// <summary>
+		/// Bytes received so far.
+		/// </summary>
+		public readonly ulong BytesDownloaded;
+
+		/// <summary>
+		/// Total bytes expected, or 0 when the server did not report a size.
+		/// </summary>
+		/// <remarks>
+		/// Sourced from the version manifest's <see cref="PatchInfo.Size"/> rather than from
+		/// the response, so it is known before the first byte arrives and the UI can open on
+		/// "0 B of 240 MB" instead of a bare "0%".
+		/// </remarks>
+		public readonly long TotalBytes;
+
+		/// <summary>
+		/// Current transfer rate in bytes per second, or 0 when not yet measurable.
+		/// </summary>
+		public readonly double BytesPerSecond;
+
+		/// <summary>
+		/// Estimated seconds until completion, or null when it cannot be estimated —
+		/// no known total, or no measurable rate.
+		/// </summary>
+		public readonly double? EstimatedSecondsRemaining;
+
+		/// <summary>
+		/// Progress from 0 to 1 as reported by the transfer.
+		/// </summary>
+		public readonly float NormalizedProgress;
+
+		/// <summary>
+		/// True when the transfer has finished and the remaining work is verification.
+		/// </summary>
+		public readonly bool IsComplete;
+
+		public DownloadStats(
+			ulong bytesDownloaded,
+			long totalBytes,
+			double bytesPerSecond,
+			double? estimatedSecondsRemaining,
+			float normalizedProgress,
+			bool isComplete = false)
+		{
+			this.BytesDownloaded = bytesDownloaded;
+			this.TotalBytes = totalBytes;
+			this.BytesPerSecond = bytesPerSecond;
+			this.EstimatedSecondsRemaining = estimatedSecondsRemaining;
+			this.NormalizedProgress = normalizedProgress;
+			this.IsComplete = isComplete;
+		}
+
+		/// <summary>
+		/// True when a total size is known, and therefore when "x of y" and a remaining time
+		/// are meaningful.
+		/// </summary>
+		public bool HasTotal => this.TotalBytes > 0;
+
+		/// <summary>
+		/// Formats a byte count as a human-readable string (for example "1.2 MB").
+		/// </summary>
+		public static string FormatBytes(ulong bytes)
+		{
+			if (bytes < 1024UL) return $"{bytes} B";
+			if (bytes < 1024UL * 1024UL) return $"{bytes / 1024.0:F1} KB";
+			if (bytes < 1024UL * 1024UL * 1024UL) return $"{bytes / (1024.0 * 1024.0):F1} MB";
+			return $"{bytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
+		}
+
+		/// <summary>
+		/// Formats a duration as a compact human-readable string (for example "3m 20s").
+		/// </summary>
+		/// <remarks>
+		/// Deliberately coarse. A remaining time derived from a fluctuating transfer rate is an
+		/// estimate, and rendering it to the second invites the player to watch it jitter.
+		/// </remarks>
+		public static string FormatDuration(double seconds)
+		{
+			if (double.IsNaN(seconds) || double.IsInfinity(seconds) || seconds < 0)
+			{
+				return "--";
+			}
+			if (seconds < 60)
+			{
+				return $"{Math.Max(1, (int)Math.Round(seconds))}s";
+			}
+			if (seconds < 3600)
+			{
+				int minutes = (int)(seconds / 60);
+				int remainder = (int)(seconds % 60);
+				return $"{minutes}m {remainder}s";
+			}
+
+			int hours = (int)(seconds / 3600);
+			int mins = (int)((seconds % 3600) / 60);
+			return $"{hours}h {mins}m";
+		}
+
+		/// <summary>
+		/// Builds the player-facing progress line, including only the parts that are actually
+		/// known.
+		/// </summary>
+		/// <remarks>
+		/// Shared by both views so they cannot drift into describing the same download
+		/// differently. Anything unknown is omitted rather than shown as a zero — a rate of
+		/// "0 B/s" on a transfer that simply has not been measured yet reads as a stall.
+		/// </remarks>
+		public string ToDisplayString()
+		{
+			if (this.IsComplete)
+			{
+				return this.HasTotal
+					? $"{FormatBytes((ulong)this.TotalBytes)} — verifying"
+					: "Verifying";
+			}
+
+			string transferred = this.HasTotal
+				? $"{FormatBytes(this.BytesDownloaded)} of {FormatBytes((ulong)this.TotalBytes)}"
+				: FormatBytes(this.BytesDownloaded);
+
+			string rate = this.BytesPerSecond > 0
+				? $"  •  {FormatBytes((ulong)this.BytesPerSecond)}/s"
+				: string.Empty;
+
+			string eta = this.EstimatedSecondsRemaining.HasValue
+				? $"  •  {FormatDuration(this.EstimatedSecondsRemaining.Value)} left"
+				: string.Empty;
+
+			return transferred + rate + eta;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadStats.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/DownloadStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 369e24e92eb943a28fdc1b75d87768f6

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/HtmlToTmpTextConverter.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/HtmlToTmpTextConverter.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Converts a parsed HTML fragment into TextMeshPro rich text.
+	/// </summary>
+	/// <remarks>
+	/// Previously lived inside <see cref="UnityHtmlContentFetcher"/>. It moved here when the
+	/// fetcher stopped producing a formatted string and started handing the parsed node to the
+	/// active view: this output format belongs to the TextMeshPro view specifically, and the
+	/// UI Toolkit view builds elements instead. Fetching and formatting are now separate
+	/// concerns because there is more than one target format.
+	/// </remarks>
+	public static class HtmlToTmpTextConverter
+	{
+		/// <summary>
+		/// Maximum recursion depth when converting HTML nodes, to prevent a stack overflow from
+		/// deeply nested input. The news document comes from an operator-configured URL, so its
+		/// nesting depth is not something this client controls.
+		/// </summary>
+		private const int MaxRecursionDepth = 100;
+
+		/// <summary>
+		/// Converts every child of <paramref name="root"/> into a single TMP rich text string.
+		/// </summary>
+		/// <param name="root">The extracted news fragment.</param>
+		/// <param name="pxToTmpSizeFactor">Approximate conversion factor from HTML pixels to TMP font size.</param>
+		/// <returns>TMP rich text, or an empty string when <paramref name="root"/> is null.</returns>
+		public static string Convert(HtmlNode root, float pxToTmpSizeFactor)
+		{
+			if (root == null)
+			{
+				return string.Empty;
+			}
+
+			StringBuilder sb = new StringBuilder();
+			foreach (HtmlNode childNode in root.ChildNodes)
+			{
+				if (childNode.NodeType == HtmlNodeType.Element || childNode.NodeType == HtmlNodeType.Text)
+				{
+					sb.Append(ConvertNode(childNode, pxToTmpSizeFactor));
+				}
+			}
+			return sb.ToString().Trim();
+		}
+
+		/// <summary>
+		/// Recursively converts an <see cref="HtmlNode"/> into a TextMeshPro rich text string.
+		/// Handles block elements, inline styles, and links.
+		/// </summary>
+		private static string ConvertNode(HtmlNode node, float pxToTmpSizeFactor, int depth = 0)
+		{
+			if (depth > MaxRecursionDepth)
+			{
+				Log.Warning("HtmlToTmpTextConverter", $"Maximum recursion depth ({MaxRecursionDepth}) exceeded. Truncating HTML conversion.");
+				return string.Empty;
+			}
+			StringBuilder sb = new StringBuilder();
+
+			if (node.NodeType == HtmlNodeType.Text)
+			{
+				return WebUtility.HtmlDecode(node.InnerText);
+			}
+
+			if (node.NodeType == HtmlNodeType.Comment)
+			{
+				return string.Empty;
+			}
+
+			// Collect all open tags in open order, then derive close tags by reversing.
+			// This ensures proper LIFO nesting regardless of CSS style attribute order,
+			// and guarantees each open tag gets exactly one close tag.
+			List<string> openTags = new List<string>();
+
+			string styleAttributes = node.GetAttributeValue("style", "");
+			if (!string.IsNullOrEmpty(styleAttributes))
+			{
+				foreach (Match match in Regex.Matches(styleAttributes, @"\s*(?<prop>[\w-]+)\s*:\s*(?<value>[^;]+);?"))
+				{
+					string prop = match.Groups["prop"].Value.ToLower();
+					string value = match.Groups["value"].Value.Trim();
+
+					switch (prop)
+					{
+						case "color":
+							openTags.Add($"<color={value}>");
+							break;
+						case "font-size":
+							if (value.EndsWith("%") && float.TryParse(value.Replace("%", ""), out float percentage))
+							{
+								// KNOWN LIMITATION: The percentage value is used directly as an absolute TMP
+								// size tag rather than being multiplied by a base font size. For example,
+								// "150%" produces <size=150> instead of <size=1.5 * baseFontSize>. To support
+								// percentage-based font sizes correctly, add a baseFontSize field and apply it:
+								// <size={(int)(percentage / 100f * baseFontSize)}>.
+								openTags.Add($"<size={(int)(percentage)}>");
+							}
+							else if (value.EndsWith("px") && float.TryParse(value.Replace("px", ""), out float pxValue))
+							{
+								openTags.Add($"<size={(int)(pxValue * pxToTmpSizeFactor)}>");
+							}
+							break;
+						case "text-align":
+							if (value == "center" || value == "left" || value == "right" || value == "justify")
+							{
+								openTags.Add($"<align=\"{value}\">");
+							}
+							break;
+					}
+				}
+			}
+
+			bool isBlockElement = false;
+			switch (node.Name.ToLower())
+			{
+				case "h1": openTags.Add("<size=180%>"); openTags.Add("<B>"); isBlockElement = true; break;
+				case "h2": openTags.Add("<size=150%>"); openTags.Add("<B>"); isBlockElement = true; break;
+				case "h3": openTags.Add("<size=130%>"); openTags.Add("<B>"); isBlockElement = true; break;
+				case "h4":
+				case "h5":
+				case "h6": openTags.Add("<B>"); isBlockElement = true; break;
+				case "strong":
+				case "b": openTags.Add("<B>"); break;
+				case "em":
+				case "i": openTags.Add("<I>"); break;
+				case "u": openTags.Add("<U>"); break;
+				case "li": sb.Append("• "); break;
+				case "br": sb.AppendLine(); return sb.ToString();
+				case "hr": sb.AppendLine("----------------------------------------"); sb.AppendLine(); return sb.ToString();
+				case "a":
+					string href = node.GetAttributeValue("href", "");
+					if (!string.IsNullOrEmpty(href))
+					{
+						openTags.Add("<color=#00FF00>");
+						openTags.Add($"<link=\"{href}\">");
+					}
+					break;
+				case "ul":
+				case "ol":
+				case "div":
+				case "p":
+					isBlockElement = true;
+					break;
+			}
+
+			if (isBlockElement && sb.Length > 0 && sb[sb.Length - 1] != '\n')
+			{
+				sb.AppendLine();
+			}
+
+			// Build the open tag string by concatenating tags in order
+			foreach (string tag in openTags)
+			{
+				sb.Append(tag);
+			}
+
+			foreach (HtmlNode child in node.ChildNodes)
+			{
+				sb.Append(ConvertNode(child, pxToTmpSizeFactor, depth + 1));
+			}
+
+			// Build and append close tags by reversing the open order.
+			// Each open tag maps to its corresponding close tag.
+			for (int i = openTags.Count - 1; i >= 0; i--)
+			{
+				string tag = openTags[i];
+				if (tag.StartsWith("<color=", System.StringComparison.Ordinal))
+					sb.Append("</color>");
+				else if (tag.StartsWith("<size=", System.StringComparison.Ordinal))
+					sb.Append("</size>");
+				else if (tag.StartsWith("<align=", System.StringComparison.Ordinal))
+					sb.Append("</align>");
+				else if (tag.StartsWith("<link=", System.StringComparison.Ordinal))
+					sb.Append("</link>");
+				else if (tag == "<B>")
+					sb.Append("</B>");
+				else if (tag == "<I>")
+					sb.Append("</I>");
+				else if (tag == "<U>")
+					sb.Append("</U>");
+			}
+
+			if (isBlockElement && sb.Length > 0 && sb[sb.Length - 1] != '\n')
+			{
+				sb.AppendLine();
+			}
+
+			return sb.ToString();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/HtmlToTmpTextConverter.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/HtmlToTmpTextConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf09824d83184129a56b7d09fcd804c1

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/HttpPatchServerService.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/HttpPatchServerService.cs
@@ -59,6 +59,23 @@ namespace FishMMO.Client
 		/// </summary>
 		public int WebRequestTimeout => webRequestTimeout;
 
+		/*
+		 * Resolved per request rather than cached, so a settings change applies to the next
+		 * attempt instead of requiring a restart. The serialized field is the fallback: an
+		 * install where the player has never touched these behaves exactly as it always has.
+		 *
+		 * Only this service honours them. The news fetcher deliberately runs with no retries
+		 * because it is cosmetic, and a player raising the download retry count has not asked
+		 * to spend that budget on the news pane.
+		 */
+
+		/// <summary>Retry count for this request, from settings or the serialized default.</summary>
+		private int EffectiveMaxRetries => LauncherSettings.GetMaxRetries(this.maxRetries);
+		/// <summary>Retry delay for this request, from settings or the serialized default.</summary>
+		private float EffectiveRetryDelay => LauncherSettings.GetRetryDelay(this.retryDelay);
+		/// <summary>Timeout for this request, from settings or the serialized default.</summary>
+		private int EffectiveTimeout => LauncherSettings.GetRequestTimeout(this.webRequestTimeout);
+
 		/// <summary>
 		/// Unity Awake method. Validates dependencies and disables script if missing.
 		/// </summary>
@@ -127,9 +144,9 @@ namespace FishMMO.Client
 				Method = UnityWebRequest.kHttpVerbGET,
 				Headers = headers,
 				CertificateHandlerFactory = () => new ClientSSLCertificateHandler(),
-				MaxRetries = this.maxRetries,
-				RetryDelay = this.retryDelay,
-				Timeout = this.webRequestTimeout,
+				MaxRetries = this.EffectiveMaxRetries,
+				RetryDelay = this.EffectiveRetryDelay,
+				Timeout = this.EffectiveTimeout,
 				OnProgress = null,
 				OnComplete = (request) =>
 				{
@@ -179,11 +196,12 @@ namespace FishMMO.Client
 		/// <param name="patchUrl">The URL to download the patch from.</param>
 		/// <param name="destinationFilePath">Full path (including file name) to save the patch archive to.</param>
 		/// <param name="expectedSha256">Lowercase hex SHA-256 the downloaded file must match, or null/empty to skip verification.</param>
+		/// <param name="expectedTotalBytes">Expected size from the version manifest, or 0 when unknown.</param>
 		/// <param name="onComplete">Callback for successful download. The argument is false when the server reported the client is already up to date.</param>
 		/// <param name="onError">Callback for error handling.</param>
 		/// <param name="onProgress">Callback for progress updates.</param>
 		/// <returns>Coroutine enumerator.</returns>
-		public IEnumerator DownloadPatch(string patchUrl, string destinationFilePath, string expectedSha256, Action<bool> onComplete, Action<string> onError, Action<float, string> onProgress)
+		public IEnumerator DownloadPatch(string patchUrl, string destinationFilePath, string expectedSha256, long expectedTotalBytes, Action<bool> onComplete, Action<string> onError, Action<DownloadStats> onProgress)
 		{
 			if (this.webRequestService == null)
 			{
@@ -227,6 +245,15 @@ namespace FishMMO.Client
 			// Sign patch download requests so the public web gateway accepts them.
 			ClientApiSigner.SignAndAdd(headers, UnityWebRequest.kHttpVerbGET, patchUrl);
 
+			// Per-download, so a retry after a failure does not inherit the previous attempt's
+			// rate history and report a throughput that is no longer happening.
+			DownloadRateTracker rateTracker = new DownloadRateTracker();
+
+			// Emitted before the request is sent so the UI opens on "0 B of 240 MB" rather than
+			// an empty bar. Without this the player sees nothing at all until the first
+			// progress callback, which on a slow connect is several seconds of blank UI.
+			onProgress?.Invoke(new DownloadStats(0UL, expectedTotalBytes, 0, null, 0f));
+
 			UnityWebRequestService.WebRequestConfig config = new UnityWebRequestService.WebRequestConfig
 			{
 				URL = patchUrl,
@@ -247,13 +274,20 @@ namespace FishMMO.Client
 #else
 				DownloadHandlerFactory = () => new DownloadHandlerBuffer(),
 #endif
-				MaxRetries = this.maxRetries,
-				RetryDelay = this.retryDelay,
-				Timeout = this.webRequestTimeout,
+				MaxRetries = this.EffectiveMaxRetries,
+				RetryDelay = this.EffectiveRetryDelay,
+				Timeout = this.EffectiveTimeout,
 				OnProgress = (request, progress) =>
 				{
-					string progressText = $"{Mathf.RoundToInt(progress * 100f)}% ({this.webRequestService.FormatBytes(request.downloadedBytes)})";
-					onProgress?.Invoke(progress, progressText);
+					ulong downloaded = request.downloadedBytes;
+					rateTracker.Sample(Time.realtimeSinceStartup, downloaded);
+
+					onProgress?.Invoke(new DownloadStats(
+						downloaded,
+						expectedTotalBytes,
+						rateTracker.BytesPerSecond,
+						rateTracker.EstimateSecondsRemaining(downloaded, expectedTotalBytes),
+						progress));
 				},
 				OnComplete = (request) =>
 				{
@@ -279,7 +313,7 @@ namespace FishMMO.Client
 						// written worth applying, so discard whatever landed on disk and
 						// tell the caller there is no patch to hand to the Updater.
 						TryDeleteTempFile(destinationFilePath);
-						onProgress?.Invoke(1f, "100% (Already Updated)");
+						onProgress?.Invoke(new DownloadStats(0UL, 0L, 0, null, 1f));
 						onComplete?.Invoke(false);
 						return;
 					}
@@ -291,7 +325,17 @@ namespace FishMMO.Client
 						return;
 					}
 
-					onProgress?.Invoke(1f, "100%");
+					// Marked complete rather than simply 100%: the shape check and SHA-256 pass
+					// below stream the whole file, which on a large patch is seconds of work
+					// after the transfer has visibly finished. Without saying so, the launcher
+					// sits at a full bar looking hung.
+					onProgress?.Invoke(new DownloadStats(
+						request.downloadedBytes,
+						expectedTotalBytes,
+						0,
+						null,
+						1f,
+						isComplete: true));
 
 					// Shape check before anything downstream trusts this file. A 200 with a
 					// JSON/HTML body (an error page, or a gateway that answers the patch

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/IHtmlContentFetcher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/IHtmlContentFetcher.cs
@@ -1,22 +1,31 @@
 using System;
 using System.Collections;
+using HtmlAgilityPack;
 
 namespace FishMMO.Client
 {
 	/// <summary>
-	/// Contract for fetching and transforming remote HTML content into launcher-ready rich text.
+	/// Contract for fetching remote HTML content and extracting the launcher's news fragment
+	/// from it.
 	/// </summary>
 	public interface IHtmlContentFetcher
 	{
 		/// <summary>
-		/// Asynchronously fetches HTML content from a given URL, extracts text from a specified div class,
-		/// and processes it.
+		/// Asynchronously fetches HTML from a URL and extracts the element identified by
+		/// <paramref name="divClass"/>.
 		/// </summary>
+		/// <remarks>
+		/// Yields the parsed node rather than formatted text. Formatting is the active view's
+		/// responsibility because the two launcher views share no common text format —
+		/// TextMeshPro and UI Toolkit disagree on rich-text tag casing and alignment syntax,
+		/// and UI Toolkit has no equivalent of TMP's <c>&lt;link&gt;</c> tag at all, so news
+		/// links have to become real elements there. See <see cref="ILauncherView.SetNewsContent"/>.
+		/// </remarks>
 		/// <param name="url">The URL from which to fetch HTML.</param>
 		/// <param name="divClass">The CSS class of the div element whose content should be extracted.</param>
-		/// <param name="onHtmlReady">Callback invoked with the processed HTML text upon successful extraction.</param>
-		/// <param name="onError">Callback invoked with an error message if fetching or processing fails.</param>
+		/// <param name="onContentReady">Callback invoked with the extracted node on success.</param>
+		/// <param name="onError">Callback invoked with an error message if fetching or parsing fails.</param>
 		/// <returns>An IEnumerator for use in a Unity Coroutine.</returns>
-		public abstract IEnumerator FetchAndProcessHtml(string url, string divClass, Action<string> onHtmlReady, Action<string> onError);
+		IEnumerator FetchAndExtract(string url, string divClass, Action<HtmlNode> onContentReady, Action<string> onError);
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/ILauncherView.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/ILauncherView.cs
@@ -1,0 +1,137 @@
+using System;
+using HtmlAgilityPack;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// The presentation surface <see cref="ClientLauncher"/> drives. Implemented once per UI
+	/// technology so the launcher's state machine, version check, and patch flow exist in
+	/// exactly one place regardless of which UI is rendering them.
+	/// </summary>
+	/// <remarks>
+	/// Members are expressed as intent ("show this status", "the progress bar is relevant now")
+	/// rather than as widget manipulation, so each view is free to satisfy them however its
+	/// technology prefers. That distinction is load-bearing: the UGUI implementation has no
+	/// dedicated status element and has to borrow the progress label and reveal its parent
+	/// group, while the UI Toolkit implementation simply writes to a status label. Encoding
+	/// that difference in the interface would export one view's limitation to the other.
+	/// </remarks>
+	public interface ILauncherView
+	{
+		/// <summary>
+		/// Sets the launcher window title (project name and version).
+		/// </summary>
+		void SetTitle(string title);
+
+		/// <summary>
+		/// Sets the label on the primary (Play/Connect/Update) button.
+		/// </summary>
+		void SetButtonText(string text);
+
+		/// <summary>
+		/// Enables or disables interaction with the primary button.
+		/// </summary>
+		void SetButtonInteractable(bool interactable);
+
+		/// <summary>
+		/// Replaces the primary button's click handler. Passing null clears it.
+		/// </summary>
+		/// <remarks>
+		/// Implementations must replace rather than add. The state machine calls this on every
+		/// transition, and an implementation that accumulated handlers would fire every action
+		/// the launcher had ever been in.
+		/// </remarks>
+		void SetButtonAction(Action action);
+
+		/// <summary>
+		/// Sets the quit button's click handler. Called once during initialisation.
+		/// </summary>
+		void SetQuitAction(Action action);
+
+		/// <summary>
+		/// Reports the state of an in-progress download.
+		/// </summary>
+		/// <remarks>
+		/// Takes the whole snapshot rather than a progress fraction and a prepared string, so a
+		/// view can present as much of it as it has room for. Use
+		/// <see cref="DownloadStats.ToDisplayString"/> for the standard line unless there is a
+		/// reason to differ — it already omits whatever is not yet known, which matters because
+		/// a rate and a remaining time do not exist for the first second of any transfer.
+		/// </remarks>
+		void SetProgress(DownloadStats stats);
+
+		/// <summary>
+		/// Shows or hides the progress bar. Hiding also resets progress to zero, so a later
+		/// download never briefly displays the previous one's final value.
+		/// </summary>
+		void SetProgressVisible(bool visible);
+
+		/// <summary>
+		/// Displays a human-readable status or error message to the player.
+		/// </summary>
+		/// <remarks>
+		/// The implementation is responsible for ensuring the message is actually visible —
+		/// including activating whatever container holds it. Writing to a deactivated element
+		/// silently loses the message, which previously left players facing a two-word button
+		/// label and no explanation.
+		/// </remarks>
+		void ShowStatus(string message);
+
+		/// <summary>
+		/// Clears any status message so a stale error does not linger into a new state.
+		/// </summary>
+		void ClearStatus();
+
+		/// <summary>
+		/// Shows or hides the news pane. Hidden when no news URL is configured, which is a
+		/// valid deployment rather than a failure.
+		/// </summary>
+		void SetNewsVisible(bool visible);
+
+		/// <summary>
+		/// Displays plain text in the news pane, used for the loading placeholder and for
+		/// fetch errors. Distinct from <see cref="SetNewsContent"/> because these messages are
+		/// launcher-authored strings, not remote content.
+		/// </summary>
+		void SetNewsMessage(string message);
+
+		/// <summary>
+		/// Renders fetched news content into the news pane.
+		/// </summary>
+		/// <remarks>
+		/// Takes the parsed node rather than a pre-formatted string because the two views have
+		/// no common text format: TextMeshPro and UI Toolkit disagree on tag casing, on how
+		/// alignment is written, and — decisively — UI Toolkit has no equivalent of TMP's
+		/// <c>&lt;link&gt;</c> tag at all. Each view converts the tree on its own terms.
+		/// <para>
+		/// <paramref name="content"/> is untrusted remote content. Implementations must bound
+		/// their traversal depth and must route any link activation through
+		/// <see cref="LauncherLinkPolicy"/>.
+		/// </para>
+		/// </remarks>
+		/// <param name="content">Root of the extracted news fragment.</param>
+		void SetNewsContent(HtmlNode content);
+
+		/// <summary>
+		/// Reports how much disk space the installation occupies, or null when it could not be
+		/// determined.
+		/// </summary>
+		/// <remarks>
+		/// Null is a real and expected outcome — a permission-restricted install directory, or
+		/// a measurement that has not run yet. Views must show "unavailable" rather than "0 B",
+		/// which would read as an empty installation.
+		/// </remarks>
+		void SetInstallSize(long? sizeBytes);
+
+		/// <summary>
+		/// Releases anything the view subscribed to. Called from the launcher's OnDestroy.
+		/// </summary>
+		/// <remarks>
+		/// Present because a view is not necessarily a component with its own Unity lifecycle —
+		/// the UGUI implementation is a plain class owned by the launcher, so something has to
+		/// tell it when to let go. Implementations backed by a MonoBehaviour may leave this
+		/// empty and clean up in OnDestroy instead.
+		/// </remarks>
+		void Teardown();
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/ILauncherView.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/ILauncherView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08426869cea644139da086bb62b1fa4a

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/IPatchServerService.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/IPatchServerService.cs
@@ -31,6 +31,10 @@ namespace FishMMO.Client
 		/// <param name="patchUrl">The full URL of the patch file to download.</param>
 		/// <param name="destinationFilePath">Full path (including file name) the patch archive is written to. Parent directories are created if missing.</param>
 		/// <param name="expectedSha256">Lowercase hex SHA-256 the downloaded file must match, or null/empty to skip verification.</param>
+		/// <param name="expectedTotalBytes">
+		/// Total size the download is expected to be, from the version manifest's
+		/// <see cref="PatchInfo.Size"/>, or 0 when the server did not report one.
+		/// </param>
 		/// <param name="onComplete">
 		/// Callback invoked upon successful download (and verification, if requested).
 		/// The argument is <c>true</c> when a patch archive was written to
@@ -38,8 +42,15 @@ namespace FishMMO.Client
 		/// reported the client is already up to date and there is nothing to apply.
 		/// </param>
 		/// <param name="onError">Callback invoked with an error message upon failure.</param>
-		/// <param name="onProgress">Callback invoked periodically with download progress (0.0 to 1.0) and a formatted string.</param>
+		/// <param name="onProgress">
+		/// Callback invoked periodically with a <see cref="DownloadStats"/> snapshot.
+		/// </param>
+		/// <remarks>
+		/// The expected size is passed in rather than read from the response so the caller can
+		/// display a total before the first byte arrives, and so a truncated or chunked
+		/// response cannot change what the player was told the download would be.
+		/// </remarks>
 		/// <returns>An IEnumerator for use in a Unity Coroutine.</returns>
-		IEnumerator DownloadPatch(string patchUrl, string destinationFilePath, string expectedSha256, Action<bool> onComplete, Action<string> onError, Action<float, string> onProgress);
+		IEnumerator DownloadPatch(string patchUrl, string destinationFilePath, string expectedSha256, long expectedTotalBytes, Action<bool> onComplete, Action<string> onError, Action<DownloadStats> onProgress);
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/IUpdaterLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/IUpdaterLauncher.cs
@@ -25,13 +25,23 @@ namespace FishMMO.Client
 		/// <param name="updaterPath">The full path to the updater executable.</param>
 		/// <param name="currentClientVersion">The current version of the client.</param>
 		/// <param name="latestServerVersion">The latest version available on the server.</param>
+		/// <param name="patchesDirectory">
+		/// The directory the patch archive was downloaded into.
+		/// </param>
 		/// <param name="onComplete">
 		/// Callback invoked once the updater has started successfully and taken over. This
 		/// signals a successful handoff, not a completed patch — the caller should shut the
 		/// launcher down so the updater can replace the client binaries.
 		/// </param>
 		/// <param name="onError">Callback invoked with an error message if the updater fails to launch or exits with an error before handoff.</param>
+		/// <remarks>
+		/// The patch directory is passed explicitly rather than left for the updater to derive.
+		/// Both sides defaulting to "Patches under the install root" agreed only by convention,
+		/// and the failure when they disagreed was silent: the updater found no archive, did
+		/// nothing, and relaunched the client at the same version, so the launcher immediately
+		/// detected the same mismatch and tried again forever.
+        /// </remarks>
 		/// <returns>An IEnumerator for use in a Unity Coroutine.</returns>
-		IEnumerator LaunchUpdater(string updaterPath, string currentClientVersion, string latestServerVersion, Action onComplete, Action<string> onError);
+		IEnumerator LaunchUpdater(string updaterPath, string currentClientVersion, string latestServerVersion, string patchesDirectory, Action onComplete, Action<string> onError);
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/InstallSizeProbe.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/InstallSizeProbe.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEngine;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Measures how much disk space the installation occupies, without blocking the launcher.
+	/// </summary>
+	/// <remarks>
+	/// The walk runs on a thread-pool thread. <see cref="Directory.EnumerateFiles(string, string,
+	/// SearchOption)"/> and <see cref="FileInfo.Length"/> are plain .NET and safe off the main
+	/// thread — no Unity API is touched from the worker, which would throw. Only the completed
+	/// total crosses back, and it is delivered from a coroutine so callers stay on the main
+	/// thread and can touch UI freely.
+	/// <para>
+	/// A full client install is tens of thousands of files. Doing this synchronously would
+	/// freeze the launcher for seconds at startup, and doing it per-frame would keep a core
+	/// busy for a readout nobody is watching — so it runs once, on request, and the result is
+	/// cached.
+	/// </para>
+	/// </remarks>
+	public static class InstallSizeProbe
+	{
+		/// <summary>
+		/// Last successfully measured size in bytes, or null when never measured.
+		/// </summary>
+		public static long? CachedSizeBytes { get; private set; }
+
+		/// <summary>
+		/// True while a measurement is running, so overlapping requests do not start a second
+		/// walk over the same tree.
+		/// </summary>
+		private static bool inProgress;
+
+		/// <summary>
+		/// Measures <paramref name="rootPath"/> and reports the result.
+		/// </summary>
+		/// <param name="rootPath">Directory to measure, typically the install root.</param>
+		/// <param name="onComplete">
+		/// Invoked on the main thread with the total in bytes, or null when the size could not
+		/// be determined. Never invoked with a partial total.
+		/// </param>
+		public static IEnumerator Measure(string rootPath, Action<long?> onComplete)
+		{
+			if (CachedSizeBytes.HasValue)
+			{
+				onComplete?.Invoke(CachedSizeBytes);
+				yield break;
+			}
+
+			if (inProgress)
+			{
+				// Another caller is already walking the same tree. Reporting "unavailable"
+				// rather than starting a duplicate walk; the first one will populate the cache.
+				onComplete?.Invoke(null);
+				yield break;
+			}
+
+			if (string.IsNullOrWhiteSpace(rootPath))
+			{
+				onComplete?.Invoke(null);
+				yield break;
+			}
+
+			inProgress = true;
+			Task<long?> task = Task.Run(() => ComputeDirectorySize(rootPath));
+
+			while (!task.IsCompleted)
+			{
+				yield return null;
+			}
+
+			inProgress = false;
+
+			long? result = null;
+			if (task.IsFaulted)
+			{
+				// Task.Run captures exceptions into the task rather than raising them, so
+				// without this an unreadable install directory would fail silently and the
+				// readout would just never appear.
+				Log.Warning("InstallSizeProbe", $"Install size measurement failed: {task.Exception?.GetBaseException().Message}");
+			}
+			else
+			{
+				result = task.Result;
+			}
+
+			if (result.HasValue)
+			{
+				CachedSizeBytes = result;
+			}
+
+			onComplete?.Invoke(result);
+		}
+
+		/// <summary>
+		/// Discards the cached total so the next <see cref="Measure"/> re-walks the tree.
+		/// Call after a patch has been applied.
+		/// </summary>
+		public static void Invalidate()
+		{
+			CachedSizeBytes = null;
+		}
+
+		/// <summary>
+		/// Sums the length of every file beneath <paramref name="rootPath"/>.
+		/// </summary>
+		/// <remarks>
+		/// Enumerated lazily and per-file guarded rather than using
+		/// <c>GetFiles</c> plus a Sum: a live install directory changes underneath the walk —
+		/// a log rotating, the patcher writing — and a file disappearing between being listed
+		/// and being measured is normal, not an error. One vanished file should cost its own
+		/// bytes, not the whole measurement.
+		/// </remarks>
+		/// <returns>The total in bytes, or null when the directory could not be read at all.</returns>
+		private static long? ComputeDirectorySize(string rootPath)
+		{
+			try
+			{
+				if (!Directory.Exists(rootPath))
+				{
+					return null;
+				}
+
+				long total = 0;
+
+				foreach (string file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+				{
+					try
+					{
+						total += new FileInfo(file).Length;
+					}
+					catch (FileNotFoundException) { }
+					catch (DirectoryNotFoundException) { }
+					catch (UnauthorizedAccessException) { }
+					catch (IOException) { }
+				}
+
+				return total;
+			}
+			catch (UnauthorizedAccessException ex)
+			{
+				Log.Warning("InstallSizeProbe", $"Access denied measuring '{rootPath}': {ex.Message}");
+				return null;
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("InstallSizeProbe", $"Could not measure '{rootPath}': {ex.Message}");
+				return null;
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/InstallSizeProbe.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/InstallSizeProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da545663b9e449c39fff9575ca74bf1b

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherLinkPolicy.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherLinkPolicy.cs
@@ -1,0 +1,76 @@
+using System;
+using UnityEngine;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Decides whether a link found in launcher news content may be handed to the operating
+	/// system's URL handler, and opens it when it may.
+	/// </summary>
+	/// <remarks>
+	/// This is a security boundary, not a formatting concern. The news document is fetched from
+	/// <see cref="Shared.Constants.Configuration.LauncherHtmlUrl"/>, an operator-configured
+	/// endpoint, so every href in it is untrusted input that ends up at
+	/// <see cref="Application.OpenURL"/> — which will happily invoke a registered protocol
+	/// handler for schemes like <c>javascript:</c>, <c>file:</c>, or an arbitrary
+	/// application-registered scheme.
+	/// <para>
+	/// It lives here as a single shared implementation because both launcher views render the
+	/// same news content through different mechanisms (TextMeshPro's link handler for UGUI,
+	/// click callbacks on VisualElements for UI Toolkit). Two copies of an allowlist drift, and
+	/// a drifted allowlist is a vulnerability — so neither view is permitted its own.
+	/// </para>
+	/// </remarks>
+	public static class LauncherLinkPolicy
+	{
+		/// <summary>
+		/// Returns true when <paramref name="link"/> is an absolute http or https URI, and
+		/// outputs its normalised form.
+		/// </summary>
+		/// <remarks>
+		/// Deliberately strict. An earlier implementation tested whether the string merely
+		/// contained "http", which accepted <c>javascript:</c> payloads, local <c>file://</c>
+		/// paths, and any custom scheme that happened to embed those four characters
+		/// (<c>chrome-http-pwn://…</c>). Parse it properly and check the scheme.
+		/// </remarks>
+		/// <param name="link">The raw href from the news document.</param>
+		/// <param name="safeUrl">The normalised absolute URI when allowed; otherwise null.</param>
+		/// <returns>True when the link is safe to open.</returns>
+		public static bool TryGetSafeUrl(string link, out string safeUrl)
+		{
+			safeUrl = null;
+
+			if (string.IsNullOrWhiteSpace(link))
+			{
+				return false;
+			}
+			if (!Uri.TryCreate(link, UriKind.Absolute, out Uri uri))
+			{
+				Log.Warning("LauncherLinkPolicy", $"Refusing to open non-absolute link: {link}");
+				return false;
+			}
+			if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+			{
+				Log.Warning("LauncherLinkPolicy", $"Refusing to open link with disallowed scheme '{uri.Scheme}': {link}");
+				return false;
+			}
+
+			safeUrl = uri.AbsoluteUri;
+			return true;
+		}
+
+		/// <summary>
+		/// Opens <paramref name="link"/> in the default browser when
+		/// <see cref="TryGetSafeUrl"/> allows it. Rejected links are logged and ignored.
+		/// </summary>
+		/// <param name="link">The raw href from the news document.</param>
+		public static void OpenIfSafe(string link)
+		{
+			if (TryGetSafeUrl(link, out string safeUrl))
+			{
+				Application.OpenURL(safeUrl);
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherLinkPolicy.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherLinkPolicy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02c83f8050e244bd95bbf33c13fba25f

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherSettings.cs
@@ -1,0 +1,302 @@
+using System;
+using UnityEngine;
+using FishMMO.Shared;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Typed access to the launcher's persisted settings, stored in the shared
+	/// <see cref="Configuration.GlobalSettings"/> file alongside the game's other options.
+	/// </summary>
+	/// <remarks>
+	/// The launcher has to load the configuration itself. Only the in-game Options panels did
+	/// so previously, and those live in the world scene — by the time either runs, the launcher
+	/// has long since finished. Nothing had read a settings file at launcher time before this.
+	/// <para>
+	/// Every getter clamps. These values reach the network layer, and the file is plain text a
+	/// player can edit: a timeout of 0 or a retry count of 100000 would otherwise be honoured
+	/// literally, and the failure would look like a launcher bug rather than a bad config.
+	/// </para>
+	/// </remarks>
+	public static class LauncherSettings
+	{
+		/// <summary>Start downloading an available update without asking first.</summary>
+		public const string KeyAutoUpdate = "Launcher.AutoUpdate";
+		/// <summary>Per-request timeout, in seconds.</summary>
+		public const string KeyRequestTimeout = "Launcher.RequestTimeout";
+		/// <summary>Retry attempts after an initial request failure.</summary>
+		public const string KeyMaxRetries = "Launcher.MaxRetries";
+		/// <summary>Delay between retries, in seconds.</summary>
+		public const string KeyRetryDelay = "Launcher.RetryDelay";
+		/// <summary>Last window width the player used.</summary>
+		public const string KeyWindowWidth = "Launcher.WindowWidth";
+		/// <summary>Last window height the player used.</summary>
+		public const string KeyWindowHeight = "Launcher.WindowHeight";
+		/// <summary>Override for where patch archives are downloaded to and read from.</summary>
+		public const string KeyPatchDirectory = "Launcher.PatchDirectory";
+
+		/// <summary>
+		/// Where patch archives are stored, or empty to use the install's own Patches folder.
+		/// </summary>
+		/// <remarks>
+		/// This is not a "move the game" setting and cannot be one: the updater patches files
+		/// relative to its own location and ships beside the client binaries, so the install
+		/// root is fixed by construction. What it does allow is keeping the archives — which
+		/// are large and transient — off a small system drive.
+		/// <para>
+		/// Whatever this resolves to has to be the same folder on both sides. The launcher
+		/// downloads here and passes the resolved path to the updater explicitly rather than
+		/// letting both derive it, because a disagreement is silent: the updater finds no
+		/// archive, does nothing, and relaunches the client at the same version forever.
+		/// </para>
+		/// </remarks>
+		public static string PatchDirectoryOverride
+		{
+			get
+			{
+				if (Configuration.GlobalSettings == null)
+				{
+					return string.Empty;
+				}
+				Configuration.GlobalSettings.TryGetString(KeyPatchDirectory, out string value, string.Empty);
+				return value ?? string.Empty;
+			}
+			set => SetValue(KeyPatchDirectory, value ?? string.Empty);
+		}
+
+		/// <summary>
+		/// Returns the directory patch archives should be written to and read from.
+		/// </summary>
+		/// <param name="defaultDirectory">
+		/// The install's own Patches folder, used when no override is set or the override is
+		/// unusable.
+		/// </param>
+		/// <remarks>
+		/// Creates the directory if it does not exist — the player is naming a location, not
+		/// promising to have made it. Any failure falls back to the default rather than
+		/// propagating: the override is a convenience, and an unusable one should cost the
+		/// convenience, not the update. The updater applies the same rule, so both sides land
+		/// on the default together.
+		/// </remarks>
+		public static string ResolvePatchDirectory(string defaultDirectory)
+		{
+			string configured = PatchDirectoryOverride;
+			if (string.IsNullOrWhiteSpace(configured))
+			{
+				return defaultDirectory;
+			}
+
+			try
+			{
+				// Rooted only, matching the updater. A relative path resolves against the
+				// working directory of whichever process reads it, so the same string could
+				// name two different folders across the handoff.
+				if (!System.IO.Path.IsPathRooted(configured))
+				{
+					Log.Warning("LauncherSettings", $"Ignoring patch directory '{configured}': it must be an absolute path.");
+					return defaultDirectory;
+				}
+
+				string full = System.IO.Path.GetFullPath(configured);
+				System.IO.Directory.CreateDirectory(full);
+				return full;
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("LauncherSettings", $"Ignoring patch directory '{configured}' ({ex.Message}). Using '{defaultDirectory}'.");
+				return defaultDirectory;
+			}
+		}
+
+		/// <summary>
+		/// Whether an available update starts downloading automatically.
+		/// </summary>
+		/// <remarks>
+		/// Defaults to true because that is what the launcher has always done — an out-of-date
+		/// client begins patching the moment the version check finishes. Turning it off makes
+		/// the launcher stop and offer an Update button instead. Changing the default would
+		/// silently alter behaviour for every existing install.
+		/// </remarks>
+		public static bool AutoUpdate
+		{
+			get => GetBool(KeyAutoUpdate, true);
+			set => SetValue(KeyAutoUpdate, value);
+		}
+
+		/// <summary>Bounds for <see cref="GetRequestTimeout"/>, in seconds.</summary>
+		public const int MinRequestTimeout = 5;
+		public const int MaxRequestTimeout = 300;
+		/// <summary>Bounds for <see cref="GetMaxRetries"/>.</summary>
+		public const int MinRetries = 0;
+		public const int MaxRetriesLimit = 10;
+		/// <summary>Bounds for <see cref="GetRetryDelay"/>, in seconds.</summary>
+		public const float MinRetryDelay = 0f;
+		public const float MaxRetryDelay = 30f;
+
+		/*
+		 * The transfer tunables take the caller's configured value as their fallback rather
+		 * than a constant of their own. The services that use these already carry the values
+		 * as serialized fields, so an install with nothing stored keeps behaving exactly as it
+		 * did — the setting only takes over once the player has actually chosen one.
+		 */
+
+		/// <summary>
+		/// Per-request timeout in seconds, or <paramref name="fallback"/> when unset.
+		/// </summary>
+		public static int GetRequestTimeout(int fallback)
+			=> Mathf.Clamp(GetInt(KeyRequestTimeout, fallback), MinRequestTimeout, MaxRequestTimeout);
+
+		public static void SetRequestTimeout(int value)
+			=> SetValue(KeyRequestTimeout, Mathf.Clamp(value, MinRequestTimeout, MaxRequestTimeout));
+
+		/// <summary>
+		/// Retry attempts after an initial failure, or <paramref name="fallback"/> when unset.
+		/// </summary>
+		public static int GetMaxRetries(int fallback)
+			=> Mathf.Clamp(GetInt(KeyMaxRetries, fallback), MinRetries, MaxRetriesLimit);
+
+		public static void SetMaxRetries(int value)
+			=> SetValue(KeyMaxRetries, Mathf.Clamp(value, MinRetries, MaxRetriesLimit));
+
+		/// <summary>
+		/// Delay between retries in seconds, or <paramref name="fallback"/> when unset.
+		/// </summary>
+		public static float GetRetryDelay(float fallback)
+			=> Mathf.Clamp(GetFloat(KeyRetryDelay, fallback), MinRetryDelay, MaxRetryDelay);
+
+		public static void SetRetryDelay(float value)
+			=> SetValue(KeyRetryDelay, Mathf.Clamp(value, MinRetryDelay, MaxRetryDelay));
+
+		/// <summary>
+		/// Remembers the launcher window size, or (0, 0) when the player has not resized it.
+		/// </summary>
+		/// <remarks>
+		/// Clamped against the current display so a window saved on a larger monitor cannot
+		/// come back bigger than the screen it is now opening on — which would put the footer
+		/// buttons off the bottom with no way to reach them.
+		/// </remarks>
+		public static Vector2Int GetWindowSize(int minWidth, int minHeight)
+		{
+			int width = GetInt(KeyWindowWidth, 0);
+			int height = GetInt(KeyWindowHeight, 0);
+
+			if (width <= 0 || height <= 0)
+			{
+				return Vector2Int.zero;
+			}
+
+			int maxWidth = Screen.currentResolution.width;
+			int maxHeight = Screen.currentResolution.height;
+
+			return new Vector2Int(
+				Mathf.Clamp(width, minWidth, Mathf.Max(minWidth, maxWidth)),
+				Mathf.Clamp(height, minHeight, Mathf.Max(minHeight, maxHeight)));
+		}
+
+		/// <summary>
+		/// Records the launcher window size.
+		/// </summary>
+		public static void SetWindowSize(int width, int height)
+		{
+			if (width <= 0 || height <= 0)
+			{
+				return;
+			}
+			SetValue(KeyWindowWidth, width);
+			SetValue(KeyWindowHeight, height);
+		}
+
+		/// <summary>
+		/// Loads the global configuration if nothing has loaded it yet.
+		/// </summary>
+		/// <remarks>
+		/// Mirrors <c>UITKOptions.EnsureConfigurationLoaded</c> so the launcher and the in-game
+		/// Options panel agree about where settings live and cannot end up with two stores.
+		/// </remarks>
+		public static void EnsureLoaded()
+		{
+			if (Configuration.GlobalSettings != null)
+			{
+				return;
+			}
+
+			try
+			{
+				Configuration.SetGlobalSettings(new Configuration(Constants.GetWorkingDirectory()));
+				if (!Configuration.GlobalSettings.Load(Configuration.DEFAULT_FILENAME))
+				{
+					Log.Debug("LauncherSettings", "No configuration file found; launcher defaults will be used.");
+				}
+			}
+			catch (Exception ex)
+			{
+				// A settings file that cannot be read must not stop the launcher. Every getter
+				// below falls back to its default when the store is unavailable, so the
+				// launcher continues with the behaviour it has always had.
+				Log.Warning("LauncherSettings", $"Could not load launcher configuration: {ex.Message}. Using defaults.");
+			}
+		}
+
+		/// <summary>
+		/// Persists settings to disk. Best-effort — a read-only install directory must not be
+		/// a fatal error for a launcher that otherwise works.
+		/// </summary>
+		public static void Save()
+		{
+			if (Configuration.GlobalSettings == null)
+			{
+				return;
+			}
+
+			try
+			{
+				Configuration.GlobalSettings.Save();
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("LauncherSettings", $"Could not save launcher configuration: {ex.Message}");
+			}
+		}
+
+		private static bool GetBool(string key, bool fallback)
+		{
+			if (Configuration.GlobalSettings == null)
+			{
+				return fallback;
+			}
+			Configuration.GlobalSettings.TryGetBool(key, out bool value, fallback);
+			return value;
+		}
+
+		private static int GetInt(string key, int fallback)
+		{
+			if (Configuration.GlobalSettings == null)
+			{
+				return fallback;
+			}
+			Configuration.GlobalSettings.TryGetInt(key, out int value, fallback);
+			return value;
+		}
+
+		private static float GetFloat(string key, float fallback)
+		{
+			if (Configuration.GlobalSettings == null)
+			{
+				return fallback;
+			}
+			Configuration.GlobalSettings.TryGetFloat(key, out float value, fallback);
+			return value;
+		}
+
+		private static void SetValue<T>(string key, T value)
+		{
+			if (Configuration.GlobalSettings == null)
+			{
+				Log.Warning("LauncherSettings", $"Cannot store '{key}': no configuration is loaded.");
+				return;
+			}
+			Configuration.GlobalSettings.Set(key, value);
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherSettings.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bd7d89f42004dc6bb1e9a0189622d6f

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherState.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/LauncherState.cs
@@ -18,6 +18,15 @@ namespace FishMMO.Client
 		/// </summary>
 		CheckingVersion,
 		/// <summary>
+		/// An update exists and is waiting for the player to start it.
+		/// </summary>
+		/// <remarks>
+		/// Only reachable when <see cref="LauncherSettings.AutoUpdate"/> is off. With it on —
+		/// the default, and how the launcher has always behaved — an out-of-date client goes
+		/// straight to <see cref="DownloadingPatch"/> without stopping here.
+		/// </remarks>
+		UpdateAvailable,
+		/// <summary>
 		/// The launcher is downloading a patch.
 		/// </summary>
 		DownloadingPatch,

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/NativeFolderPicker.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/NativeFolderPicker.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Opens the operating system's "choose a folder" dialog.
+	/// </summary>
+	/// <remarks>
+	/// Windows only. Unity exposes no runtime folder picker — <c>EditorUtility.OpenFolderPanel</c>
+	/// exists solely in the Editor — so this is a direct shell call, and the other platforms the
+	/// launcher supports would each need their own backend (GTK/portal on Linux, Cocoa on macOS).
+	/// <para>
+	/// <see cref="IsSupported"/> is false everywhere else and callers are expected to hide the
+	/// browse affordance rather than offer a button that does nothing. The path text field
+	/// remains the way to set a folder on every platform, so nothing is unreachable without
+	/// this — it is a convenience over that field, not the only route to it.
+	/// </para>
+	/// </remarks>
+	public static class NativeFolderPicker
+	{
+		/// <summary>
+		/// True when a native folder dialog can be shown on this platform.
+		/// </summary>
+		public static bool IsSupported =>
+#if UNITY_STANDALONE_WIN && !UNITY_EDITOR
+			true;
+#else
+			false;
+#endif
+
+#if UNITY_STANDALONE_WIN && !UNITY_EDITOR
+		/// <summary>Only return file system directories.</summary>
+		private const uint BIF_RETURNONLYFSDIRS = 0x00000001;
+		/// <summary>Use the newer dialog with an edit box and resize grip.</summary>
+		private const uint BIF_NEWDIALOGSTYLE = 0x00000040;
+		/// <summary>Maximum path length the shell will write back.</summary>
+		private const int MAX_PATH = 260;
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+		private struct BROWSEINFO
+		{
+			public IntPtr hwndOwner;
+			public IntPtr pidlRoot;
+			public string pszDisplayName;
+			public string lpszTitle;
+			public uint ulFlags;
+			public IntPtr lpfn;
+			public IntPtr lParam;
+			public int iImage;
+		}
+
+		[DllImport("shell32.dll", CharSet = CharSet.Auto)]
+		private static extern IntPtr SHBrowseForFolder(ref BROWSEINFO lpbi);
+
+		[DllImport("shell32.dll", CharSet = CharSet.Auto)]
+		private static extern bool SHGetPathFromIDList(IntPtr pidl, StringBuilder pszPath);
+
+		/// <summary>
+		/// Frees the PIDL the shell allocated for the selection.
+		/// </summary>
+		/// <remarks>
+		/// SHBrowseForFolder returns shell-allocated memory that the caller owns. Letting it go
+		/// leaks a little on every use of the dialog.
+		/// </remarks>
+		[DllImport("ole32.dll")]
+		private static extern void CoTaskMemFree(IntPtr pv);
+
+		[DllImport("user32.dll")]
+		private static extern IntPtr GetActiveWindow();
+#endif
+
+		/// <summary>
+		/// Shows the folder dialog and returns the chosen path, or null when the player
+		/// cancelled or no dialog is available.
+		/// </summary>
+		/// <param name="title">Prompt shown above the folder tree.</param>
+		/// <remarks>
+		/// Every failure returns null rather than throwing. This is reached from a UI callback
+		/// on the launcher — the screen that, if it breaks, leaves no way into the game — and a
+		/// shell call that misbehaves must cost the convenience, not the launcher.
+		/// </remarks>
+		public static string PickFolder(string title)
+		{
+#if UNITY_STANDALONE_WIN && !UNITY_EDITOR
+			IntPtr pidl = IntPtr.Zero;
+			try
+			{
+				BROWSEINFO info = new BROWSEINFO
+				{
+					// Parenting to the launcher window keeps the dialog modal to it, rather
+					// than letting it open behind and look like a freeze.
+					hwndOwner = GetActiveWindow(),
+					pidlRoot = IntPtr.Zero,
+					pszDisplayName = new string('\0', MAX_PATH),
+					lpszTitle = title,
+					ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE,
+					lpfn = IntPtr.Zero,
+					lParam = IntPtr.Zero,
+					iImage = 0,
+				};
+
+				pidl = SHBrowseForFolder(ref info);
+				if (pidl == IntPtr.Zero)
+				{
+					// Cancelled.
+					return null;
+				}
+
+				StringBuilder path = new StringBuilder(MAX_PATH);
+				if (!SHGetPathFromIDList(pidl, path))
+				{
+					// A virtual folder with no filesystem path (This PC, a library root).
+					Log.Warning("NativeFolderPicker", "The selected item is not a filesystem folder.");
+					return null;
+				}
+
+				string result = path.ToString();
+				return string.IsNullOrWhiteSpace(result) ? null : result;
+			}
+			catch (Exception ex)
+			{
+				Log.Warning("NativeFolderPicker", $"Could not open the folder dialog: {ex.Message}. Type the path instead.");
+				return null;
+			}
+			finally
+			{
+				if (pidl != IntPtr.Zero)
+				{
+					try { CoTaskMemFree(pidl); } catch { }
+				}
+			}
+#else
+			return null;
+#endif
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/NativeFolderPicker.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/NativeFolderPicker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a1b5b3c5e13e5c40b0ab104fad47ff2

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/README.md
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/README.md
@@ -32,6 +32,17 @@ Everything it does over the network goes through an injected service so the flow
 | News HTML | `IHtmlContentFetcher` | `UnityHtmlContentFetcher` |
 | Version + patch download | `IPatchServerService` | `HttpPatchServerService` |
 | Updater process | `IUpdaterLauncher` | `SystemUpdaterLauncher` |
+| Presentation | `ILauncherView` | `UGUILauncherView` |
+
+Rendering is behind `ILauncherView` so the state machine, version check, and patch flow exist
+once regardless of which UI technology draws them. `ClientLauncher` falls back to
+`UGUILauncherView` — built from the element references already serialized on it — whenever no
+view component is assigned, so existing scenes keep working untouched.
+
+The interface deliberately expresses intent (*show this status*) rather than widget
+manipulation (*set this label, activate that group*). The uGUI view has no dedicated status
+element and has to borrow the progress label and reveal its parent group to be seen at all;
+encoding that quirk in the interface would export one view's limitation to every other.
 
 ## Supported Platforms
 
@@ -73,6 +84,34 @@ Everything it does over the network goes through an injected service so the flow
 
 > **Why `htmlViewURL` defaults to empty.** A non-empty default gets baked into the scene the first time it is saved, and the serialized copy then silently wins over the build-time configured value for every subsequent build — which is exactly how a stale hard-coded URL once shipped. Resolution happens at read time instead: `HtmlViewURL` falls back to `Constants.Configuration.LauncherHtmlUrl` whenever the override is blank.
 
+### Player settings
+
+Persisted in the shared `Configuration.GlobalSettings` file, the same store the in-game Options
+panel uses. The launcher loads it itself — only the Options panels did previously, and those
+live in the world scene, so nothing had read a settings file this early.
+
+| Key | Default | Effect |
+|---|---|---|
+| `Launcher.AutoUpdate` | `true` | Off stops at `UpdateAvailable` with the download size instead of patching straight away |
+| `Launcher.RequestTimeout` | inspector value | Per-request timeout, clamped 5–300s |
+| `Launcher.MaxRetries` | inspector value | Retries after a failure, clamped 0–10. Patch downloads only — the news fetcher stays at 0 |
+| `Launcher.RetryDelay` | inspector value | Seconds between retries, clamped 0–30 |
+| `Launcher.PatchDirectory` | empty | Where patch archives are stored. Empty uses the install's own `Patches` folder |
+| `Launcher.WindowWidth` / `Height` | unset | Last windowed size, restored on next launch |
+
+The transfer tunables take the component's serialized value as their fallback, so an install
+where nothing has been changed behaves exactly as it did before these existed.
+
+`Launcher.PatchDirectory` is **not** a "move the game" setting and cannot be one — the Updater
+patches files relative to its own location and ships beside the client binaries, so the install
+root is fixed by construction. It exists to keep large, transient archives off a small system
+drive. It must be an absolute path; anything unusable falls back to the default, and both the
+launcher and the Updater apply that same rule so they fall back together.
+
+Unity exposes no receive-buffer setting for `DownloadHandlerFile`, and on desktop
+`UnityWebRequest` defers to the platform HTTP stack — timeout, retry count and retry delay are
+the only real throughput controls available, which is why nothing else is offered.
+
 ### UI text
 
 All player-facing strings are constants on the nested `UIText` class — status labels (`StatusPatchUnavailable`, `StatusServerRejectedVersion`, …), long-form explanations (`DetailPatchUnavailable`, `DetailApplyingPatch`, …), and log format strings. Change copy there, not at the call sites.
@@ -111,7 +150,7 @@ All player-facing strings are constants on the nested `UIText` class — status 
 
 `PlayButtonUpdate()` then:
 
-1. Computes the destination as `Constants.GetPatchesDirectory()` + `Constants.GetPatchFileName(currentVersion, latestVersion)` — i.e. `<install root>/Patches/<from>-<to>.zip`. **This path is a contract.** The Updater resolves the same location from its own base directory and looks nowhere else; if the archive is not exactly there it reports "patch file not found", relaunches the client unchanged, and the launcher detects the same mismatch on the next run. See the [Updater README](../../../../../FishMMO-Patcher/Updater/README.md).
+1. Computes the destination as `LauncherSettings.ResolvePatchDirectory(Constants.GetPatchesDirectory())` + `Constants.GetPatchFileName(currentVersion, latestVersion)` — by default `<install root>/Patches/<from>-<to>.zip`. **This path is a contract**, and it is now passed to the Updater as `-patches=<dir>` rather than derived independently on both sides. A disagreement fails silently: the Updater reports "patch file not found", relaunches the client unchanged, and the launcher detects the same mismatch on the next run, forever. See the [Updater README](../../../../../FishMMO-Patcher/Updater/README.md).
 2. Downloads from the pinned host, verifying the SHA-256 when the server supplied one.
 3. If the server answers **204 No Content** mid-flight — the version we checked against was superseded, or we raced a deployment — no archive is written and the launcher goes straight to `ReadyToPlay` instead of invoking the Updater on a file that does not exist.
 4. Otherwise enters `ApplyingPatch` and starts the Updater. The archive is deliberately **not** deleted here: the Updater is about to read it, and removes it itself once applied.
@@ -200,14 +239,19 @@ flowchart TD
 
 ```
 Client/Launcher/
-├── ClientLauncher.cs            # MonoBehaviour: UI, state machine, orchestration
+├── ClientLauncher.cs            # MonoBehaviour: state machine, orchestration
 ├── LauncherState.cs             # The 15 UI/process states
 ├── PatchInfo.cs                 # Server patch metadata: UpToDate, PatchAvailable, Sha256, Size
 ├── VersionFetch.cs              # Version response parsing
 │
+├── ILauncherView.cs             # Contract: the presentation surface the state machine drives
+├── UGUILauncherView.cs          #   → legacy uGUI/TextMeshPro implementation
+├── HtmlToTmpTextConverter.cs    # News node tree → TextMeshPro rich text (uGUI view only)
+├── LauncherLinkPolicy.cs        # Scheme allowlist for opening news links (shared by all views)
+│
 ├── IPatchServerService.cs       # Contract: GetLatestVersion, DownloadPatch
 ├── HttpPatchServerService.cs    #   → HTTP implementation with SHA-256 verification
-├── IHtmlContentFetcher.cs       # Contract: fetch a page, extract a div's text
+├── IHtmlContentFetcher.cs       # Contract: fetch a page, extract a div as a parsed node
 ├── UnityHtmlContentFetcher.cs   #   → UnityWebRequest implementation
 ├── IUpdaterLauncher.cs          # Contract: start the external updater and hand off
 ├── SystemUpdaterLauncher.cs     #   → Process.Start implementation

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/SystemUpdaterLauncher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/SystemUpdaterLauncher.cs
@@ -53,10 +53,11 @@ namespace FishMMO.Client
 		/// <param name="updaterPath">Path to the updater executable.</param>
 		/// <param name="currentClientVersion">Current client version string.</param>
 		/// <param name="latestServerVersion">Latest server version string.</param>
+		/// <param name="patchesDirectory">Directory the patch archive was downloaded into.</param>
 		/// <param name="onComplete">Callback invoked once the updater has started successfully and taken over.</param>
 		/// <param name="onError">Callback invoked when updater fails to start or exits with an error before handoff.</param>
 		/// <returns>An IEnumerator for use in a Unity Coroutine.</returns>
-		public IEnumerator LaunchUpdater(string updaterPath, string currentClientVersion, string latestServerVersion, Action onComplete, Action<string> onError)
+		public IEnumerator LaunchUpdater(string updaterPath, string currentClientVersion, string latestServerVersion, string patchesDirectory, Action onComplete, Action<string> onError)
 		{
 #if UNITY_WEBGL && !UNITY_EDITOR
 			// WebGL builds run in the browser sandbox (MEMFS in-memory virtual filesystem);
@@ -120,6 +121,12 @@ namespace FishMMO.Client
 					startInfo.ArgumentList.Add($"-latestversion={latestServerVersion}");
 					startInfo.ArgumentList.Add($"-pid={Process.GetCurrentProcess().Id}");
 					startInfo.ArgumentList.Add($"-exe={Constants.Configuration.ClientExecutable}");
+					// Only sent when set, so an updater built before this argument existed is
+					// still launched with exactly the arguments it understands.
+					if (!string.IsNullOrWhiteSpace(patchesDirectory))
+					{
+						startInfo.ArgumentList.Add($"-patches={patchesDirectory}");
+					}
 				}
 				catch (NotSupportedException)
 				{
@@ -129,6 +136,10 @@ namespace FishMMO.Client
 						+ $"-latestversion=\"{latestServerVersion}\"" + " "
 						+ $"-pid={Process.GetCurrentProcess().Id}" + " "
 						+ $"-exe=\"{Constants.Configuration.ClientExecutable}\"";
+					if (!string.IsNullOrWhiteSpace(patchesDirectory))
+					{
+						startInfo.Arguments += $" -patches=\"{patchesDirectory}\"";
+					}
 				}
 
 				process = new Process { StartInfo = startInfo };

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UGUILauncherView.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UGUILauncherView.cs
@@ -1,0 +1,302 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using HtmlAgilityPack;
+using FishMMO.Shared;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Renders the launcher onto the legacy uGUI canvas.
+	/// </summary>
+	/// <remarks>
+	/// A plain class rather than a MonoBehaviour, constructed by <see cref="ClientLauncher"/>
+	/// from the element references already serialized on it. That is deliberate: promoting
+	/// these fields onto a new component would invalidate every reference the launcher scene
+	/// has stored against <see cref="ClientLauncher"/>, silently breaking the working launcher
+	/// until someone re-wired it by hand. Adapting in code costs nothing and touches no scene.
+	/// </remarks>
+	public class UGUILauncherView : ILauncherView
+	{
+		private readonly TMP_Text title;
+		private readonly GameObject htmlView;
+		private readonly GameObject progressBarGroup;
+		private readonly Slider progressSlider;
+		private readonly TMP_Text progressText;
+		private readonly Button quitButton;
+		private readonly Button playButton;
+		private readonly TMP_Text playButtonText;
+		private readonly TMP_Text htmlText;
+		private readonly TMPro_TextLinkHandler htmlTextLinkHandler;
+		private readonly TMP_Text statusText;
+		private readonly float pxToTmpSizeFactor;
+
+		/// <summary>
+		/// The handler currently attached to the primary button, retained so it can be removed
+		/// before the next one is attached.
+		/// </summary>
+		private UnityEngine.Events.UnityAction primaryButtonHandler;
+
+		/// <summary>
+		/// Whether the progress bar is currently meant to be showing.
+		/// </summary>
+		private bool progressVisible;
+
+		/// <summary>
+		/// Whether a status message is currently displayed.
+		/// </summary>
+		private bool hasStatus;
+
+		/// <summary>
+		/// True when status messages have to borrow <see cref="progressText"/> because no
+		/// dedicated status element is assigned. In that case the containing progress group
+		/// must be visible for the message to be seen at all.
+		/// </summary>
+		private bool UsesProgressTextForStatus => this.statusText == null && this.progressText != null;
+
+		public UGUILauncherView(
+			TMP_Text title,
+			GameObject htmlView,
+			GameObject progressBarGroup,
+			Slider progressSlider,
+			TMP_Text progressText,
+			Button quitButton,
+			Button playButton,
+			TMP_Text playButtonText,
+			TMP_Text htmlText,
+			TMPro_TextLinkHandler htmlTextLinkHandler,
+			TMP_Text statusText,
+			float pxToTmpSizeFactor)
+		{
+			this.title = title;
+			this.htmlView = htmlView;
+			this.progressBarGroup = progressBarGroup;
+			this.progressSlider = progressSlider;
+			this.progressText = progressText;
+			this.quitButton = quitButton;
+			this.playButton = playButton;
+			this.playButtonText = playButtonText;
+			this.htmlText = htmlText;
+			this.htmlTextLinkHandler = htmlTextLinkHandler;
+			this.statusText = statusText;
+			this.pxToTmpSizeFactor = pxToTmpSizeFactor;
+
+			if (this.htmlTextLinkHandler != null)
+			{
+				this.htmlTextLinkHandler.OnLinkClicked += HandleLinkClicked;
+			}
+		}
+
+		/// <inheritdoc />
+		public void Teardown()
+		{
+			if (this.htmlTextLinkHandler != null)
+			{
+				this.htmlTextLinkHandler.OnLinkClicked -= HandleLinkClicked;
+			}
+			if (this.quitButton != null)
+			{
+				this.quitButton.onClick.RemoveAllListeners();
+			}
+			if (this.playButton != null)
+			{
+				this.playButton.onClick.RemoveAllListeners();
+			}
+		}
+
+		/// <summary>
+		/// Routes a clicked news link through the shared scheme allowlist.
+		/// </summary>
+		private void HandleLinkClicked(string link)
+		{
+			LauncherLinkPolicy.OpenIfSafe(link);
+		}
+
+		/// <inheritdoc />
+		public void SetTitle(string title)
+		{
+			if (this.title != null)
+			{
+				this.title.text = title;
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetButtonText(string text)
+		{
+			if (this.playButtonText != null)
+			{
+				this.playButtonText.text = text;
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetButtonInteractable(bool interactable)
+		{
+			if (this.playButton != null)
+			{
+				this.playButton.interactable = interactable;
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetButtonAction(Action action)
+		{
+			if (this.playButton == null)
+			{
+				return;
+			}
+
+			// Remove only what this view attached. RemoveAllListeners would also discard
+			// listeners configured on the scene object, which is a different contract than
+			// "replace the action".
+			if (this.primaryButtonHandler != null)
+			{
+				this.playButton.onClick.RemoveListener(this.primaryButtonHandler);
+				this.primaryButtonHandler = null;
+			}
+
+			if (action != null)
+			{
+				this.primaryButtonHandler = () => action.Invoke();
+				this.playButton.onClick.AddListener(this.primaryButtonHandler);
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetQuitAction(Action action)
+		{
+			if (this.quitButton == null)
+			{
+				return;
+			}
+
+			// Wired in code rather than trusted to the scene. The scene's persistent
+			// UnityEvent listener had a null target, so the button silently did nothing;
+			// a code-side listener cannot be broken by a scene re-save.
+			this.quitButton.onClick.RemoveAllListeners();
+			if (action != null)
+			{
+				this.quitButton.onClick.AddListener(() => action.Invoke());
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetProgress(DownloadStats stats)
+		{
+			if (this.progressSlider != null)
+			{
+				this.progressSlider.value = stats.NormalizedProgress;
+			}
+			if (this.progressText != null)
+			{
+				this.progressText.text = stats.ToDisplayString();
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetProgressVisible(bool visible)
+		{
+			this.progressVisible = visible;
+
+			if (this.progressSlider != null)
+			{
+				this.progressSlider.gameObject.SetActive(visible);
+				if (!visible)
+				{
+					this.progressSlider.value = 0f;
+				}
+			}
+
+			RefreshGroupVisibility();
+		}
+
+		/// <inheritdoc />
+		public void ShowStatus(string message)
+		{
+			this.hasStatus = !string.IsNullOrEmpty(message);
+
+			TMP_Text target = this.statusText != null ? this.statusText : this.progressText;
+			if (target != null)
+			{
+				target.text = message;
+			}
+
+			if (this.statusText != null)
+			{
+				this.statusText.gameObject.SetActive(true);
+			}
+
+			RefreshGroupVisibility();
+		}
+
+		/// <inheritdoc />
+		public void ClearStatus()
+		{
+			this.hasStatus = false;
+
+			TMP_Text target = this.statusText != null ? this.statusText : this.progressText;
+			if (target != null)
+			{
+				target.text = string.Empty;
+			}
+
+			RefreshGroupVisibility();
+		}
+
+		/// <summary>
+		/// Reconciles the progress group's visibility against the two independent reasons it
+		/// might need to be on screen.
+		/// </summary>
+		/// <remarks>
+		/// The group holds the progress bar and, when no dedicated status element exists, the
+		/// status message too. Deriving its visibility from the progress bar alone wrote every
+		/// error message to a deactivated object, leaving the player a two-word button label
+		/// and no explanation of what had gone wrong.
+		/// </remarks>
+		private void RefreshGroupVisibility()
+		{
+			if (this.progressBarGroup == null)
+			{
+				return;
+			}
+			this.progressBarGroup.SetActive(this.progressVisible || (UsesProgressTextForStatus && this.hasStatus));
+		}
+
+		/// <inheritdoc />
+		public void SetNewsVisible(bool visible)
+		{
+			if (this.htmlView != null)
+			{
+				this.htmlView.SetActive(visible);
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetNewsMessage(string message)
+		{
+			if (this.htmlText != null)
+			{
+				this.htmlText.text = message;
+			}
+		}
+
+		/// <inheritdoc />
+		public void SetInstallSize(long? sizeBytes)
+		{
+			// The uGUI launcher has no element for this. It is the legacy fallback view and is
+			// not gaining new scene objects — adding one would mean editing the scene that this
+			// view exists specifically to leave untouched.
+		}
+
+		/// <inheritdoc />
+		public void SetNewsContent(HtmlNode content)
+		{
+			if (this.htmlText != null)
+			{
+				this.htmlText.text = HtmlToTmpTextConverter.Convert(content, this.pxToTmpSizeFactor);
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UGUILauncherView.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UGUILauncherView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a879b23433ce4d19abce030578aaca65

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityHtmlContentFetcher.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityHtmlContentFetcher.cs
@@ -2,9 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using FishMMO.Logging;
 using UnityEngine;
@@ -13,8 +10,13 @@ using UnityEngine.Networking;
 namespace FishMMO.Client
 {
 	/// <summary>
-	/// Fetches launcher news HTML and converts selected content into TextMeshPro-compatible rich text.
+	/// Fetches launcher news HTML and extracts the configured content fragment from it.
 	/// </summary>
+	/// <remarks>
+	/// Fetching and formatting are separate concerns: this component produces a parsed node and
+	/// the active <see cref="ILauncherView"/> renders it. Formatting used to live here, back
+	/// when TextMeshPro rich text was the only output format.
+	/// </remarks>
 	public class UnityHtmlContentFetcher : MonoBehaviour, IHtmlContentFetcher
 	{
 		[Header("Dependencies")]
@@ -34,15 +36,17 @@ namespace FishMMO.Client
 		/// </summary>
 		/// <remarks>
 		/// Defaults to 0 (a single attempt) because this fetcher serves the launcher's news
-		/// pane, which is purely cosmetic but sits on the critical path: the version check and
-		/// launch only begin once this request settles. Retrying stacked the per-attempt
-		/// timeout and the inter-attempt delay in front of every startup — with the previous
-		/// value of 3 and an unreachable host that times out rather than refusing, that is
-		/// 4 x 10s + 3 x 1s of the player watching "Loading News..." before the game even
-		/// checks its version. A decorative panel is not worth retrying; the news pane simply
-		/// shows an error and startup continues.
+		/// pane, which is purely cosmetic. Retrying stacked the per-attempt timeout and the
+		/// inter-attempt delay for content nobody is waiting on — with the previous value of 3
+		/// and an unreachable host that times out rather than refusing, that is 4 x 10s + 3 x 1s
+		/// of requests for a decorative panel. The news pane simply shows an error instead.
+		/// <para>
+		/// This used to also sit on the critical path, with the version check waiting on it.
+		/// It no longer does — startup and the news fetch are dispatched independently — so the
+		/// retry count now costs only the news pane, not the launch.
+		/// </para>
 		/// </remarks>
-		[Tooltip("Maximum number of retries for each web request. 0 = a single attempt (news is cosmetic and blocks startup).")]
+		[Tooltip("Maximum number of retries for each web request. 0 = a single attempt (news is cosmetic).")]
 		[SerializeField]
 		private int maxRetries = 0;
 		/// <summary>
@@ -72,6 +76,11 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Approximate conversion factor from HTML pixels to TextMeshPro font size.
 		/// </summary>
+		/// <remarks>
+		/// Consumed by <see cref="HtmlToTmpTextConverter"/> via the TextMeshPro view. It stays
+		/// serialized on this component so the existing scene keeps its configured value; the
+		/// launcher passes it to the view rather than the view reaching for it.
+		/// </remarks>
 		[Tooltip("Approximate conversion factor from HTML pixels to TextMeshPro font size.")]
 		[SerializeField]
 		private float htmlPxToTmpSizeFactor = 1.5f;
@@ -90,7 +99,7 @@ namespace FishMMO.Client
 				// Disable only this component. Deactivating the GameObject would take the
 				// sibling ClientLauncher down with it (they share one GameObject) and abort
 				// its in-flight news coroutine, leaving the UI stuck on "Loading News..."
-				// with a disabled button and no message. FetchAndProcessHtml null-checks
+				// with a disabled button and no message. FetchAndExtract null-checks
 				// and reports through onError instead.
 				Log.Error("UnityHtmlContentFetcher", "WebRequestService dependency is not assigned! This script will not function.");
 				this.enabled = false;
@@ -98,19 +107,14 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
-		/// Maximum recursion depth when converting HTML nodes to TMP text to prevent stack overflow from deeply nested input.
-		/// </summary>
-		private const int maxRecursionDepth = 100;
-
-		/// <summary>
-		/// Fetches HTML from a URL, extracts content from a div, and processes it into TMP rich text.
+		/// Fetches HTML from a URL and extracts the element identified by <paramref name="divClass"/>.
 		/// </summary>
 		/// <param name="url">The URL to fetch HTML from.</param>
 		/// <param name="divClass">The class name of the div to extract.</param>
-		/// <param name="onHtmlReady">Callback for successful extraction.</param>
+		/// <param name="onContentReady">Callback for successful extraction.</param>
 		/// <param name="onError">Callback for error handling.</param>
 		/// <returns>Coroutine enumerator.</returns>
-		public IEnumerator FetchAndProcessHtml(string url, string divClass, Action<string> onHtmlReady, Action<string> onError)
+		public IEnumerator FetchAndExtract(string url, string divClass, Action<HtmlNode> onContentReady, Action<string> onError)
 		{
 			if (WebRequestService == null)
 			{
@@ -135,9 +139,13 @@ namespace FishMMO.Client
 				{
 					try
 					{
-						string htmlContent = request.downloadHandler.text;
-						string extractedText = ExtractTextFromDiv(htmlContent, divClass);
-						onHtmlReady?.Invoke(extractedText);
+						HtmlNode extracted = ExtractDivNode(request.downloadHandler.text, divClass);
+						if (extracted == null)
+						{
+							onError?.Invoke($"No element with class '{divClass}' was found in the news page.");
+							return;
+						}
+						onContentReady?.Invoke(extracted);
 					}
 					catch (Exception ex)
 					{
@@ -161,17 +169,20 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
-		/// Extracts and converts HTML content from a specific div element into TextMeshPro rich text.
-		/// Handles various HTML tags, inline styles, and basic sanitization.
+		/// Parses <paramref name="htmlContent"/> and returns the first element whose class
+		/// contains <paramref name="divClass"/>, with script and style nodes stripped.
 		/// </summary>
 		/// <param name="htmlContent">The raw HTML content.</param>
 		/// <param name="divClass">The class name of the div to extract.</param>
-		/// <returns>Extracted and converted TMP rich text, or empty string if not found.</returns>
-		private string ExtractTextFromDiv(string htmlContent, string divClass)
+		/// <returns>The matching node, or null when it is not present.</returns>
+		private static HtmlNode ExtractDivNode(string htmlContent, string divClass)
 		{
 			HtmlDocument htmlDoc = new HtmlDocument();
 			htmlDoc.LoadHtml(htmlContent);
 
+			// Strip executable and styling content before anything walks the tree. Neither is
+			// rendered by either view, and leaving script bodies in place would let them
+			// surface as visible text.
 			foreach (var scriptOrStyle in htmlDoc.DocumentNode.SelectNodes("//script|//style") ?? Enumerable.Empty<HtmlNode>())
 			{
 				scriptOrStyle.Remove();
@@ -180,167 +191,11 @@ namespace FishMMO.Client
 			// NOTE: divClass comes from an Inspector field (not user input), so XPath injection is not a concern here.
 			// If this method is ever called with attacker-controlled input, parameterize the XPath.
 			HtmlNode divNode = htmlDoc.DocumentNode.SelectSingleNode($"//div[contains(@class, '{divClass}')]");
-			if (divNode != null)
+			if (divNode == null)
 			{
-				StringBuilder sb = new StringBuilder();
-				foreach (HtmlNode childNode in divNode.ChildNodes)
-				{
-					if (childNode.NodeType == HtmlNodeType.Element || childNode.NodeType == HtmlNodeType.Text)
-					{
-						sb.Append(ConvertHtmlNodeToTmpText(childNode));
-					}
-				}
-				return sb.ToString().Trim();
+				Log.Error("UnityHtmlContentFetcher", $"Div with class '{divClass}' not found in HTML content. Cannot extract news.");
 			}
-
-			Log.Error("UnityHtmlContentFetcher", $"Div with class '{divClass}' not found in HTML content. Cannot extract news.");
-			return string.Empty;
-		}
-
-		/// <summary>
-		/// Recursively converts an HtmlAgilityPack HtmlNode into a TextMeshPro rich text string.
-		/// Handles block elements, inline styles, and links.
-		/// </summary>
-		/// <param name="node">The HTML node to convert.</param>
-		/// <returns>Converted TMP rich text string.</returns>
-		private string ConvertHtmlNodeToTmpText(HtmlNode node, int depth = 0)
-		{
-			if (depth > maxRecursionDepth)
-			{
-				Log.Warning("UnityHtmlContentFetcher", $"Maximum recursion depth ({maxRecursionDepth}) exceeded. Truncating HTML conversion.");
-				return string.Empty;
-			}
-			StringBuilder sb = new StringBuilder();
-
-			if (node.NodeType == HtmlNodeType.Text)
-			{
-				return WebUtility.HtmlDecode(node.InnerText);
-			}
-
-			if (node.NodeType == HtmlNodeType.Comment)
-			{
-				return string.Empty;
-			}
-
-			// Collect all open tags in open order, then derive close tags by reversing.
-			// This ensures proper LIFO nesting regardless of CSS style attribute order,
-			// and guarantees each open tag gets exactly one close tag.
-			List<string> openTags = new List<string>();
-
-			string styleAttributes = node.GetAttributeValue("style", "");
-			if (!string.IsNullOrEmpty(styleAttributes))
-			{
-				foreach (Match match in Regex.Matches(styleAttributes, @"\s*(?<prop>[\w-]+)\s*:\s*(?<value>[^;]+);?"))
-				{
-					string prop = match.Groups["prop"].Value.ToLower();
-					string value = match.Groups["value"].Value.Trim();
-
-					switch (prop)
-					{
-						case "color":
-							openTags.Add($"<color={value}>");
-							break;
-						case "font-size":
-							if (value.EndsWith("%") && float.TryParse(value.Replace("%", ""), out float percentage))
-							{
-								// KNOWN LIMITATION: The percentage value is used directly as an absolute TMP
-								// size tag rather than being multiplied by a base font size. For example,
-								// "150%" produces <size=150> instead of <size=1.5 * baseFontSize>. To support
-								// percentage-based font sizes correctly, add a baseFontSize field and apply it:
-								// <size={(int)(percentage / 100f * baseFontSize)}>.
-								openTags.Add($"<size={(int)(percentage)}>");
-							}
-							else if (value.EndsWith("px") && float.TryParse(value.Replace("px", ""), out float pxValue))
-							{
-								openTags.Add($"<size={(int)(pxValue * HtmlPxToTmpSizeFactor)}>");
-							}
-							break;
-						case "text-align":
-							if (value == "center" || value == "left" || value == "right" || value == "justify")
-							{
-								openTags.Add($"<align=\"{value}\">");
-							}
-							break;
-					}
-				}
-			}
-
-			bool isBlockElement = false;
-			switch (node.Name.ToLower())
-			{
-				case "h1": openTags.Add("<size=180%>"); openTags.Add("<B>"); isBlockElement = true; break;
-				case "h2": openTags.Add("<size=150%>"); openTags.Add("<B>"); isBlockElement = true; break;
-				case "h3": openTags.Add("<size=130%>"); openTags.Add("<B>"); isBlockElement = true; break;
-				case "h4":
-				case "h5":
-				case "h6": openTags.Add("<B>"); isBlockElement = true; break;
-				case "strong":
-				case "b": openTags.Add("<B>"); break;
-				case "em":
-				case "i": openTags.Add("<I>"); break;
-				case "u": openTags.Add("<U>"); break;
-				case "li": sb.Append("• "); break;
-				case "br": sb.AppendLine(); return sb.ToString();
-				case "hr": sb.AppendLine("----------------------------------------"); sb.AppendLine(); return sb.ToString();
-				case "a":
-					string href = node.GetAttributeValue("href", "");
-					if (!string.IsNullOrEmpty(href))
-					{
-						openTags.Add("<color=#00FF00>");
-						openTags.Add($"<link=\"{href}\">");
-					}
-					break;
-				case "ul":
-				case "ol":
-				case "div":
-				case "p":
-					isBlockElement = true;
-					break;
-			}
-
-			if (isBlockElement && sb.Length > 0 && sb[sb.Length - 1] != '\n')
-			{
-				sb.AppendLine();
-			}
-
-			// Build the open tag string by concatenating tags in order
-			foreach (string tag in openTags)
-			{
-				sb.Append(tag);
-			}
-
-			foreach (HtmlNode child in node.ChildNodes)
-			{
-				sb.Append(ConvertHtmlNodeToTmpText(child, depth + 1));
-			}
-
-			// Build and append close tags by reversing the open order.
-			// Each open tag maps to its corresponding close tag.
-			for (int i = openTags.Count - 1; i >= 0; i--)
-			{
-				string tag = openTags[i];
-				if (tag.StartsWith("<color=", StringComparison.Ordinal))
-					sb.Append("</color>");
-				else if (tag.StartsWith("<size=", StringComparison.Ordinal))
-					sb.Append("</size>");
-				else if (tag.StartsWith("<align=", StringComparison.Ordinal))
-					sb.Append("</align>");
-				else if (tag.StartsWith("<link=", StringComparison.Ordinal))
-					sb.Append("</link>");
-				else if (tag == "<B>")
-					sb.Append("</B>");
-				else if (tag == "<I>")
-					sb.Append("</I>");
-				else if (tag == "<U>")
-					sb.Append("</U>");
-			}
-
-			if (isBlockElement && sb.Length > 0 && sb[sb.Length - 1] != '\n')
-			{
-				sb.AppendLine();
-			}
-
-			return sb.ToString();
+			return divNode;
 		}
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityWebRequestService.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Launcher/UnityWebRequestService.cs
@@ -232,18 +232,9 @@ namespace FishMMO.Client
 			}
 		}
 
-		/// <summary>
-		/// Formats a byte count (ulong) into a human-readable string (e.g., "1.2 MB").
-		/// This helper is placed here as it's often used in conjunction with network downloads.
-		/// </summary>
-		/// <param name="bytes">The number of bytes.</param>
-		/// <returns>A formatted string representing the byte count.</returns>
-		public string FormatBytes(ulong bytes)
-		{
-			if (bytes < 1024) return $"{bytes} B";
-			if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
-			if (bytes < 1024 * 1024 * 1024) return $"{bytes / (1024.0 * 1024.0):F1} MB";
-			return $"{bytes / (1024.0 * 1024.0 * 1024.0):F1} GB";
-		}
+		// Byte formatting moved to DownloadStats.FormatBytes when progress reporting became
+		// structured. It lives with the data it formats, and being static it is reachable
+		// without a component reference. Two copies of the same formatter would eventually
+		// disagree about what a megabyte looks like.
 	}
 }


### PR DESCRIPTION
Moves the launcher to UI Toolkit and gives it the feedback and settings a front door needs. Branched from current `dev`.

## Verified in a running build

Earlier revisions of this PR carried a caveat that the layout had never been rendered. That no longer applies — it has since been run end to end against a full local stack (Login/World/Scene servers, nginx, IPFetch, Patcher):

- Launcher renders; all elements resolve
- Login → world entry completes with no errors
- No `SetCharacter failed` during world entry, so no HUD panel threw
- 175/175 EditMode tests pass
- `FishMMO.Client`, `FishMMO.Shared`, `FishMMO.Server`, `FishMMO.UnitTests` and the Updater all build with 0 errors

One bug was found and fixed that way, and it is worth knowing about because the failure mode is nasty: an unclosed `ScrollView` tag made the UXML malformed, and **Unity imported it to an empty `VisualTreeAsset` without a single console error** — parse failures are recorded on an `ImportLog` sub-asset attached to the file instead of being printed. The scene referenced the empty asset happily and the launcher ran its entire flow against a tree with no elements in it, drawing a black screen. Element resolution now logs on success as well as failure, and treats an empty root as "not ready" rather than "nothing to find".

**Reverting to uGUI is two fields, no code**: clear `Launcher View Component` on `FishMMOClientLauncher`, re-activate the `Canvas` root. Nothing was deleted; the entire uGUI hierarchy is still in the scene.

## Rendering behind an interface, rather than a second launcher

The obvious way to do this was to copy `ClientLauncher` and swap its UI calls. That forks ~1300 lines of version-check and patch logic — including the six fixes you took into `dev` — so every future launcher bug needs fixing twice.

Instead `ILauncherView` describes the presentation surface and the logic stays in one place. Members express intent (*show this status*) rather than widget manipulation, because the two views differ in ways the state machine should not know about: the uGUI view has no dedicated status element and must borrow the progress label and reveal its parent group.

`UGUILauncherView` is deliberately **a plain class, not a component**. Promoting the serialized element fields onto a new MonoBehaviour would invalidate every reference the launcher scene has stored against `ClientLauncher` and silently break the working launcher until it was re-wired by hand. It stays the fallback whenever no view is assigned, so any scene without one is unaffected.

## News is a VisualElement tree

`IHtmlContentFetcher` now yields a parsed `HtmlNode` instead of TextMeshPro markup, because the two views share no text format. UI Toolkit parses only lowercase rich-text tags and has **no equivalent of TMP's link tag** — a news link has to be an element that can receive a click, not a span of styled text.

Building elements also closes an escaping hole: composing markup concatenates remote content into a string that is then parsed, so a news page containing tag-like text could alter the formatting of everything after it. Text assigned to a `Label` is never parsed as markup.

The URI scheme allowlist guarding `Application.OpenURL` moved to `LauncherLinkPolicy`, shared by both views rather than reimplemented — two copies of an allowlist drift, and a drifted allowlist is a vulnerability. Element count and traversal depth are both bounded, since the news URL is operator-configured and its content untrusted.

## Transfer stats

Progress is a `DownloadStats` snapshot rather than a preformatted `"42% (12.1 MB)"`, so views decide presentation.

Rate is measured over a **trailing window, not cumulatively**. Total-bytes-over-total-elapsed keeps reporting a healthy rate for minutes after a transfer has stalled, because the historical average props the number up — precisely when the player most needs to be told something is wrong.

Anything not yet known is omitted rather than shown as zero (`0 B/s` reads as a stall, not as an unmeasured value), and the ETA is null rather than large when the rate is zero. Total size comes from the manifest's `PatchInfo.Size`, which the server already returns, so the UI opens on "0 B of 240 MB" instead of an empty bar. Post-transfer SHA-256 verification is reported too — it streams the whole file, and without saying so the launcher looks hung at 100%.

## Settings

Persisted to the existing `Configuration.GlobalSettings` file, the same store the in-game Options panel uses. **The launcher has to load it itself** — only the Options panels did before, and those live in the world scene, so nothing had read a settings file this early.

Every getter clamps: these values reach the network layer and the file is plain text a player can edit. The transfer tunables take the component's serialized value as their fallback, so an install where nothing was changed behaves exactly as it does today.

Only timeout, retry count and retry delay are offered. Unity exposes no receive-buffer setting for `DownloadHandlerFile` and defers to the platform HTTP stack on desktop, so anything else would be theatre.

`Launcher.AutoUpdate` defaults to **true**, matching current behaviour. Off routes to a new `UpdateAvailable` state that names the download size and waits — on a metered connection that is the difference between a convenience and a cost. Changing the default would silently alter behaviour for every existing install.

## Configurable patch directory (touches the Updater)

`Launcher.PatchDirectory` lets large, transient archives live off a small system drive. The resolved path is passed to the Updater as `-patches=<dir>` instead of both sides deriving `<install root>/Patches` and agreeing by convention.

That was already fragile independent of the setting, because the failure is silent: the Updater reports "patch file not found", relaunches the client unchanged, the launcher detects the same mismatch, and the pair loops forever with nothing in the UI to indicate why.

- Both sides apply identical rules — absolute paths only, fall back to the default on anything unusable — so they fall back **together** rather than to different places.
- Relative paths are rejected deliberately: they resolve against whatever the current directory happens to be, which is not guaranteed to be the install root when the Updater is started by the OS rather than the launcher.
- `-patches` is only sent when set, so an Updater built before this argument existed still receives exactly the arguments it understands.
- It does **not** weaken integrity: the launcher verifies the archive against the server-supplied SHA-256 before the Updater is invoked, and anyone able to write the config file could equally drop a file into the default location.
- It is **not** a "move the game" setting and cannot be one — the Updater patches relative to its own directory and ships beside the client binaries. The UI says so rather than implying otherwise.

## Also

- **Folder picker** for the patch directory. Unity has no runtime folder dialog, so this calls the Windows shell directly; the button hides itself on other platforms and the path text field remains the real control everywhere. Failures return null and log rather than throwing.
- **Install size on disk**, measured on a thread-pool thread and only once the launcher is idle — never during a download, where it would contend for disk with the thing the player is waiting on. Files vanishing mid-walk are skipped; unknown reports as "unavailable", never "0 B".
- **Resizable window**, remembered across launches and debounced (a drag-resize changes the size every frame). Needs the "Resizable Window" Player Setting enabled to have any effect.
- **Art hooks** — empty backdrop, logo and hero elements that take artwork from USS alone. The hero band is collapsed until given an image so the layout does not gap.

## Testing

`FishMMO.Client` and `FishMMO-Patcher/Updater` both build with 0 errors. `FishMMO.Shared`, `FishMMO.Server` and `FishMMO.UnitTests` also build clean on the branch this was cut from.

Not covered: rendering, and a real patch download end to end. The Editor cannot exercise the download path at all — `BeginStartupFlow` skips the version check under `#if UNITY_EDITOR` — so that needs a standalone build against a live patch server.

## Splitting

This is much larger than the last one. If it is easier to review in pieces, the commit history on my branch separates cleanly into: the `ILauncherView` extraction (no behaviour change), the UI Toolkit view, transfer stats, settings, install size + resize + art, and the patch-directory change. Say the word and I will resend it as a stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
