### PR TITLE
UI Toolkit: carry the rest of the panel lifecycle across from UGUI

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bc50cfddcc247a4fbaac749978193a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/FishMMO.Client.GUI.Editor.asmdef
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/FishMMO.Client.GUI.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "FishMMO.Client.GUI.Editor",
+    "rootNamespace": "FishMMO.Client",
+    "references": [
+        "FishMMO.Client",
+        "FishMMO.Shared"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/FishMMO.Client.GUI.Editor.asmdef.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/FishMMO.Client.GUI.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c5e8147ccd9a3448aaaf6d294baed5d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/UITKPanelWiringTool.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/UITKPanelWiringTool.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UIElements;
+
+namespace FishMMO.Client.Editor
+{
+	/// <summary>
+	/// Wires UI Toolkit panels into the open scene: for each <see cref="UITKControl"/> subclass
+	/// that has no GameObject yet, creates one with a configured <see cref="UIDocument"/> and
+	/// deactivates the legacy UGUI panel it replaces.
+	/// </summary>
+	/// <remarks>
+	/// The UI Toolkit migration wrote a control, a UXML and a USS per panel, but placing each one
+	/// in a scene stayed a manual step — so a panel could be fully implemented and still never
+	/// appear, with the legacy version answering in its place. That is not a state the project
+	/// can detect on its own: <see cref="UIManager"/> resolves panels by GameObject name, so an
+	/// unwired panel looks exactly like one that was never written.
+	/// <para>
+	/// Scene authoring belongs in the editor, so this does the mechanical part and reports
+	/// anything it will not decide for itself rather than guessing.
+	/// </para>
+	/// </remarks>
+	public static class UITKPanelWiringTool
+	{
+		/// <summary>Panel settings asset applied to every generated <see cref="UIDocument"/>.</summary>
+		private const string PanelSettingsPath = "Assets/UI Toolkit/PanelSettings.asset";
+
+		/// <summary>Prefix on the UI Toolkit control types.</summary>
+		private const string ControlPrefix = "UITK";
+
+		/// <summary>Prefix shared by GameObject names, UXML file names and legacy controls.</summary>
+		private const string PanelPrefix = "UI";
+
+		/// <summary>
+		/// What wiring a single panel would do, or why it cannot be done.
+		/// </summary>
+		private sealed class PanelPlan
+		{
+			public Type ControlType;
+			public string PanelName;
+			public VisualTreeAsset SourceAsset;
+			public GameObject LegacyObject;
+			public string SkipReason;
+		}
+
+		/// <summary>
+		/// Reports what wiring would do without changing anything.
+		/// </summary>
+		[MenuItem("FishMMO/UI Toolkit/Report Unwired Panels", priority = 100)]
+		public static void ReportUnwiredPanels()
+		{
+			List<PanelPlan> plans = BuildPlans();
+			Debug.Log(Describe(plans, "Report only — nothing was changed."));
+		}
+
+		/// <summary>
+		/// Wires every panel that can be wired into the currently open scene.
+		/// </summary>
+		[MenuItem("FishMMO/UI Toolkit/Wire Unwired Panels Into Open Scene", priority = 101)]
+		public static void WireUnwiredPanels()
+		{
+			List<PanelPlan> plans = BuildPlans();
+			List<PanelPlan> actionable = plans.Where(p => p.SkipReason == null).ToList();
+
+			if (actionable.Count == 0)
+			{
+				Debug.Log(Describe(plans, "Nothing to wire."));
+				return;
+			}
+
+			Scene scene = SceneManager.GetActiveScene();
+			bool proceed = EditorUtility.DisplayDialog(
+				"Wire UI Toolkit Panels",
+				$"Wire {actionable.Count} panel(s) into '{scene.name}'?\n\n" +
+				"Each one gets a new GameObject with a UIDocument and its control, and the legacy " +
+				"UGUI panel of the same name is deactivated (not deleted).\n\n" +
+				"This is undoable, and the scene is not saved for you.",
+				"Wire Them",
+				"Cancel");
+
+			if (!proceed)
+			{
+				return;
+			}
+
+			PanelSettings panelSettings = AssetDatabase.LoadAssetAtPath<PanelSettings>(PanelSettingsPath);
+			if (panelSettings == null)
+			{
+				Debug.LogError($"[UITKPanelWiringTool] Panel settings not found at '{PanelSettingsPath}'. Nothing was wired.");
+				return;
+			}
+
+			int undoGroup = Undo.GetCurrentGroup();
+			Undo.SetCurrentGroupName("Wire UI Toolkit Panels");
+
+			foreach (PanelPlan plan in actionable)
+			{
+				WirePanel(plan, panelSettings);
+			}
+
+			Undo.CollapseUndoOperations(undoGroup);
+			EditorSceneManager.MarkSceneDirty(scene);
+
+			Debug.Log(Describe(plans, $"Wired {actionable.Count} panel(s) into '{scene.name}'. Save the scene to keep this."));
+		}
+
+		/// <summary>
+		/// Creates the GameObject, document and control for one panel, and retires its legacy twin.
+		/// </summary>
+		private static void WirePanel(PanelPlan plan, PanelSettings panelSettings)
+		{
+			GameObject go = new GameObject(plan.PanelName);
+			Undo.RegisterCreatedObjectUndo(go, "Create UI Toolkit Panel");
+
+			UIDocument document = Undo.AddComponent<UIDocument>(go);
+			document.panelSettings = panelSettings;
+			document.visualTreeAsset = plan.SourceAsset;
+
+			UITKControl control = (UITKControl)Undo.AddComponent(go, plan.ControlType);
+			control.Document = document;
+
+			/* Visibility flags are copied from the legacy panel rather than defaulted. They decide
+			 * whether a panel is on screen at world entry and whether quitting to login closes it,
+			 * and the answer differs per panel — a HUD element that is always open and a dialog
+			 * that opens on demand disagree on every one of them. The legacy panel is the only
+			 * place that answer already exists. */
+			if (plan.LegacyObject != null)
+			{
+				UIControl legacy = plan.LegacyObject.GetComponent<UIControl>();
+				if (legacy != null)
+				{
+					control.StartOpen = legacy.StartOpen;
+					control.IsAlwaysOpen = legacy.IsAlwaysOpen;
+					control.CloseOnQuitToMenu = legacy.CloseOnQuitToMenu;
+
+					/* CloseOnEscape is what gates the legacy cursor release, so it is the existing
+					 * answer to "is this a window the player clicks, or a HUD element?" — which is
+					 * exactly what ReleasesCursor decides. Different name, same question. */
+					control.ReleasesCursor = legacy.CloseOnEscape;
+				}
+
+				if (plan.LegacyObject.activeSelf)
+				{
+					Undo.RecordObject(plan.LegacyObject, "Deactivate Legacy Panel");
+					plan.LegacyObject.SetActive(false);
+				}
+			}
+
+			EditorUtility.SetDirty(go);
+		}
+
+		/// <summary>
+		/// Works out, for every UI Toolkit control type, whether it can be wired and how.
+		/// </summary>
+		private static List<PanelPlan> BuildPlans()
+		{
+			List<PanelPlan> plans = new List<PanelPlan>();
+
+			IEnumerable<Type> controlTypes = TypeCache.GetTypesDerivedFrom<UITKControl>()
+				.Where(t => !t.IsAbstract)
+				.OrderBy(t => t.Name);
+
+			GameObject[] sceneRoots = SceneManager.GetActiveScene().GetRootGameObjects();
+
+			foreach (Type type in controlTypes)
+			{
+				PanelPlan plan = new PanelPlan { ControlType = type };
+
+				if (!type.Name.StartsWith(ControlPrefix, StringComparison.Ordinal))
+				{
+					plan.SkipReason = $"type name does not start with '{ControlPrefix}'";
+					plans.Add(plan);
+					continue;
+				}
+
+				plan.PanelName = PanelPrefix + type.Name.Substring(ControlPrefix.Length);
+
+				// Already wired: a control of this exact type is present in the scene.
+				if (sceneRoots.Any(r => r.GetComponentsInChildren(type, true).Length > 0))
+				{
+					plan.SkipReason = "already in this scene";
+					plans.Add(plan);
+					continue;
+				}
+
+				plan.SourceAsset = FindSourceAsset(type, plan.PanelName);
+				if (plan.SourceAsset == null)
+				{
+					/* Panels that share a UXML — the resource bars all use UIResourceBar.uxml —
+					 * cannot be resolved from the name alone, and picking one would be a guess
+					 * about which document a panel is meant to display. Reported instead. */
+					plan.SkipReason = $"no '{plan.PanelName}.uxml' beside the script; wire this one by hand";
+					plans.Add(plan);
+					continue;
+				}
+
+				plan.LegacyObject = FindLegacyPanel(sceneRoots, plan.PanelName);
+				if (plan.LegacyObject == null)
+				{
+					/* A panel is wired into the scene that already hosts the version it replaces.
+					 * Without that twin there is nothing to say this panel belongs here: the login
+					 * panels live in ClientLoginGUI and the shared dialogs in ClientPreboot, and
+					 * creating them here would put a login screen in the world scene. The same
+					 * answer covers a genuinely new panel that has no legacy version anywhere —
+					 * where it goes is a design decision, not one to infer from a name. */
+					plan.SkipReason = $"no legacy '{plan.PanelName}' in this scene; it likely belongs to another scene, or is new — place this one by hand";
+					plans.Add(plan);
+					continue;
+				}
+
+				plans.Add(plan);
+			}
+
+			return plans;
+		}
+
+		/// <summary>
+		/// Finds the UXML sitting beside the control's own source file.
+		/// </summary>
+		private static VisualTreeAsset FindSourceAsset(Type type, string panelName)
+		{
+			string[] scriptGuids = AssetDatabase.FindAssets($"{type.Name} t:MonoScript");
+			foreach (string guid in scriptGuids)
+			{
+				string scriptPath = AssetDatabase.GUIDToAssetPath(guid);
+				if (Path.GetFileNameWithoutExtension(scriptPath) != type.Name)
+				{
+					continue;
+				}
+
+				string directory = Path.GetDirectoryName(scriptPath)?.Replace('\\', '/');
+				if (string.IsNullOrEmpty(directory))
+				{
+					continue;
+				}
+
+				string candidate = $"{directory}/{panelName}.uxml";
+				VisualTreeAsset asset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(candidate);
+				if (asset != null)
+				{
+					return asset;
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Finds an active legacy UGUI panel occupying the name this panel wants.
+		/// </summary>
+		/// <remarks>
+		/// Matched by name because that is what <see cref="UIManager"/> resolves on. Two objects
+		/// may end up sharing a name, one of them inactive — which is what the already-migrated
+		/// panels look like, and is harmless: an inactive GameObject never runs Awake, so it never
+		/// registers.
+		/// </remarks>
+		private static GameObject FindLegacyPanel(GameObject[] sceneRoots, string panelName)
+		{
+			foreach (GameObject root in sceneRoots)
+			{
+				foreach (UIControl legacy in root.GetComponentsInChildren<UIControl>(true))
+				{
+					// Inactive ones count. A panel that opens on demand may sit deactivated in the
+					// scene, and it still carries the visibility flags worth copying.
+					if (legacy.gameObject.name == panelName)
+					{
+						return legacy.gameObject;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Builds a readable summary of what was, or would be, done.
+		/// </summary>
+		private static string Describe(List<PanelPlan> plans, string headline)
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.AppendLine($"[UITKPanelWiringTool] {headline}");
+
+			List<PanelPlan> actionable = plans.Where(p => p.SkipReason == null).ToList();
+			if (actionable.Count > 0)
+			{
+				sb.AppendLine($"\nWirable ({actionable.Count}):");
+				foreach (PanelPlan p in actionable)
+				{
+					string legacy = p.LegacyObject != null && p.LegacyObject.activeSelf ? " (deactivates legacy panel)" : " (legacy already inactive)";
+					sb.AppendLine($"  {p.PanelName}  <- {p.ControlType.Name}{legacy}");
+				}
+			}
+
+			List<PanelPlan> needsHand = plans
+				.Where(p => p.SkipReason != null && p.SkipReason != "already in this scene")
+				.ToList();
+			if (needsHand.Count > 0)
+			{
+				sb.AppendLine($"\nNeeds a decision ({needsHand.Count}):");
+				foreach (PanelPlan p in needsHand)
+				{
+					sb.AppendLine($"  {p.ControlType.Name}: {p.SkipReason}");
+				}
+			}
+
+			int already = plans.Count(p => p.SkipReason == "already in this scene");
+			sb.AppendLine($"\nAlready in this scene: {already}");
+
+			return sb.ToString();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/UITKPanelWiringTool.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/Editor/UITKPanelWiringTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bd068660cbe0994c821c1986c103bce

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKCharacterControl.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKCharacterControl.cs
@@ -63,6 +63,26 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
+		/// Re-applies the character once the visual tree exists.
+		/// </summary>
+		/// <remarks>
+		/// World entry calls <see cref="UIManager.SetCharacter"/> for every control at once, and
+		/// a control that starts hidden has no visual tree until something shows it — so
+		/// <see cref="OnPostSetCharacter"/> can run before <c>OnStarting</c> has cached any
+		/// elements. Overrides that write into those elements would then dereference null, and
+		/// even a null-safe one would leave the panel showing nothing, because the only call
+		/// that had data already happened. Running it again here is what makes the two orders
+		/// equivalent.
+		/// </remarks>
+		protected override void OnAfterStarting()
+		{
+			if (Character != null)
+			{
+				OnPostSetCharacter();
+			}
+		}
+
+		/// <summary>
 		/// Invoked before <see cref="Character"/> is cleared. Override to perform
 		/// any pre-unset cleanup.
 		/// </summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKCharacterControl.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKCharacterControl.cs
@@ -78,6 +78,11 @@ namespace FishMMO.Client
 		{
 			if (Character != null)
 			{
+				/* Pre before Post, exactly as SetCharacter does it. This runs again whenever the
+				 * visual tree is rebuilt, and OnPostSetCharacter subscribes to character events —
+				 * without the matching unsubscribe first, every rebuild would add another
+				 * subscription and the handlers would run once more each time. */
+				OnPreSetCharacter();
 				OnPostSetCharacter();
 			}
 		}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
@@ -1,6 +1,7 @@
-using System.Collections;
+﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.UIElements;
+using FishMMO.Logging;
 using FishMMO.Shared;
 
 namespace FishMMO.Client
@@ -35,6 +36,23 @@ namespace FishMMO.Client
 		public bool CloseOnQuitToMenu = true;
 
 		/// <summary>
+		/// If true, showing this panel releases the mouse cursor so it can be clicked.
+		/// </summary>
+		/// <remarks>
+		/// Mirrors what <see cref="UIControl"/> does for its own panels, where the same behaviour
+		/// is gated on <c>CloseOnEscape</c>: a window the player interacts with needs the cursor,
+		/// and a HUD element that is permanently on screen must not take it away. Defaulting this
+		/// to false keeps bars and hotkey strips from stealing the cursor the moment they appear.
+		/// <para>
+		/// Only ever set true here, never false, which matches the legacy panels — releasing the
+		/// cursor is a panel's business but recapturing it is not, since another panel may still
+		/// be open. <see cref="PlayerInputController"/> and <see cref="Client"/> own the reset.
+		/// </para>
+		/// </remarks>
+		[Tooltip("Show() releases the mouse cursor. Enable for windows and dialogs, not for HUD elements.")]
+		public bool ReleasesCursor = false;
+
+		/// <summary>
 		/// GameObject name; used as the key in <see cref="UIManager"/>.
 		/// </summary>
 		public string Name => gameObject.name;
@@ -59,6 +77,23 @@ namespace FishMMO.Client
 		/// True once <see cref="OnStarting"/> has run against a populated visual tree.
 		/// </summary>
 		private bool hasStarted;
+
+		/// <summary>
+		/// The first child of the visual tree <see cref="OnStarting"/> last ran against, used to
+		/// notice when the tree has been replaced underneath us.
+		/// </summary>
+		/// <remarks>
+		/// Hiding a panel disables its <see cref="UIDocument"/>, and re-enabling it clones the
+		/// UXML afresh. Every element reference an override cached during <c>OnStarting</c> then
+		/// points into a tree that is no longer displayed: writes to it are silently lost and the
+		/// panel shows whatever the UXML declares. A label authored as a placeholder keeps
+		/// reading that placeholder, and a bar fill keeps whatever width the stylesheet gave it.
+		/// <para>
+		/// Comparing identity of the first child is enough to catch a re-clone, and costs one
+		/// reference comparison per Show.
+		/// </para>
+		/// </remarks>
+		private VisualElement startedTreeRoot;
 
 		/// <summary>
 		/// Registers this control with the <see cref="UIManager"/>, applies
@@ -133,6 +168,7 @@ namespace FishMMO.Client
 			}
 
 			this.hasStarted = true;
+			this.startedTreeRoot = root[0];
 			OnStarting();
 			OnAfterStarting();
 			return true;
@@ -261,6 +297,60 @@ namespace FishMMO.Client
 			}
 			Document.enabled = true;
 			Visible = true;
+
+			if (ReleasesCursor)
+			{
+				PlayerInputController.MouseMode = true;
+
+				/* Registered together with the cursor release, and not optional. The input
+				 * controller recaptures the cursor on every frame where nothing is registered as
+				 * closeable, so a panel that releases it without registering gets it taken back
+				 * before the player can click anything. Escape closing the panel falls out of the
+				 * same registration. */
+				UIManager.RegisterCloseOnEscapeTK(this);
+			}
+
+			ReinitializeIfTreeReplaced();
+		}
+
+		/// <summary>
+		/// Re-runs initialisation when the visual tree has been rebuilt since it last ran.
+		/// </summary>
+		/// <remarks>
+		/// See <see cref="startedTreeRoot"/> for why the tree can change identity. If it has not
+		/// changed this is a single reference comparison and does nothing, so it is safe to call
+		/// on every Show regardless of whether a given panel ever gets hidden.
+		/// </remarks>
+		private void ReinitializeIfTreeReplaced()
+		{
+			if (!this.hasStarted)
+			{
+				// Never initialised; the startup retry still owns this.
+				return;
+			}
+
+			VisualElement root = Root;
+			if (root == null || root.childCount == 0)
+			{
+				return;
+			}
+
+			if (ReferenceEquals(root[0], this.startedTreeRoot))
+			{
+				return;
+			}
+
+			Log.Debug("UITKControl", $"[{Name}] Visual tree was replaced; re-resolving elements.");
+
+			this.startedTreeRoot = root[0];
+
+			/* Both halves run. Re-resolving elements alone is not enough: panels that build their
+			 * contents from character state do it in OnPostSetCharacter, so a rebuilt tree would
+			 * come back correctly wired and completely empty — an inventory with no slots in it.
+			 * OnAfterStarting re-applies that state, and pairs Pre with Post so re-running it does
+			 * not stack up duplicate event subscriptions. */
+			OnStarting();
+			OnAfterStarting();
 		}
 
 		/// <summary>
@@ -283,6 +373,8 @@ namespace FishMMO.Client
 			}
 			Document.enabled = false;
 			Visible = false;
+
+			UIManager.UnregisterCloseOnEscapeTK(this);
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UIElements;
 using FishMMO.Shared;
@@ -55,25 +56,109 @@ namespace FishMMO.Client
 		protected VisualElement Root => Document != null ? Document.rootVisualElement : null;
 
 		/// <summary>
-		/// Registers this control with the <see cref="UIManager"/>, calls <see cref="OnStarting"/>,
-		/// and hides the panel if <see cref="StartOpen"/> is false.
+		/// True once <see cref="OnStarting"/> has run against a populated visual tree.
+		/// </summary>
+		private bool hasStarted;
+
+		/// <summary>
+		/// Registers this control with the <see cref="UIManager"/>, applies
+		/// <see cref="StartOpen"/>, and runs <see cref="OnStarting"/> as soon as the visual
+		/// tree exists.
 		/// </summary>
 		private void Awake()
 		{
 			UIManager.RegisterTK(this);
 
-			OnStarting();
-
+			// Applied before OnStarting, and independently of it. A panel's initial visibility
+			// must not wait on the visual tree, and a hidden panel disables its UIDocument —
+			// which is precisely why OnStarting cannot run here for every control.
 			if (!StartOpen)
 			{
 				Hide();
 			}
+
+			if (!TryStart())
+			{
+				StartCoroutine(WaitForVisualTree());
+			}
 		}
 
 		/// <summary>
-		/// Called at the end of the MonoBehaviour Awake function.
+		/// Retries initialisation until the visual tree exists.
+		/// </summary>
+		/// <remarks>
+		/// A coroutine rather than <c>Update</c> deliberately. Unity dispatches magic methods to
+		/// the most-derived declaration, and several controls — <c>UITKResourceBar</c> and
+		/// <c>UITKHotkeyBar</c> among them — declare their own <c>Update</c>, which would shadow
+		/// a base one and silently disable this retry for exactly the panels that need it.
+		/// A coroutine cannot be shadowed that way.
+		/// <para>
+		/// A panel that starts hidden has its UIDocument disabled and therefore no tree, so this
+		/// keeps waiting until something shows it. The GameObject itself stays active
+		/// throughout — only the document is disabled — so the coroutine survives.
+		/// </para>
+		/// </remarks>
+		private IEnumerator WaitForVisualTree()
+		{
+			while (!TryStart())
+			{
+				yield return null;
+			}
+		}
+
+		/// <summary>
+		/// Runs <see cref="OnStarting"/> exactly once, and only when the visual tree is
+		/// actually populated.
+		/// </summary>
+		/// <remarks>
+		/// This used to be called directly from <see cref="Awake"/>, which was too early.
+		/// <see cref="UIDocument"/> allocates <c>rootVisualElement</c> up front but only clones
+		/// the UXML into it during its own <c>OnEnable</c> — after every component's Awake — so
+		/// Awake sees a real but empty root. Every <c>Q&lt;&gt;</c> in an override returned
+		/// null, was cached as null, and never re-resolved, leaving controls that looked
+		/// initialised but were wired to nothing.
+		/// </remarks>
+		private bool TryStart()
+		{
+			if (this.hasStarted)
+			{
+				return true;
+			}
+
+			VisualElement root = Root;
+			if (root == null || root.childCount == 0)
+			{
+				// Not an error: the document may be disabled, or its tree not cloned yet.
+				return false;
+			}
+
+			this.hasStarted = true;
+			OnStarting();
+			OnAfterStarting();
+			return true;
+		}
+
+		/// <summary>
+		/// Called immediately after <see cref="OnStarting"/>. Override to re-apply any state
+		/// that arrived before the visual tree existed.
+		/// </summary>
+		/// <remarks>
+		/// Initialisation is no longer guaranteed to happen before the control is given data.
+		/// A panel that starts hidden has no visual tree until it is shown, and world entry can
+		/// hand it a character in the meantime — so whatever it was told before it had elements
+		/// to write into has to be applied again here, or the panel stays blank.
+		/// </remarks>
+		protected virtual void OnAfterStarting() { }
+
+		/// <summary>
+		/// Called once the control's visual tree is available.
 		/// Override to perform one-time initialisation against <see cref="Root"/>.
 		/// </summary>
+		/// <remarks>
+		/// Guaranteed to see a populated <see cref="Root"/>. For a control that starts hidden
+		/// this runs when it is first shown rather than at Awake, because a hidden panel's
+		/// UIDocument is disabled and has no tree to query.
+		/// </remarks>
 		public virtual void OnStarting() { }
 
 		/// <summary>
@@ -131,6 +216,14 @@ namespace FishMMO.Client
 				Show();
 			}
 			OnQuitToLogin();
+
+			/* OnQuitToLogin stops all coroutines by default, which would silently take the
+			 * initialisation retry with it — leaving a control that had not yet seen its visual
+			 * tree permanently uninitialised after a single quit to login. Restart it. */
+			if (!this.hasStarted)
+			{
+				StartCoroutine(WaitForVisualTree());
+			}
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uss
@@ -3,7 +3,15 @@
     Layout for the chat panel. Colours come from FishMMO-Theme.uss.
 */
 
+/*
+    Anchored bottom-right. Each panel is its own UIDocument whose root fills the screen, so a
+    panel with a size but no position resolves to the top-left corner rather than anywhere
+    meaningful — which is where this sat.
+*/
 .chat-panel {
+    position: absolute;
+    left: 24px;
+    bottom: 40px;
     width: 420px;
     height: 280px;
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Equipment/UITKEquipment.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Equipment/UITKEquipment.cs
@@ -300,7 +300,11 @@ namespace FishMMO.Client
 				equipmentController.OnSlotUpdated    -= OnEquipmentSlotUpdated;
 				equipmentController.OnSlotLockChanged -= OnEquipmentSlotLockChanged;
 
-				for (int i = 0; i < slotViews.Length; ++i)
+				// The array itself is null until OnStarting builds it, and OnStarting does not
+				// run until this panel's visual tree exists — which, for a panel that starts
+				// hidden, is after world entry has already handed it a character. The existing
+				// per-slot check guards the elements, not the array holding them.
+				for (int i = 0; slotViews != null && i < slotViews.Length; ++i)
 				{
 					if (slotViews[i].Root == null)
 					{

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/HotkeyBar/UIHotkeyBar.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/HotkeyBar/UIHotkeyBar.uss
@@ -4,9 +4,17 @@
     (slots reuse the .fish-slot look where useful; cooldown/label are bar-specific).
 */
 
+/*
+    Fills the panel and pushes the strip to the bottom edge. Without flex-grow the root
+    collapses to the height of its contents, and a zero-height element sits at the top of
+    the screen — which is where the bar was appearing. justify-content places it along the
+    vertical axis, so flex-end is what puts it at the bottom rather than centred.
+*/
 .hotkey-bar {
+    flex-grow: 1;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
+    padding-bottom: 24px;
     background-color: rgba(0, 0, 0, 0);
 }
 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UIResourceBar.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UIResourceBar.uss
@@ -3,11 +3,24 @@
     Layout only — colours come from FishMMO-Theme.uss (.fish-bar, .fish-bar__fill--*).
 */
 
+/*
+    Each bar lives in its own UIDocument, so the three cannot be laid out relative to one
+    another by a shared container — every panel root fills the screen independently. Left
+    unanchored they all resolved to the same full-width strip across the top and drew on top
+    of each other, so only whichever panel sorted last was visible and the other two looked
+    like they were missing entirely. Anchoring each one explicitly is what keeps them apart.
+*/
 .res-bar {
-    width: 100%;
+    position: absolute;
+    left: 24px;
+    width: 220px;
     height: 22px;
-    position: relative;
 }
+
+/* Stacked bottom-left, clear of the hotkey bar along the bottom centre. */
+.res-bar--hp   { bottom: 96px; }
+.res-bar--mp   { bottom: 68px; }
+.res-bar--stam { bottom: 40px; }
 
 /* The fill grows left-to-right; width is driven from C# as a percentage. */
 .res-bar__fill {

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKHealthBar.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKHealthBar.cs
@@ -1,4 +1,4 @@
-namespace FishMMO.Client
+﻿namespace FishMMO.Client
 {
 	/// <summary>
 	/// UI Toolkit health bar. Inherits resource bar logic from <see cref="UITKResourceBar"/>.
@@ -7,5 +7,8 @@ namespace FishMMO.Client
 	{
 		/// <inheritdoc />
 		protected override string FillModifierClass => "fish-bar__fill--hp";
+
+		/// <inheritdoc/>
+		protected override string RootModifierClass => "res-bar--hp";
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKManaBar.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKManaBar.cs
@@ -1,4 +1,4 @@
-namespace FishMMO.Client
+﻿namespace FishMMO.Client
 {
 	/// <summary>
 	/// UI Toolkit mana bar. Inherits resource bar logic from <see cref="UITKResourceBar"/>.
@@ -7,5 +7,8 @@ namespace FishMMO.Client
 	{
 		/// <inheritdoc />
 		protected override string FillModifierClass => "fish-bar__fill--mp";
+
+		/// <inheritdoc/>
+		protected override string RootModifierClass => "res-bar--mp";
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKResourceBar.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKResourceBar.cs
@@ -160,6 +160,13 @@ namespace FishMMO.Client
 		/// </summary>
 		private void ApplyFill()
 		{
+			// Null until OnStarting has run, which does not happen until this panel's visual
+			// tree exists — and an attribute update can arrive before that. The value is not
+			// lost: UITKCharacterControl re-applies the character once the tree is available.
+			if (fill == null)
+			{
+				return;
+			}
 			fill.style.width = Length.Percent(Mathf.Clamp01(displayedValue) * 100.0f);
 		}
 	}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKResourceBar.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKResourceBar.cs
@@ -19,6 +19,9 @@ namespace FishMMO.Client
 		/// <summary>Name of the value label inside the resource-bar UXML.</summary>
 		private const string LABEL_NAME = "bar-label";
 
+		/// <summary>Name of the bar's own root element inside the resource-bar UXML.</summary>
+		private const string BAR_ROOT_NAME = "bar-root";
+
 		/// <summary>
 		/// The attribute template ID used to identify which resource this bar represents.
 		/// </summary>
@@ -43,6 +46,18 @@ namespace FishMMO.Client
 		/// (e.g. "fish-bar__fill--hp"). Supplied by the concrete subclass.
 		/// </summary>
 		protected abstract string FillModifierClass { get; }
+
+		/// <summary>
+		/// USS modifier class applied to the bar root to place it on screen
+		/// (e.g. "res-bar--hp"). Supplied by the concrete subclass.
+		/// </summary>
+		/// <remarks>
+		/// Each bar owns a separate <see cref="UIDocument"/>, so the three of them cannot be
+		/// laid out relative to one another by a shared container — every panel root fills the
+		/// screen independently. Without a per-bar anchor they all resolve to the same strip
+		/// and draw on top of each other, leaving only whichever panel sorts last visible.
+		/// </remarks>
+		protected abstract string RootModifierClass { get; }
 
 		/// <summary>Cached reference to the bar fill element.</summary>
 		private VisualElement fill;
@@ -72,6 +87,14 @@ namespace FishMMO.Client
 			if (fill != null && !string.IsNullOrEmpty(FillModifierClass))
 			{
 				fill.AddToClassList(FillModifierClass);
+			}
+
+			// Applied to the bar root itself rather than the panel root, which belongs to the
+			// UIDocument and is shared with nothing.
+			VisualElement barRoot = root.Q(BAR_ROOT_NAME);
+			if (barRoot != null && !string.IsNullOrEmpty(RootModifierClass))
+			{
+				barRoot.AddToClassList(RootModifierClass);
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKStaminaBar.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ResourceBar/UITKStaminaBar.cs
@@ -1,4 +1,4 @@
-namespace FishMMO.Client
+﻿namespace FishMMO.Client
 {
 	/// <summary>
 	/// UI Toolkit stamina bar. Inherits resource bar logic from <see cref="UITKResourceBar"/>.
@@ -7,5 +7,8 @@ namespace FishMMO.Client
 	{
 		/// <inheritdoc />
 		protected override string FillModifierClass => "fish-bar__fill--stam";
+
+		/// <inheritdoc/>
+		protected override string RootModifierClass => "res-bar--stam";
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Target/UITKTarget.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Target/UITKTarget.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FishNet;
 using FishMMO.Shared;
 using FishMMO.Shared.Core;
@@ -19,6 +19,9 @@ namespace FishMMO.Client
 
 		/// <summary>Name of the target health fill element.</summary>
 		private const string HEALTH_FILL_NAME = "target-health-fill";
+
+		/// <summary>Name of the target health bar container element.</summary>
+		private const string HEALTH_BAR_NAME = "target-health";
 
 		/// <summary>Name of the container that holds the target's buff icons.</summary>
 		private const string BUFF_LIST_NAME = "target-buff-list";
@@ -53,6 +56,9 @@ namespace FishMMO.Client
 		private Label nameLabel;
 		/// <summary>Cached reference to the target health fill element.</summary>
 		private VisualElement healthFill;
+		/// <summary>Cached reference to the target health bar container element.</summary>
+		private VisualElement healthBar;
+
 		/// <summary>Cached reference to the target buff list container element.</summary>
 		private VisualElement buffList;
 
@@ -76,7 +82,28 @@ namespace FishMMO.Client
 
 			nameLabel = root.Q<Label>(NAME_LABEL_NAME);
 			healthFill = root.Q(HEALTH_FILL_NAME);
+			healthBar = root.Q(HEALTH_BAR_NAME);
 			buffList = root.Q(BUFF_LIST_NAME);
+		}
+
+		/// <summary>
+		/// Unsubscribes from the target controller before a character is set.
+		/// </summary>
+		/// <remarks>
+		/// Pairs with <see cref="OnPostSetCharacter"/> so the two can be run back to back without
+		/// subscribing twice. That happens whenever this panel's visual tree is rebuilt and its
+		/// state has to be re-applied — the unsubscribe already existed for the unset path, but
+		/// re-applying the same character never went through it.
+		/// </remarks>
+		public override void OnPreSetCharacter()
+		{
+			if (Character != null &&
+				Character.TryGet(out ITargetController targetController))
+			{
+				targetController.OnChangeTarget -= TargetController_OnChangeTarget;
+				targetController.OnUpdateTarget -= TargetController_OnUpdateTarget;
+				targetController.OnClearTarget -= TargetController_OnClearTarget;
+			}
 		}
 
 		/// <summary>
@@ -155,8 +182,19 @@ namespace FishMMO.Client
 				nameLabel.style.color = color;
 			}
 
-			if (characterAttributeController != null &&
-				characterAttributeController.TryGetResourceAttribute(HealthAttributeID, out CharacterResourceAttribute health))
+			/* Whether a health bar is shown follows from whether the target actually has a health
+			 * resource, rather than from what kind of thing it is. A portal or a signpost is
+			 * worth targeting and naming but has no health to show, and an empty bar reads as a
+			 * dead one. Anything that does gain health later — a destructible structure, a siege
+			 * engine — starts showing a bar the moment it has the attribute, with no change
+			 * here. */
+			CharacterResourceAttribute health = default;
+			bool hasHealth = characterAttributeController != null &&
+				characterAttributeController.TryGetResourceAttribute(HealthAttributeID, out health);
+
+			SetHealthVisible(hasHealth);
+
+			if (hasHealth)
 			{
 				SetHealthFill(health.FinalValue > 0 ? health.CurrentValue / health.FinalValueAsFloat : 0.0f);
 
@@ -164,10 +202,6 @@ namespace FishMMO.Client
 				{
 					nameLabel.text += $" [{health.CurrentValue}/{health.FinalValue}]";
 				}
-			}
-			else
-			{
-				SetHealthFill(0.0f);
 			}
 
 			RefreshTargetBuffs(buffController);
@@ -236,6 +270,18 @@ namespace FishMMO.Client
 			ClearTargetBuffs();
 
 			Hide();
+		}
+
+		/// <summary>
+		/// Shows or hides the health bar.
+		/// </summary>
+		/// <param name="visible">True to show the bar.</param>
+		private void SetHealthVisible(bool visible)
+		{
+			if (healthBar != null)
+			{
+				healthBar.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
+			}
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
@@ -1,4 +1,4 @@
-using FishNet.Transporting;
+﻿using FishNet.Transporting;
 using UnityEngine;
 using FishMMO.Shared;
 using FishMMO.Shared.Core;
@@ -202,6 +202,7 @@ namespace FishMMO.Client
 			// Player action callbacks
 			Controls.Player.Interact.performed += OnInteractPerformed;
 			Controls.Player.ToggleFirstPerson.performed += OnToggleFirstPersonPerformed;
+			Controls.Player.ToggleMouseMode.performed += OnToggleMouseModePerformed;
 			Controls.Player.Cancel.performed += OnCancelPerformed;
 			Controls.Player.CloseLastUI.performed += OnCloseLastUIPerformed;
 			Controls.Player.Chat.performed += OnChatPerformed;
@@ -245,6 +246,7 @@ namespace FishMMO.Client
 			// Player action callbacks
 			Controls.Player.Interact.performed -= OnInteractPerformed;
 			Controls.Player.ToggleFirstPerson.performed -= OnToggleFirstPersonPerformed;
+			Controls.Player.ToggleMouseMode.performed -= OnToggleMouseModePerformed;
 			Controls.Player.Cancel.performed -= OnCancelPerformed;
 			Controls.Player.CloseLastUI.performed -= OnCloseLastUIPerformed;
 			Controls.Player.Chat.performed -= OnChatPerformed;
@@ -621,6 +623,21 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
+		/// Callback for the mouse-mode input action. Releases or recaptures the cursor on demand.
+		/// </summary>
+		/// <remarks>
+		/// Releasing is forced so it survives <see cref="HandleAutoDismiss"/>, which recaptures the
+		/// cursor as soon as no panel is open. That is right when a panel released it and wrong when
+		/// the player asked for it — unforced, this key would release the cursor and have it taken
+		/// straight back. Pressing it again clears the flag and hands control back to the panels.
+		/// </remarks>
+		/// <param name="context">Input callback context.</param>
+		private void OnToggleMouseModePerformed(InputAction.CallbackContext context)
+		{
+			PlayerInputController.ToggleMouseMode(!PlayerInputController.MouseMode);
+		}
+
+		/// <summary>
 		/// Callback for closing the last UI element.
 		/// If no UI can be closed and mouse mode is active, toggles mouse mode off.
 		/// </summary>
@@ -704,6 +721,14 @@ namespace FishMMO.Client
 
 		private void OnMenuPerformed(InputAction.CallbackContext context)
 		{
+			/* Escape is bound to CloseLastUI as well as Menu, and CloseLastUI is handled first.
+			 * If it already closed a panel, this press is spent — toggling here would see the
+			 * menu closed and immediately reopen it, so Escape could never close the menu. */
+			if (UIManager.ClosedThisFrame)
+			{
+				return;
+			}
+
 			UIManager.ToggleVisibility("UIMenu");
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/UI/UIManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/UI/UIManager.cs
@@ -36,6 +36,34 @@ namespace FishMMO.Client
 		/// Maps GameObject names to their corresponding UITKControl instances.
 		/// </summary>
 		private static Dictionary<string, UITKControl> tkControls = new Dictionary<string, UITKControl>();
+
+		/// <summary>
+		/// Visible UI Toolkit panels that Escape should close, oldest first.
+		/// </summary>
+		/// <remarks>
+		/// Separate from <see cref="closeOnEscapeControls"/> only because that one is a
+		/// <c>CircularBuffer&lt;UIControl&gt;</c> keyed on node bookkeeping the legacy class owns —
+		/// a <see cref="UITKControl"/> cannot join it without inheriting from a UGUI base. A plain
+		/// list is enough here: these are opened and closed by hand, never in bulk.
+		/// </remarks>
+		private static readonly List<UITKControl> tkCloseOnEscapeControls = new List<UITKControl>();
+
+		/// <summary>
+		/// Frame on which <see cref="CloseNext"/> last actually closed something.
+		/// </summary>
+		private static int lastCloseFrame = -1;
+
+		/// <summary>
+		/// True when a panel was closed earlier in this same frame.
+		/// </summary>
+		/// <remarks>
+		/// Escape is bound to four separate actions — Player/Cancel, Player/CloseLastUI,
+		/// Player/Menu and UI/Cancel — so one press runs several handlers in subscription order.
+		/// CloseLastUI closes the top panel, and Menu then toggles the menu, which sees it closed
+		/// and opens it straight back up: the menu becomes impossible to close with the key that
+		/// opened it. A handler that would re-open something checks this first so the close wins.
+		/// </remarks>
+		internal static bool ClosedThisFrame => lastCloseFrame == UnityEngine.Time.frameCount;
 		/// <summary>
 		/// Maps GameObject names to their corresponding UITKCharacterControl instances.
 		/// </summary>
@@ -308,7 +336,71 @@ namespace FishMMO.Client
 				}
 			}
 			control = null;
+
+			WarnIfMigrated(name, typeof(T));
+
 			return false;
+		}
+
+		/// <summary>
+		/// Reports a lookup that failed only because the panel has moved to UI Toolkit.
+		/// </summary>
+		/// <remarks>
+		/// A caller asking for a UGUI panel by name gets a plain false when that panel now exists
+		/// as a <see cref="UITKControl"/>, because the two live in separate registries and are
+		/// unrelated types. The call site is invariably an <c>if</c>, so the feature it guards
+		/// stops working with no exception, no log, and nothing on screen — the keybind simply
+		/// does nothing. Migrating a panel silently breaks every name lookup still pointing at it,
+		/// and this is the only place that can notice.
+		/// <para>
+		/// Only the mismatched case is reported. A name absent from both registries is an ordinary
+		/// miss — plenty of callers ask about panels that are not in the current scene — and
+		/// logging those would bury the real signal.
+		/// </para>
+		/// </remarks>
+		/// <param name="name">The name that was looked up.</param>
+		/// <param name="requestedType">The type the caller asked for.</param>
+		private static void WarnIfMigrated(string name, Type requestedType)
+		{
+			if (!tkControls.TryGetValue(name, out UITKControl migrated))
+			{
+				return;
+			}
+
+			Log.Error("UIManager",
+				$"'{name}' was requested as {requestedType.Name} (UGUI) but is registered as " +
+				$"{migrated.GetType().Name} (UI Toolkit). This lookup returns false and whatever " +
+				$"it guards will silently do nothing. Use TryGetTK<{migrated.GetType().Name}>(\"{name}\", ...) instead.");
+		}
+
+		/// <summary>
+		/// Marks a UI Toolkit panel as open, so Escape closes it and the cursor stays released.
+		/// </summary>
+		/// <param name="control">The panel that just became visible.</param>
+		internal static void RegisterCloseOnEscapeTK(UITKControl control)
+		{
+			if (control == null)
+			{
+				return;
+			}
+
+			// Re-registering moves it to the top, so the newest panel closes first.
+			tkCloseOnEscapeControls.Remove(control);
+			tkCloseOnEscapeControls.Add(control);
+		}
+
+		/// <summary>
+		/// Marks a UI Toolkit panel as closed.
+		/// </summary>
+		/// <param name="control">The panel that is no longer visible.</param>
+		internal static void UnregisterCloseOnEscapeTK(UITKControl control)
+		{
+			if (control == null)
+			{
+				return;
+			}
+
+			tkCloseOnEscapeControls.Remove(control);
 		}
 
 		/// <summary>
@@ -474,6 +566,34 @@ namespace FishMMO.Client
 		/// <returns>True if a control was closed or peeked, false otherwise.</returns>
 		public static bool CloseNext(bool peakOnly = false)
 		{
+			/* UI Toolkit panels are checked first, so the most recently opened panel wins while
+			 * the migration has both kinds on screen at once.
+			 *
+			 * They must be checked at all: PlayerInputController recaptures the mouse cursor on
+			 * every frame where this returns false, so a panel missing from here releases the
+			 * cursor in Show() and has it taken back before the player can click anything. That
+			 * was the whole symptom of "the menu opens but nothing is clickable". */
+			for (int i = tkCloseOnEscapeControls.Count - 1; i >= 0; --i)
+			{
+				UITKControl tkControl = tkCloseOnEscapeControls[i];
+				if (tkControl == null || !tkControl.Visible)
+				{
+					// Destroyed, or hidden by something other than Escape.
+					tkCloseOnEscapeControls.RemoveAt(i);
+					continue;
+				}
+
+				if (peakOnly)
+				{
+					return true;
+				}
+
+				tkCloseOnEscapeControls.RemoveAt(i);
+				tkControl.Hide();
+				lastCloseFrame = UnityEngine.Time.frameCount;
+				return true;
+			}
+
 			if (closeOnEscapeControls != null)
 			{
 				if (peakOnly)
@@ -487,6 +607,7 @@ namespace FishMMO.Client
 					if (control != null)
 					{
 						control.Hide();
+						lastCloseFrame = UnityEngine.Time.frameCount;
 						return true;
 					}
 				}


### PR DESCRIPTION
## Problem

Health, stamina, mana and the hotkey bar did not appear in game, and `UITKEquipment`, `UIHealthBar`, `UIStaminaBar` and `UIManaBar` each logged a `SetCharacter` failure.

## Cause

`UITKControl` called `OnStarting` from `Awake`.

`UIDocument` allocates `rootVisualElement` up front but only clones the UXML into it during its own `OnEnable` — after every component's `Awake`. So `Awake` saw a real but **empty** root: every `Q<>` in an override returned null, was cached as null, and was never re-resolved. The controls looked initialised but were wired to nothing.

## Change

Defer `OnStarting` until the tree is actually populated.

A panel that starts hidden has its `UIDocument` disabled and no tree at all, so the retry waits until something shows it. It's a **coroutine rather than `Update`** on purpose: Unity dispatches magic methods to the most-derived declaration, and `UITKResourceBar` and `UITKHotkeyBar` declare their own `Update` — a base `Update` would be shadowed for exactly the panels that need the retry.

Deferring introduces the opposite ordering: world entry calls `UIManager.SetCharacter` for every control at once, which can now land *before* `OnStarting` has cached any elements. `UITKCharacterControl` re-applies the character in a new `OnAfterStarting` hook so both orders converge, with null guards in `UITKResourceBar` and `UITKEquipment` for the window in between.

Also anchors the hotkey bar to the bottom centre — without `flex-grow` the root collapsed to the height of its contents and the strip rendered at the top of the screen.

## Verification

Client rebuilt and run through login → world. All four `SetCharacter` failures are gone from the player log, the bars and hotbar render, and the hotbar sits at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Update: the rest of the lifecycle, and a tool for the wiring

Everything below was found by putting the migrated panels in front of a player. Each bug looked unrelated to the others; all of them are the same root cause — **`UITKControl` was written as a UI Toolkit analogue of `UIControl` but only implements part of its contract.**

## The gaps, and what each looked like

| Symptom reported | Actual cause |
|---|---|
| Target frame says "Target", health bar always full | Cached elements point into a **discarded visual tree** |
| Inventory opens with no slot grid | Rebuilt tree is re-wired but **never repopulated** |
| No panel is clickable | **Nothing releases the mouse cursor** |
| Cursor released, then instantly recaptured | Panels **can't join the close-on-escape registry** |
| Escape opens the menu but can't close it | Two handlers on one key, **fighting** |
| Keybind silently does nothing | Name lookup **can't see the other registry** |

## Visual trees are rebuilt behind cached references

Hiding a panel disables its `UIDocument`; re-showing clones the UXML afresh. Every element cached in `OnStarting` then points into a tree that is no longer displayed — writes go nowhere and the panel renders whatever the UXML declares. The target frame kept showing its `text="Target"` placeholder and a permanently full health bar, looking fully wired and completely inert.

Tree identity is now checked on `Show`, and initialisation re-runs when it changes. This is confirmed, not theorised — the guard logs when it fires, and it fires on `UITarget` on every target change.

## Re-running it must re-apply state, not just re-resolve elements

Panels build their contents in `OnPostSetCharacter`. Re-resolving alone gave a rebuilt tree that was correctly wired and completely empty — an inventory with no slots.

`OnAfterStarting` now pairs `OnPreSetCharacter` with `OnPostSetCharacter` exactly as `SetCharacter` does, so repeating it cannot stack duplicate subscriptions, and `UITKTarget` gained the `OnPreSetCharacter` half it was missing.

## The cursor, and why releasing it wasn't enough

`UIControl` releases the cursor when a panel becomes visible, gated on `CloseOnEscape`. The UI Toolkit base had no equivalent, so **no UI Toolkit panel was ever clickable**. `ReleasesCursor` restores that, defaulting off so HUD elements don't take the cursor the moment they appear.

That alone still didn't work. `PlayerInputController` recaptures the cursor on every frame where `UIManager.CloseNext` reports nothing closeable, and that only consulted a `CircularBuffer<UIControl>` — which no `UITKControl` can join, since its bookkeeping belongs to the UGUI base. Panels released the cursor and had it taken back the same frame. They now have their own close-on-escape list, which also gives them **Escape-to-close**, which they never had.

## Which exposed a key-binding collision

Escape is bound to four actions — `Player/Cancel`, `Player/CloseLastUI`, `Player/Menu`, `UI/Cancel` — handled in subscription order. `CloseLastUI` (line 207) closes the top panel; `Menu` (line 220) then toggles the menu, sees it closed, and reopens it. The menu became impossible to close with the key that opened it.

A close now marks the frame, and the menu toggle stands aside when the press is already spent. Worth noting as a latent hazard beyond this fix: four actions on one key, correctness depending on subscription order, is fragile for whoever adds the fifth.

## Panels with size but no position

Each panel owns a `UIDocument` whose root fills the screen, so a panel with dimensions but no anchor resolves to the top-left. All three resource bars landed on the same strip across the top and drew over one another — two of the three appeared to be missing entirely. Bars are now stacked bottom-left; chat is anchored beside them.

## Migrated-panel lookups now report themselves

The two hierarchies have separate registries and unrelated types, so `TryGet("UIChat", out UIChat _)` returns a plain `false` once that panel becomes a `UITKChat`. The call site is invariably an `if`, so the feature it guards stops working with no exception and nothing on screen.

**Migrating a panel silently breaks every name lookup still pointing at it.** A survey found 80 such lookups — `UIDialogBox` ×26, `UIChat` ×12, `UIDragObject` ×7. Only the mismatched case is reported, naming both types and the call that would work; genuine misses stay quiet.

## The editor tool

`FishMMO → UI Toolkit → Report / Wire Unwired Panels`.

Placing a panel in a scene was a manual step, so a panel could be complete and never appear — and nothing can detect that, because `UIManager` resolves by GameObject name, making an unwired panel indistinguishable from one that was never written. **15 were wired; 27 were not.**

Report changes nothing. Wire creates a GameObject per panel with a configured `UIDocument`, assigns the `Document` field, and deactivates the legacy panel rather than deleting it — one undo group, scene left unsaved.

Two deliberate refusals:

- **Visibility flags are read from the legacy panel, not defaulted.** They differ per panel, and the panel being replaced is the only place the answer already exists.
- **A legacy twin in the open scene is required.** It is what establishes that a panel belongs there — without that rule, running this on the world scene would have created the login panels in it too. Panels whose UXML can't be resolved by name are reported rather than guessed at, which is what the resource bars need since all three share one document.

## Verification

Client assembly and the new editor assembly both compile. Everything above was exercised in a running client against a live server: target names and portal health bars confirmed fixed in game, the tree-replacement guard confirmed firing in the log, and the remaining fixes built and shipped for testing.

## Not included

`ClientWorldGUI.unity` — the scene wiring the tool produces — is deliberately left out of this PR. It's a ~3,400-line scene diff that also carries earlier unshipped migration work, and it belongs in a change of its own rather than buried here.

`UIControl` also implements `IDragHandler` for window dragging, which `UITKControl` still lacks, so no UI Toolkit panel is draggable yet. That's a feature to build rather than a wire to reconnect.