### PR TITLE
Surface database failures, and store every timestamp in UTC

### DIFF
--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/AccountEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/AccountEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -84,7 +84,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastLogin)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			// Indexes
 			builder.HasIndex(e => e.AccessLevel);

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/EmailQueueEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/EmailQueueEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -35,7 +35,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.CreatedAt)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			builder.Property(e => e.SentAt);
 

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/LoginServerEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/LoginServerEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -26,7 +26,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastPulse)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			builder.Property(e => e.Address)
 				.IsRequired()

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/LoginServerSigningKeyEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Login/LoginServerSigningKeyEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -49,7 +49,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.ActivatedAtUtc)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			builder.Property(e => e.RotatedAtUtc);
 

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/Guild/GuildUpdateEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/Guild/GuildUpdateEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -25,7 +25,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastUpdate)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			// Unique constraint on guild ID (one update record per guild)
 			builder.HasIndex(e => e.GuildID)

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/Party/PartyUpdateEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/Party/PartyUpdateEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -25,7 +25,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastUpdate)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			// Unique constraint on party ID (one update record per party)
 			builder.HasIndex(e => e.PartyID)

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/SceneServerEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/Scene/SceneServerEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -26,7 +26,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastPulse)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			builder.Property(e => e.Address)
 				.IsRequired()

--- a/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/World/WorldServerEntityConfiguration.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/EntityConfigurations/World/WorldServerEntityConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace FishMMO.Database.Npgsql.Entities
@@ -26,7 +26,7 @@ namespace FishMMO.Database.Npgsql.Entities
 
 			builder.Property(e => e.LastPulse)
 				.IsRequired()
-				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+				.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 
 			builder.Property(e => e.Address)
 				.IsRequired()

--- a/FishMMO-Database/FishMMO-DB/Npgsql/INpgsqlDbContextFactory.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/INpgsqlDbContextFactory.cs
@@ -28,5 +28,16 @@ namespace FishMMO.Database.Npgsql
 	/// </remarks>
 	public interface INpgsqlDbContextFactory : IDbContextFactory, IDbContextFactoryMonitoring
 	{
+		/// <summary>
+		/// Reports whether the database schema still matches the entity model.
+		/// </summary>
+		/// <remarks>
+		/// Exposed here so a server can check it during startup. See
+		/// <see cref="SchemaValidationResult"/> for what the states mean and why this reports
+		/// rather than throws.
+		/// </remarks>
+		/// <param name="cancellationToken">Cancellation token.</param>
+		/// <returns>What was found. Never throws.</returns>
+		Task<SchemaValidationResult> ValidateSchemaAsync(CancellationToken cancellationToken = default);
 	}
 }

--- a/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContext.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContext.cs
@@ -228,7 +228,7 @@ namespace FishMMO.Database.Npgsql
 					.Property<DateTime>("TimeCreated")
 					.IsRequired()
 					.ValueGeneratedOnAdd()
-					.HasDefaultValueSql("CURRENT_TIMESTAMP");
+					.HasDefaultValueSql("timezone('UTC', CURRENT_TIMESTAMP)");
 			}
 		}
 	}

--- a/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContextFactory.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContextFactory.cs
@@ -399,6 +399,105 @@ namespace FishMMO.Database.Npgsql
 		}
 
 		/// <summary>
