### PR TITLE
Build: don't queue a second script compile on a batch-mode target switch

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/BuildEnvironmentOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/BuildEnvironmentOptions.cs
@@ -281,8 +281,19 @@ namespace FishMMO.Shared
 				AssetDatabase.SaveAssets();
 				AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
 
-				// Force script recompilation (non-blocking)
-				ForceEditorScriptRecompile();
+				/* Force script recompilation (non-blocking).
+				 *
+				 * Skipped in batch mode. SwitchActiveBuildTarget above is synchronous and
+				 * already recompiles for the new target, and the ForceUpdate refresh settles
+				 * the define symbols this was added to refresh. Queueing a further compile on
+				 * top of that is actively harmful under -executeMethod: nothing runs the editor
+				 * loop until the method returns, so that compile stays pending, and the CLI
+				 * build that follows is rejected for running while scripts compile. That is
+				 * what made every batch-mode build following a target switch fail. */
+				if (!UnityEngine.Application.isBatchMode)
+				{
+					ForceEditorScriptRecompile();
+				}
 
 				UnityEngine.Debug.Log($"[BuildEnvironmentOptions] Build target switched to: {targetBuild}:{targetSubtarget}. Scripts will recompile automatically.");
 			}

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Core/CustomBuildTool.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Core/CustomBuildTool.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 using UnityEditor;
 using UnityEditorInternal;
 using System.IO;
@@ -420,6 +420,21 @@ namespace FishMMO.Shared.CustomBuildTool.Core
 				BuildEnvironmentOptions.SetBuildType(buildType);
 				BuildEnvironmentOptions.SetOSTarget(osTarget);
 				BuildEnvironmentOptions.SwitchToEnvironmentBuildTarget();
+
+				/* SwitchToEnvironmentBuildTarget recompiles for the new target before it
+				 * returns, so scripts should be settled by the time we get here. If they are
+				 * not, the Addressables/player builds below reject the request for running
+				 * while scripts are compiling, and under -batchmode there is nothing this
+				 * thread can do about it: compilation is driven by the editor loop, which
+				 * does not turn over until this method returns. Waiting here cannot help and
+				 * sleeping actively prevents it, so fail immediately with a clear reason
+				 * rather than hand back an opaque build rejection. */
+				if (Application.isBatchMode && BuildEnvironmentOptions.IsCompiling())
+				{
+					UnityEngine.Debug.LogError("[CustomBuildTool] Scripts are still compiling after the build target switch; cannot start a CLI build.");
+					EditorApplication.Exit(1);
+					return;
+				}
 
 				if (includeAddressables)
 				{


### PR DESCRIPTION
## Problem

A CLI build that has to switch build target can be rejected for running while scripts are compiling, producing no artifact. Re-running the identical command immediately afterwards succeeds, because by then the target already matches and no switch happens.

## Cause

`SwitchActiveBuildTarget` is synchronous and already recompiles for the new target, and the `AssetDatabase.Refresh(ForceUpdate)` that follows settles the define symbols. `ForceEditorScriptRecompile` then queues a *further* compile on top of that.

Under `-executeMethod` nothing turns the editor loop over until the method returns, so that extra compile stays pending for the rest of the invocation — and the Addressables/player build that follows is refused for running while scripts compile.

## Change

- Skip the redundant recompile in batch mode. Interactive Dashboard builds keep it, where the editor loop can service it, and stay non-blocking so the UI doesn't freeze.
- Fail fast in `RunCliBuild` if scripts somehow are still compiling, naming the reason instead of surfacing an opaque build rejection. Nothing on that thread can advance a pending compile in batch mode, so waiting cannot help — and sleeping would block the very thread that runs compilation.

## Verification

A full server build now succeeds in a single invocation starting from the Client build target — previously the failing case. The resulting dedicated server binary runs and binds its ports.

Verified on Unity 6000.4.10f1, Windows, `BuildServerCLI` and `BuildAddressablesCLI` in both switch directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)