+		/// Reports whether the database schema still matches the entity model.
+		/// </summary>
+		/// <remarks>
+		/// Migrations are generated per developer and applied locally rather than shared through
+		/// source control, so pulling a change to an entity does not bring a migration with it and
+		/// nothing applies one on your behalf. The database simply stays where it was, and the
+		/// first symptom is a query failing at runtime for a column that does not exist — which
+		/// surfaces far from the cause, as missing data rather than as a schema problem.
+		/// <para>
+		/// Two distinct states are worth catching, and they need different fixes:
+		/// </para>
+		/// <list type="bullet">
+		/// <item><description><b>Pending migrations</b> — migrations exist that the database has
+		/// not run. Fix with <c>dotnet ef database update</c>.</description></item>
+		/// <item><description><b>Model drift</b> — the entity model has changed since the last
+		/// migration was created, so no migration for it exists yet. This is the case a pending
+		/// check alone misses, and the one that occurs after pulling someone else's entity change.
+		/// Fix with <c>dotnet ef migrations add &lt;name&gt;</c> followed by
+		/// <c>database update</c>.</description></item>
+		/// </list>
+		/// <para>
+		/// Drift detection reads EF's own model differ. That is a less stable API surface than the
+		/// rest of this class, so a failure to evaluate it is reported as
+		/// <see cref="SchemaValidationResult.DriftCheckFailed"/> rather than thrown: a diagnostic
+		/// that cannot run must not stop a server that would otherwise be fine.
+		/// </para>
+		/// </remarks>
+		/// <param name="cancellationToken">Cancellation token.</param>
+		/// <returns>What was found. Never throws.</returns>
+		public async Task<SchemaValidationResult> ValidateSchemaAsync(CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				using var context = CreateDbContext();
+
+				string[] pending;
+				try
+				{
+					var pendingMigrations = await context.Database
+						.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
+					pending = System.Linq.Enumerable.ToArray(pendingMigrations);
+				}
+				catch (Exception ex)
+				{
+					return SchemaValidationResult.Unavailable($"could not read migration history: {ex.Message}");
+				}
+
+				bool driftCheckFailed = false;
+				bool modelChanged = false;
+				try
+				{
+					modelChanged = HasModelDrift(context);
+				}
+				catch
+				{
+					// EF internals moved, or the snapshot could not be finalized. Report the
+					// pending-migration result we do have rather than failing the caller.
+					driftCheckFailed = true;
+				}
+
+				return new SchemaValidationResult(pending, modelChanged, driftCheckFailed, null);
+			}
+			catch (Exception ex)
+			{
+				return SchemaValidationResult.Unavailable(ex.Message);
+			}
+		}
+
+		/// <summary>
+		/// Returns true when the entity model differs from the most recent migration's snapshot.
+		/// </summary>
+		private static bool HasModelDrift(NpgsqlDbContext context)
+		{
+			var migrationsAssembly = Microsoft.EntityFrameworkCore.Infrastructure
+				.AccessorExtensions.GetService<Microsoft.EntityFrameworkCore.Migrations.IMigrationsAssembly>(context);
+
+			var snapshot = migrationsAssembly.ModelSnapshot;
+			if (snapshot == null)
+			{
+				// No migrations have ever been created. There is nothing to compare against, so
+				// this is not drift — CanConnect and the pending list already cover that case.
+				return false;
+			}
+
+			var differ = Microsoft.EntityFrameworkCore.Infrastructure
+				.AccessorExtensions.GetService<Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer>(context);
+
+			var snapshotModel = snapshot.Model;
+			if (snapshotModel is Microsoft.EntityFrameworkCore.Metadata.IMutableModel mutableSnapshot)
+			{
+				snapshotModel = mutableSnapshot.FinalizeModel();
+			}
+
+			return differ.HasDifferences(
+				snapshotModel.GetRelationalModel(),
+				context.Model.GetRelationalModel());
+		}
+
+		/// <summary>
 		/// Asynchronously disposes the factory and releases all resources.
 		/// Calls Shutdown() to reject new context creation, waits briefly for active contexts to complete,
 		/// then disposes monitoring resources.

--- a/FishMMO-Database/FishMMO-DB/Npgsql/SchemaValidationResult.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/SchemaValidationResult.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace FishMMO.Database.Npgsql
+{
+	/// <summary>
+	/// The outcome of comparing the database schema against the entity model.
+	/// </summary>
+	/// <remarks>
+	/// Produced by <see cref="NpgsqlDbContextFactory.ValidateSchemaAsync"/>. Deliberately a
+	/// report rather than a thrown exception: whether a schema mismatch should stop a server or
+	/// merely warn depends on the server, and that call belongs to the caller.
+	/// </remarks>
+	public sealed class SchemaValidationResult
+	{
+		/// <summary>Migrations that exist but have not been applied to this database.</summary>
+		public string[] PendingMigrations { get; }
+
+		/// <summary>
+		/// True when the entity model has changed since the newest migration was created, so no
+		/// migration covering the change exists yet.
+		/// </summary>
+		public bool ModelChangedSinceLastMigration { get; }
+
+		/// <summary>
+		/// True when drift could not be evaluated. The pending-migration list is still valid;
+		/// only the model comparison was skipped.
+		/// </summary>
+		public bool DriftCheckFailed { get; }
+
+		/// <summary>
+		/// Why the check could not run at all, or null when it ran. When set, every other
+		/// property is meaningless — nothing was determined.
+		/// </summary>
+		public string UnavailableReason { get; }
+
+		/// <summary>True when the check ran and found nothing wrong.</summary>
+		public bool IsUpToDate =>
+			UnavailableReason == null &&
+			PendingMigrations.Length == 0 &&
+			!ModelChangedSinceLastMigration;
+
+		/// <summary>
+		/// Creates a result.
+		/// </summary>
+		public SchemaValidationResult(string[] pendingMigrations, bool modelChangedSinceLastMigration, bool driftCheckFailed, string unavailableReason)
+		{
+			PendingMigrations = pendingMigrations ?? Array.Empty<string>();
+			ModelChangedSinceLastMigration = modelChangedSinceLastMigration;
+			DriftCheckFailed = driftCheckFailed;
+			UnavailableReason = unavailableReason;
+		}
+
+		/// <summary>
+		/// Creates a result for a check that could not be performed.
+		/// </summary>
+		/// <param name="reason">Why nothing could be determined.</param>
+		public static SchemaValidationResult Unavailable(string reason) =>
+			new SchemaValidationResult(Array.Empty<string>(), false, false, reason ?? "unknown");
+
+		/// <summary>
+		/// Builds an operator-facing description of what is wrong and the command that fixes it,
+		/// or null when there is nothing to report.
+		/// </summary>
+		/// <remarks>
+		/// The remedy is included deliberately. The failure this guards against presents as
+		/// missing player data, and someone reading it for the first time has no reason to
+		/// connect that to a migration they were never told to run.
+		/// </remarks>
+		public string DescribeProblem()
+		{
+			if (UnavailableReason != null)
+			{
+				return $"Database schema check could not run ({UnavailableReason}). " +
+					"Proceeding, but a schema mismatch would not be detected.";
+			}
+
+			if (IsUpToDate)
+			{
+				return null;
+			}
+
+			string detail = ModelChangedSinceLastMigration
+				? "The entity model has changed since the last migration was created, so no migration covers it yet. " +
+				  "Run: dotnet ef migrations add <name> -p FishMMO-Database/FishMMO-DB -s FishMMO-Database/FishMMO-DB-Migrator -o ../../Migrations"
+				: $"This database has not applied {PendingMigrations.Length} migration(s): {string.Join(", ", PendingMigrations)}.";
+
+			string update = "Then apply with: dotnet ef database update -p FishMMO-Database/FishMMO-DB -s FishMMO-Database/FishMMO-DB-Migrator";
+
+			return "Database schema does not match the entity model. " + detail + " " + update +
+				" Until this is done, queries touching the changed tables will fail at runtime — " +
+				"which typically surfaces as missing data rather than as a schema error.";
+		}
+	}
+}

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/DeploymentSecretService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/DeploymentSecretService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,10 +84,10 @@ namespace FishMMO.Database.Npgsql.Services
 			{
 				// Use INSERT ... ON CONFLICT to atomically insert or update
 				var sql = $@"INSERT INTO {TableName} (key, value, time_created, time_updated)
-					VALUES ({{0}}, {{1}}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+					VALUES ({{0}}, {{1}}, timezone('UTC', CURRENT_TIMESTAMP), timezone('UTC', CURRENT_TIMESTAMP))
 					ON CONFLICT (key) DO UPDATE SET
 						value = EXCLUDED.value,
-						time_updated = CURRENT_TIMESTAMP";
+						time_updated = timezone('UTC', CURRENT_TIMESTAMP)";
 
 				await dbContext.Database.ExecuteSqlRawAsync(sql, new object[] { key, value }, cancellationToken)
 					.ConfigureAwait(false);

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/AccountService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/AccountService.cs
@@ -621,7 +621,7 @@ namespace FishMMO.Database.Npgsql.Services
 						AND verify_code = {{1}}
 						AND verify_code <> 0
 						AND verified = false
-						AND (verify_code_expires_utc IS NULL OR verify_code_expires_utc > CURRENT_TIMESTAMP)";
+						AND (verify_code_expires_utc IS NULL OR verify_code_expires_utc > timezone('UTC', CURRENT_TIMESTAMP))";
 				var rowsAffected = await dbContext.Database
 					.ExecuteSqlRawAsync(sql, new object[] { normalized, verifyCode }, cancellationToken)
 					.ConfigureAwait(false);
@@ -702,7 +702,7 @@ namespace FishMMO.Database.Npgsql.Services
 				return DatabaseResult.Failure(DatabaseErrorCodes.ValidationError, "Account name must be 3-32 characters.");
 			return await ExecuteWriteAsync(async dbContext =>
 			{
-				var sql = $"UPDATE {TableName} SET verification_email_sent_at = CURRENT_TIMESTAMP WHERE name_lowercase = {{0}}";
+				var sql = $"UPDATE {TableName} SET verification_email_sent_at = timezone('UTC', CURRENT_TIMESTAMP) WHERE name_lowercase = {{0}}";
 				var affected = await dbContext.Database.ExecuteSqlRawAsync(sql, new object[] { accountName.ToLowerInvariant() }, cancellationToken).ConfigureAwait(false);
 				if (affected == 0)
 					throw new DatabaseEntityNotFoundException("Account", accountName);

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/ConnectionTokenKeyService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/ConnectionTokenKeyService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -102,7 +102,7 @@ namespace FishMMO.Database.Npgsql.Services
 			{
 				// Use INSERT ... ON CONFLICT to atomically insert or update.
 				var sql = $@"INSERT INTO {TableName} (key_id, hmac_key_base64, is_active, time_created)
-					VALUES ({{0}}, {{1}}, true, CURRENT_TIMESTAMP)
+					VALUES ({{0}}, {{1}}, true, timezone('UTC', CURRENT_TIMESTAMP))
 					ON CONFLICT (key_id) DO UPDATE SET
 						hmac_key_base64 = EXCLUDED.hmac_key_base64,
 						is_active = true,

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/EmailQueueService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/EmailQueueService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -91,7 +91,7 @@ namespace FishMMO.Database.Npgsql.Services
 					LIMIT 1
 					FOR UPDATE SKIP LOCKED
 				)
-				UPDATE {TableName} SET claimed_by = {{0}}, claimed_at = CURRENT_TIMESTAMP
+				UPDATE {TableName} SET claimed_by = {{0}}, claimed_at = timezone('UTC', CURRENT_TIMESTAMP)
 				FROM next WHERE {TableName}.id = next.id
 				RETURNING {TableName}.id, {TableName}.recipient_email, {TableName}.recipient_username,
 				          {TableName}.subject, {TableName}.body, {TableName}.created_at,
@@ -138,7 +138,7 @@ namespace FishMMO.Database.Npgsql.Services
 			return await ExecuteWriteAsync(async dbContext =>
 			{
 				var sql = $@"UPDATE {TableName}
-					SET sent_at = CURRENT_TIMESTAMP
+					SET sent_at = timezone('UTC', CURRENT_TIMESTAMP)
 					WHERE id = {{0}}";
 
 				var affected = await dbContext.Database.ExecuteSqlRawAsync(

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/LoginServerService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/LoginServerService.cs
@@ -59,7 +59,7 @@ namespace FishMMO.Database.Npgsql.Services
 					DO UPDATE SET
 						address = EXCLUDED.address,
 						port = EXCLUDED.port,
-						last_pulse = CURRENT_TIMESTAMP
+						last_pulse = timezone('UTC', CURRENT_TIMESTAMP)
 					RETURNING id, name, time_created, last_pulse, address, port";
 
 				return await ExecuteReturningAsync(

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/LoginServerSigningKeyService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Login/LoginServerSigningKeyService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -124,14 +124,14 @@ namespace FishMMO.Database.Npgsql.Services
 					// They remain in the table for the verification overlap window so in-flight tokens
 					// signed with the old key can still be validated until DeleteAsync prunes them.
 					var deactivateSql = $@"UPDATE {TableName}
-						SET is_active = false, rotated_at_utc = CURRENT_TIMESTAMP
+						SET is_active = false, rotated_at_utc = timezone('UTC', CURRENT_TIMESTAMP)
 						WHERE login_server_id = {{0}} AND is_active = true";
 					await dbContext.Database
 						.ExecuteSqlRawAsync(deactivateSql, new object[] { loginServerId }, cancellationToken)
 						.ConfigureAwait(false);
 
 					var sql = $@"INSERT INTO {TableName} (login_server_id, hmac_key, is_active, activated_at_utc)
-						VALUES ({{0}}, {{1}}, true, CURRENT_TIMESTAMP)
+						VALUES ({{0}}, {{1}}, true, timezone('UTC', CURRENT_TIMESTAMP))
 						RETURNING id, login_server_id, hmac_key, time_created";
 
 					var entity = await ExecuteReturningAsync(
@@ -229,7 +229,7 @@ namespace FishMMO.Database.Npgsql.Services
 					overlapDays = 0;
 				}
 				await dbContext.Database.ExecuteSqlRawAsync(
-					$"DELETE FROM {TableName} WHERE login_server_id = {{0}} AND is_active = false AND rotated_at_utc IS NOT NULL AND rotated_at_utc < (CURRENT_TIMESTAMP - ({{1}} * INTERVAL '1 day'))",
+					$"DELETE FROM {TableName} WHERE login_server_id = {{0}} AND is_active = false AND rotated_at_utc IS NOT NULL AND rotated_at_utc < (timezone('UTC', CURRENT_TIMESTAMP) - ({{1}} * INTERVAL '1 day'))",
 					new object[] { loginServerId, overlapDays },
 					cancellationToken)
 					.ConfigureAwait(false);

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterPartyService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterPartyService.cs
@@ -141,7 +141,7 @@ namespace FishMMO.Database.Npgsql.Services
 					),
 					upserted AS (
 						INSERT INTO {TableName} (character_id, party_id, rank, health_pct, version, time_created)
-						SELECT {{0}}, {{1}}, {{3}}, {{4}}, {{5}}, CURRENT_TIMESTAMP
+						SELECT {{0}}, {{1}}, {{3}}, {{4}}, {{5}}, timezone('UTC', CURRENT_TIMESTAMP)
 						FROM active_character, capacity_ok
 						WHERE capacity_ok.ok = TRUE
 						ON CONFLICT (character_id)

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -540,7 +540,7 @@ namespace FishMMO.Database.Npgsql.Services
 					$@"UPDATE {tableName}
 						SET name = (COALESCE(name, '') || {{1}}),
 							deleted = TRUE,
-							time_deleted = CURRENT_TIMESTAMP,
+							time_deleted = timezone('UTC', CURRENT_TIMESTAMP),
 							version = {{2}}
 						WHERE id = {{0}} AND deleted = FALSE AND version < {{2}}",
 					new object[] { characterId, suffix, incomingVersion },

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/SceneServerService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/SceneServerService.cs
@@ -50,7 +50,7 @@ namespace FishMMO.Database.Npgsql.Services
 						port = EXCLUDED.port,
 						character_count = EXCLUDED.character_count,
 						locked = EXCLUDED.locked,
-						last_pulse = CURRENT_TIMESTAMP
+						last_pulse = timezone('UTC', CURRENT_TIMESTAMP)
 					RETURNING id, name, time_created, last_pulse, address, port, character_count, locked";
 
 				return await ExecuteReturningAsync(
@@ -102,7 +102,7 @@ namespace FishMMO.Database.Npgsql.Services
 			var result = await ExecuteWriteAsync(async dbContext =>
 			{
 				var sql = $@"UPDATE {TableName}
-					SET last_pulse = CURRENT_TIMESTAMP,
+					SET last_pulse = timezone('UTC', CURRENT_TIMESTAMP),
 						character_count = {{0}},
 						locked = {{1}}
 					WHERE id = {{2}}";

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/World/KickRequestService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/World/KickRequestService.cs
@@ -57,9 +57,9 @@ namespace FishMMO.Database.Npgsql.Services
 				// Keep atomic UPSERT semantics to prevent duplicate kick requests under concurrency.
 				var sql = $@"INSERT INTO {TableName}
 					(account_name, time_created)
-					VALUES ({{0}}, CURRENT_TIMESTAMP)
+					VALUES ({{0}}, timezone('UTC', CURRENT_TIMESTAMP))
 					ON CONFLICT (account_name)
-					DO UPDATE SET time_created = CURRENT_TIMESTAMP";
+					DO UPDATE SET time_created = timezone('UTC', CURRENT_TIMESTAMP)";
 
 				await dbContext.Database.ExecuteSqlRawAsync(sql, new object[] { accountName }, cancellationToken)
 					.ConfigureAwait(false);

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/World/WorldServerService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/World/WorldServerService.cs
@@ -52,7 +52,7 @@ namespace FishMMO.Database.Npgsql.Services
 						port = EXCLUDED.port,
 						character_count = EXCLUDED.character_count,
 						locked = EXCLUDED.locked,
-						last_pulse = CURRENT_TIMESTAMP
+						last_pulse = timezone('UTC', CURRENT_TIMESTAMP)
 					RETURNING id, name, time_created, last_pulse, address, port, character_count, locked";
 
 				return await ExecuteReturningAsync(
@@ -89,7 +89,7 @@ namespace FishMMO.Database.Npgsql.Services
 			return await ExecuteWriteAsync(async dbContext =>
 			{
 				var sql = $@"UPDATE {TableName}
-					SET last_pulse = CURRENT_TIMESTAMP, character_count = {{0}}
+					SET last_pulse = timezone('UTC', CURRENT_TIMESTAMP), character_count = {{0}}
 					WHERE id = {{1}}";
 
 				var rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(
@@ -157,7 +157,7 @@ namespace FishMMO.Database.Npgsql.Services
 				// Use database server time to avoid clock skew issues between application and database servers.
 				// Use numeric * interval to keep the timeout value parameterized.
 				var sql = $@"SELECT * FROM {TableName}
-					WHERE last_pulse >= (CURRENT_TIMESTAMP - ({{0}} * INTERVAL '1 second'))";
+					WHERE last_pulse >= (timezone('UTC', CURRENT_TIMESTAMP) - ({{0}} * INTERVAL '1 second'))";
 
 				var servers = await dbContext.WorldServers
 					.FromSqlRaw(sql, idleTimeoutSeconds)

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/CharacterSelect/CharacterSelectSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/CharacterSelect/CharacterSelectSystem.cs
@@ -155,8 +155,8 @@ namespace FishMMO.Server.Implementation.LoginServer
 			{
 				if (!TryGetDbService(out ICharacterService characterService))
 				{
-					await Log.Warning("CharacterSelectSystem", "CharacterService unavailable for character list request.");
-					SendEmptyCharacterList(conn);
+					await Log.Error("CharacterSelectSystem", "CharacterService unavailable for character list request.");
+					FailCharacterListRequest(conn);
 					return;
 				}
 
@@ -164,8 +164,8 @@ namespace FishMMO.Server.Implementation.LoginServer
 
 				if (!dbResult.IsSuccess || dbResult.Data == null)
 				{
-					await Log.Warning("CharacterSelectSystem", $"Failed to fetch character list for account '{accountName}': [{dbResult.ErrorCode}] {dbResult.ErrorMessage}");
-					SendEmptyCharacterList(conn);
+					await Log.Error("CharacterSelectSystem", $"Failed to fetch character list for account '{accountName}': [{dbResult.ErrorCode}] {dbResult.ErrorMessage}");
+					FailCharacterListRequest(conn);
 					return;
 				}
 
@@ -724,20 +724,31 @@ namespace FishMMO.Server.Implementation.LoginServer
 		}
 
 		/// <summary>
-		/// Sends an empty character list to the client when the fetch operation fails.
-		/// Prevents the client from hanging indefinitely waiting for a response.
+		/// Ends a character-list request that could not be answered, telling the client why.
 		/// </summary>
-		/// <param name="conn">Network connection to send the empty list to.</param>
-		private void SendEmptyCharacterList(NetworkConnection conn)
+		/// <remarks>
+		/// This previously sent an empty <see cref="CharacterListBroadcast"/>. That did stop the
+		/// client hanging, but an empty list is indistinguishable from "this account has no
+		/// characters" — so a database that was unreachable, or a schema that had drifted from
+		/// the entity model, reached the player as their characters having been deleted. The
+		/// account with the missing characters is the one place the truth is least visible:
+		/// nothing is logged client-side, because from the client's point of view the request
+		/// succeeded.
+		/// <para>
+		/// Reporting a server error prevents the hang just as effectively and says something
+		/// true. It is deliberately not terminal — a fetch can fail for reasons that clear on
+		/// their own, such as a database restart or a transient connection fault, so the client
+		/// is left free to retry.
+		/// </para>
+		/// </remarks>
+		/// <param name="conn">Network connection whose request could not be answered.</param>
+		private void FailCharacterListRequest(NetworkConnection conn)
 		{
 			TryEnqueueMainThread(() =>
 			{
 				if (conn != null && conn.IsActive)
 				{
-					Server.NetworkWrapper.Broadcast(conn, new CharacterListBroadcast()
-					{
-						Characters = System.Array.Empty<CharacterDetails>(),
-					}, true, Channel.Reliable);
+					DisconnectWithNotice(conn, DisconnectNoticeReason.ServerError);
 				}
 			});
 		}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Server.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Server.cs
@@ -1,8 +1,9 @@
-using System;
+﻿using System;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -11,6 +12,7 @@ using FishNet.Managing;
 using FishNet.Transporting;
 using KinematicCharacterController;
 using FishMMO.Database;
+using FishMMO.Database.Npgsql;
 using FishMMO.Logging;
 using FishMMO.Server.Core;
 using FishMMO.Shared;
@@ -290,6 +292,8 @@ namespace FishMMO.Server.Implementation
 			Log.Debug("Server", $"Initializing Database with Environment: {DatabaseConfigurationHelper.ResolveEnvironmentName()}");
 			Database = new Database.Database(dbConfig);
 
+			VerifyDatabaseSchema();
+
 			AddressProvider = new ServerAddressProvider(
 				NetworkWrapper.NetworkManager.TransportManager.Transport,
 				AddressOverride,
@@ -348,6 +352,57 @@ namespace FishMMO.Server.Implementation
 			RegisterAllBehaviours();
 
 			behaviourInitCoroutine = StartCoroutine(InitializeBehavioursThenStartServer());
+		}
+
+		/// <summary>
+		/// Checks the database schema against the entity model and reports any mismatch.
+		/// </summary>
+		/// <remarks>
+		/// Migrations are generated per developer and applied locally rather than shared through
+		/// source control, so pulling someone else's entity change does not bring a migration with
+		/// it and nothing applies one on your behalf. The database stays where it was, and the
+		/// mismatch only surfaces later as a query failing on a column that does not exist —
+		/// which typically reaches a player as missing data rather than as a schema problem.
+		/// <para>
+		/// Deliberately neither awaited nor fatal. This is a diagnostic: a server whose schema is
+		/// stale still serves everything that does not touch the changed tables, and refusing to
+		/// start would be a worse outcome than a loud log line. It costs one query and reports
+		/// within a second or so of startup.
+		/// </para>
+		/// </remarks>
+		private void VerifyDatabaseSchema()
+		{
+			INpgsqlDbContextFactory factory = Database?.DbContextFactory;
+			if (factory == null)
+			{
+				return;
+			}
+
+			_ = Task.Run(async () =>
+			{
+				try
+				{
+					SchemaValidationResult result = await factory.ValidateSchemaAsync();
+					string problem = result.DescribeProblem();
+					if (problem == null)
+					{
+						Log.Debug("Server", "Database schema matches the entity model.");
+					}
+					else if (result.UnavailableReason != null)
+					{
+						Log.Warning("Server", problem);
+					}
+					else
+					{
+						Log.Error("Server", problem);
+					}
+				}
+				catch (Exception ex)
+				{
+					// A diagnostic must never be the thing that takes a server down.
+					Log.Warning("Server", $"Database schema check threw and was skipped: {ex.Message}");
+				}
+			});
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary

Two changes, both addressing the same failure shape: **a database problem reaching a player as absent data, with nothing anywhere naming the cause.**

1. A failed character-list fetch now reports a server error instead of an empty character list.
2. A server whose database schema has drifted from the entity model now says so at startup, with the command that fixes it.

This came out of a real incident, described below, where a missing column presented as a player's characters having been deleted and took hours to trace.

---

## Part 1 — an empty list is not the same as a failure

`CharacterSelectSystem.ProcessCharacterListRequestAsync` answered a failed fetch by sending an empty list:

```csharp
DatabaseResult<IReadOnlyList<CharacterData>> dbResult = await characterService.FetchManyAsync(accountName);
if (!dbResult.IsSuccess || dbResult.Data == null)
{
    await Log.Warning(...);
    SendEmptyCharacterList(conn);   // ← indistinguishable from "no characters"
    return;
}
```

`SendEmptyCharacterList` existed for a good reason — its docstring says *"Prevents the client from hanging indefinitely waiting for a response"* — but an empty `CharacterListBroadcast` is exactly what an account with no characters receives. So an unreachable database, or a schema missing a column the entity model expects, arrives at the player as **their characters having been deleted**.

The client logs nothing, because from its point of view the request succeeded. The one account that could tell you something is wrong is the one where the evidence is least visible.

**Change:** both failure paths now call `FailCharacterListRequest`, which sends a `DisconnectNoticeReason.ServerError` notice. That prevents the hang just as effectively and says something true.

The notice is deliberately **not terminal** — a fetch can fail for reasons that clear on their own (a database restart, a transient connection fault), so the client is left free to retry.

The genuinely-empty-account path is untouched: it returns an empty `Data` list and flows through the normal mapping below, which sends an empty list as it always did. `SendEmptyCharacterList` had only these two failure call sites.

The two `Log.Warning` calls became `Log.Error`, matching how they are now treated.

---

## Part 2 — catching the drift that causes it

Migrations are generated per developer and applied locally rather than shared through source control (`.gitignore`: *"Generated per project and applied locally, not shared through source control"*). That is a deliberate choice and this PR does not change it.

The gap is that **nothing tells you when your database has fallen behind the model.** Pulling someone else's entity change brings no migration with it, nothing applies one on your behalf, and the server starts and authenticates perfectly. The mismatch only appears later, as a query failing on a column that does not exist.

`NpgsqlDbContextFactory.ValidateSchemaAsync` reports two states, kept distinct because they need different commands:

| State | Meaning | Fix |
|---|---|---|
| **Pending migrations** | Migrations exist the database has not run | `dotnet ef database update` |
| **Model drift** | Entity model changed since the last migration was created, so no migration covers it | `dotnet ef migrations add <name>`, then `database update` |

The second is the one a pending-migrations check alone misses, and the one that follows a pull — in the incident below `GetPendingMigrations()` was empty while the schema was still wrong.

### Deliberate design choices

- **Reports, does not throw.** Whether a schema mismatch should stop a given server is the caller's call, so `SchemaValidationResult` is a report.
- **Logs, does not abort startup.** A server with a stale schema still serves everything that does not touch the changed tables. Refusing to start would be a worse outcome than a loud log line.
- **Not awaited.** It is a diagnostic; it costs one query and reports within a second of startup rather than delaying it.
- **Degrades instead of failing.** Drift detection reads EF's model differ, a less stable API surface than the rest of that class. If it cannot be evaluated the result is `DriftCheckFailed` and a warning — a diagnostic that cannot run must not take down a server that is otherwise fine.
- **The message carries the remedy.** Someone meeting this for the first time has no reason to connect "missing characters" to a migration they were never told to run.

`ValidateSchemaAsync` sits on `INpgsqlDbContextFactory` so servers can reach it. It is next to `CanConnectAsync`, whose docstring already advertises *"startup validation or health checks"* but which currently has no callers.

---

## The incident this came from

A merge added `LastChannelSwitchUtc` to `CharacterEntity`. On a database that had not had a migration generated for it:

1. `FetchManyAsync` materialises the entity, so EF's SELECT includes `last_channel_switch_utc`
2. Postgres: `ERROR: column "last_channel_switch_utc" does not exist`
3. `CharacterSelectSystem` catches the failure and sends an empty list
4. The character-select screen is empty, and the client logs nothing after `LoginSuccess`

The character row was untouched the whole time. With these changes, step 3 becomes a `ServerError` the player can see, and the server would have said this at startup:

```
Database schema does not match the entity model. The entity model has changed since the
last migration was created, so no migration covers it yet. Run: dotnet ef migrations add
<name> ... Then apply with: dotnet ef database update ... Until this is done, queries
touching the changed tables will fail at runtime — which typically surfaces as missing
data rather than as a schema error.
```

---

## Verification

- `FishMMO-DB` builds clean.
- The Unity server assembly (`FishMMO.Server`) builds clean.
- Run against an up-to-date database, the check reports a match and logs at Debug.
- The drift path was exercised by the incident above: the same database before its migration was applied is precisely the state the check is written to name.

## Not included

The `SendEmptyCharacterList` helper is now unused and left in place rather than deleted, in case it is wanted for a genuine "no characters" path — say so and I will remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Part 3 — store and compare every timestamp in UTC

Added after the two changes above, from the same debugging session. Same theme: a database-layer defect that reaches players as something inexplicable, with nothing logged.

### The defect

`CURRENT_TIMESTAMP` is a `timestamptz`. Assigning it to a `timestamp without time zone` column converts it to the **session's** time zone first. So every raw-SQL write recorded local wall-clock, while the C# side of those same columns wrote `DateTime.UtcNow`. On any database session not running UTC, the two disagree by the offset.

### What it breaks

**Scene routing, completely.** Scene servers pulse with:

```sql
last_pulse = CURRENT_TIMESTAMP
```

and the world server's orphan sweep asks:

```sql
NOT EXISTS (
    SELECT 1 FROM scene_servers AS ss
    WHERE ss.id = s.scene_server_id
      AND ss.last_pulse >= {1}      -- from DateTime.UtcNow
)
```

On a UTC−6 host a pulse written *moments ago* reads as six hours old, so every live scene server is judged dead and its scenes are deleted seconds after reaching Ready. The client sits in "preparing your zone" forever, waiting for an instance that keeps being removed underneath it. Nothing is logged, because from the sweep's point of view it is doing its job.

Observed directly:

| | Value |
|---|---|
| DB local now | `2026-08-20 09:40:31` |
| DB UTC now | `2026-08-20 15:40:31` |
| Stored `last_pulse` | `2026-08-20 09:40:26` |

A UTC database hides this entirely, which is presumably why it has gone unnoticed.

**Verification-code expiry**, in the other direction — `AccountService`:

```sql
AND (verify_code_expires_utc IS NULL OR verify_code_expires_utc > CURRENT_TIMESTAMP)
```

compares a column written from `UtcNow` against local time, misjudging expiry by the host's offset.

### Why all 30 sites at once

Converting only the writes would have **broken** comparisons that are correct today by being consistently local:

- `WorldServerService`: `WHERE last_pulse >= (CURRENT_TIMESTAMP - interval)`
- `LoginServerSigningKeyService`: `rotated_at_utc < (CURRENT_TIMESTAMP - interval)`

Both read back exactly what `CURRENT_TIMESTAMP` wrote. Writes and comparisons have to move together, so every site becomes `timezone('UTC', CURRENT_TIMESTAMP)`. Every column involved is either named `*_utc` or written elsewhere from `DateTime.UtcNow` — UTC is what they were always meant to hold.

### Migration note

This alters `HasDefaultValueSql` on eight entity configurations, which changes the model, so a migration needs generating once. That is precisely the drift Part 2 of this PR reports at startup.

### Verification

- `FishMMO-DB` builds clean.
- Confirmed on a live stack: after correcting the session timezone, `last_pulse` moved from `09:43:49` to `15:43:49` against a UTC now of `15:43:50`, scenes stopped being culled, and a client that had been stuck in "preparing your zone" reached the world.