### PR TITLE
Chat, guild/party and interactable fixes found in play testing

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/FishMMO-Theme.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/FishMMO-Theme.uss
@@ -995,6 +995,20 @@ TextField.fish-input > #unity-text-input .unity-text-element {
     flex-grow: 1;
 }
 
+/*
+    A BaseField's own label: the `label` attribute on a TextField, or the text passed to
+    `new Toggle("Say")`. The rule above deliberately scopes through #unity-text-input to keep
+    flex-grow off these labels, which leaves their colour unset, so they fall back to UITK's
+    near-black default and vanish against a dark panel. The chat channel picker showed both
+    halves of it at once: "Tab Name" and every channel name rendered as black-on-black.
+
+    Colour only, so none of the layout the scoping was protecting comes back with it.
+*/
+.fish-input > .unity-base-field__label,
+.fish-toggle > .unity-base-field__label {
+    color: var(--abyss-200);
+}
+
 .fish-input > #unity-text-input,
 TextField.fish-input > #unity-text-input {
     background-color: var(--abyss-900);

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uss
@@ -80,8 +80,28 @@
     min-height: 26px;
     padding: 2px 4px;
     flex-shrink: 0;
+    /* UITK defaults flex-direction to column, not row as CSS does. With a single child that was
+       invisible; the moment the channel selector joined the field it stacked above it instead of
+       sitting beside it. */
+    flex-direction: row;
+    align-items: center;
 }
 
 .chat-input {
     flex-grow: 1;
+}
+
+/*
+    Channel selector sitting to the left of the input. It names the channel a plain line will be
+    sent on, so it has to hold its width rather than be squeezed by the field beside it — the
+    input carries flex-grow, and without flex-shrink: 0 here the label collapses as soon as the
+    panel narrows.
+*/
+.chat-channel-selector {
+    flex-shrink: 0;
+    min-width: 54px;
+    height: 20px;
+    margin-right: 4px;
+    padding: 0 6px;
+    font-size: 10px;
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChat.uxml
@@ -1,4 +1,4 @@
-<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
+﻿<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
     <Style src="../../FishMMO-Theme.uss" />
     <Style src="UIChat.uss" />
     <ui:VisualElement name="chat-root" class="fish-panel chat-panel">
@@ -10,6 +10,7 @@
             <ui:VisualElement name="chat-messages" class="chat-messages" />
         </ui:ScrollView>
         <ui:VisualElement name="chat-input-row" class="chat-input-row">
+            <ui:Button name="chat-channel-selector" text="Say" class="fish-button chat-channel-selector" />
             <ui:TextField name="chat-input" class="fish-input chat-input" />
         </ui:VisualElement>
     </ui:VisualElement>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChatChannelPicker.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChatChannelPicker.uss
@@ -18,6 +18,9 @@
     position: absolute;
     min-width: 160px;
     padding: 8px;
+    /* The panel is placed at the click point, so without a ceiling a list this tall simply
+       runs off the bottom of the screen. Cap it against the viewport and let the list scroll. */
+    max-height: 90%;
 }
 
 .channel-name-input {
@@ -26,8 +29,21 @@
 
 .channel-list {
     flex-direction: column;
+    /* UITK defaults flex-shrink to 0, so without these the ScrollView refuses to give up
+       height and overflows the capped panel instead of scrolling inside it. */
+    flex-shrink: 1;
+    min-height: 0;
 }
 
 .channel-toggle {
     margin: 1px 0;
+}
+
+/*
+    The channel names are this menu's actual content — the list of things being chosen — rather
+    than captions for some other control, so they carry primary text weight instead of the
+    --abyss-200 the theme gives a BaseField label by default.
+*/
+.channel-toggle > .unity-base-field__label {
+    color: var(--abyss-100);
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChatChannelPicker.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UIChatChannelPicker.uxml
@@ -4,7 +4,7 @@
     <ui:VisualElement name="channel-picker-root" class="channel-picker-root" picking-mode="Ignore">
         <ui:VisualElement name="channel-picker-panel" class="fish-panel channel-picker-panel">
             <ui:TextField name="channel-name-input" label="Tab Name" class="fish-input channel-name-input" />
-            <ui:VisualElement name="channel-list" class="channel-list" />
+            <ui:ScrollView name="channel-list" class="channel-list" />
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChat.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChat.cs
@@ -75,6 +75,8 @@ namespace FishMMO.Client
 		private const string CHAT_MESSAGES_NAME = "chat-messages";
 		/// <summary>Name of the chat input field.</summary>
 		private const string CHAT_INPUT_NAME = "chat-input";
+		/// <summary>Name of the channel selector button beside the input.</summary>
+		private const string CHAT_CHANNEL_SELECTOR_NAME = "chat-channel-selector";
 
 		/// <summary>Theme class giving a chat tab its shared tab appearance.</summary>
 		/// <remarks>
@@ -113,16 +115,20 @@ namespace FishMMO.Client
 
 		/// <summary>
 		/// Colour mapping for each chat channel.
+		///
+		/// These are drawn on the dark chat panel, so a channel colour has to carry enough
+		/// lightness to be read there. Trade was Color.black and Region was Color.blue; both
+		/// are near-invisible against that background rather than merely dim.
 		/// </summary>
 		public Dictionary<ChatChannel, Color> ChannelColors = new Dictionary<ChatChannel, Color>()
 		{
 			{ ChatChannel.Say,      Color.white },
 			{ ChatChannel.World,    Color.cyan },
-			{ ChatChannel.Region,   Color.blue },
+			{ ChatChannel.Region,   new Color(0.45f, 0.65f, 1f) },
 			{ ChatChannel.Party,    Color.red },
 			{ ChatChannel.Guild,    Color.green},
 			{ ChatChannel.Tell,     Color.magenta },
-			{ ChatChannel.Trade,    Color.black },
+			{ ChatChannel.Trade,    new Color(0.98f, 0.68f, 0.34f) },
 			{ ChatChannel.System,   Color.yellow },
 			{ ChatChannel.Discord,  TinyColor.turquoise.ToUnityColor() },
 		};
@@ -223,6 +229,27 @@ namespace FishMMO.Client
 		private VisualElement messagesContainer;
 		/// <summary>Chat text input field.</summary>
 		private TextField inputField;
+		/// <summary>Button naming the channel a plain line is sent on.</summary>
+		private Button channelSelectorButton;
+
+		/// <summary>
+		/// Channels a player can actually send on, in selector order. Tell is excluded because it
+		/// needs a recipient typed with it, and System and Discord are not player-sendable.
+		/// </summary>
+		private static readonly ChatChannel[] SelectableChannels = new ChatChannel[]
+		{
+			ChatChannel.Say,
+			ChatChannel.World,
+			ChatChannel.Region,
+			ChatChannel.Party,
+			ChatChannel.Guild,
+			ChatChannel.Trade,
+		};
+
+		/// <summary>
+		/// The channel a line with no leading slash command is sent on.
+		/// </summary>
+		private ChatChannel sendChannel = ChatChannel.Say;
 
 		/// <summary>Chat tabs keyed by display name. Configuration survives a tree rebuild.</summary>
 		private readonly Dictionary<string, ChatTabView> tabs = new Dictionary<string, ChatTabView>();
@@ -329,6 +356,13 @@ namespace FishMMO.Client
 			scrollView = Root.Q<ScrollView>(CHAT_SCROLL_NAME);
 			messagesContainer = Root.Q<VisualElement>(CHAT_MESSAGES_NAME);
 			inputField = Root.Q<TextField>(CHAT_INPUT_NAME);
+
+			channelSelectorButton = Root.Q<Button>(CHAT_CHANNEL_SELECTOR_NAME);
+			if (channelSelectorButton != null)
+			{
+				channelSelectorButton.clicked += CycleSendChannel;
+				RefreshChannelSelector();
+			}
 
 			Button addTabButton = Root.Q<Button>(CHAT_ADD_TAB_NAME);
 			if (addTabButton != null)
@@ -564,6 +598,13 @@ namespace FishMMO.Client
 				case KeyCode.Return:
 				case KeyCode.KeypadEnter:
 					OnSubmit(inputField.value);
+					/* Sending has to release the field for the same reason Escape does. A focused
+					 * text field is what UIManager.InputControlHasFocus gates ALL player input on
+					 * — movement, hotkeys and interaction alike — so a field that keeps focus
+					 * after Enter leaves the player unable to move or press E until they think to
+					 * hit Escape or click the world. Escape was given this treatment and Enter was
+					 * not, which is why sending one chat line silently disabled the game. */
+					inputField.Blur();
 					evt.StopPropagation();
 					break;
 
@@ -726,6 +767,14 @@ namespace FishMMO.Client
 
 			PushInputHistory(input);
 
+			/* The selector names where a plain line goes. Anything already carrying a slash
+			 * command states its own destination and is left exactly as typed — that includes
+			 * non-channel commands like /leaveinstance, which must not be prefixed into chat. */
+			if (!input.StartsWith("/") && sendChannel != ChatChannel.Say)
+			{
+				input = $"{ChatHelper.ChannelCommandMap[sendChannel][0]} {input}";
+			}
+
 			/* Clean locally before sending.
 			 *
 			 * The server does this again and does not trust this — a client is free to skip it —
@@ -788,6 +837,36 @@ namespace FishMMO.Client
 			if (inputField != null)
 			{
 				inputField.value = "";
+			}
+		}
+
+		/// <summary>
+		/// Advances the selector to the next sendable channel.
+		/// </summary>
+		private void CycleSendChannel()
+		{
+			int index = System.Array.IndexOf(SelectableChannels, sendChannel);
+			sendChannel = SelectableChannels[(index + 1) % SelectableChannels.Length];
+			RefreshChannelSelector();
+		}
+
+		/// <summary>
+		/// Repaints the selector to match the current send channel.
+		/// </summary>
+		private void RefreshChannelSelector()
+		{
+			if (channelSelectorButton == null)
+			{
+				return;
+			}
+
+			channelSelectorButton.text = sendChannel.ToString();
+
+			/* Tinting the button with the channel colour means the destination is readable at a
+			 * glance without reading the word — the same cue the messages themselves use. */
+			if (ChannelColors.TryGetValue(sendChannel, out Color channelColor))
+			{
+				channelSelectorButton.style.color = channelColor;
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChatChannelPicker.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChatChannelPicker.cs
@@ -37,6 +37,11 @@ namespace FishMMO.Client
 		private bool suppressCallbacks;
 
 		/// <summary>
+		/// The position Activate asked for, before clamping it into view.
+		/// </summary>
+		private Vector3 requestedPosition;
+
+		/// <summary>
 		/// Builds a toggle per chat channel (except Command) and wires the rename input.
 		/// </summary>
 		public override void OnStarting()
@@ -71,6 +76,7 @@ namespace FishMMO.Client
 					{
 						name = $"channel-toggle-{channelName}",
 					};
+					toggle.AddToClassList("fish-toggle");
 					toggle.AddToClassList("channel-toggle");
 					toggle.RegisterValueChangedCallback((evt) => OnToggleChannel(channel, evt.newValue));
 					channelList.Add(toggle);
@@ -80,13 +86,24 @@ namespace FishMMO.Client
 
 			if (nameInput != null)
 			{
+				/* Trickle-down for the same reason the chat input uses it: a TextField handles
+				 * Return itself, and on the bubble phase that handling consumes the event before
+				 * this callback is reached — so the one gesture that committed a rename never
+				 * actually ran. */
 				nameInput.RegisterCallback<KeyDownEvent>((evt) =>
 				{
 					if (evt.keyCode == KeyCode.Return || evt.keyCode == KeyCode.KeypadEnter)
 					{
 						ChangeTabName();
+						evt.StopPropagation();
 					}
-				});
+				}, TrickleDown.TrickleDown);
+
+				/* Enter was also the ONLY thing that committed. This panel dismisses itself as
+				 * soon as the pointer leaves it, so typing a name and clicking a channel — or
+				 * simply moving away — threw the edit away with no indication it had been
+				 * ignored. Commit on losing the field instead. */
+				nameInput.RegisterCallback<FocusOutEvent>((evt) => ChangeTabName());
 			}
 
 			Root.RegisterCallback<PointerDownEvent>(OnRootPointerDown, TrickleDown.TrickleDown);
@@ -161,7 +178,44 @@ namespace FishMMO.Client
 				panel.style.position = Position.Absolute;
 				panel.style.left = position.x;
 				panel.style.top = position.y;
+
+				/* The panel is as tall as the channel list makes it, and Activate runs before
+				 * layout, so its height cannot be measured here — resolvedStyle reports NaN
+				 * until a layout pass has run. Clamp on the first geometry pass instead, once
+				 * both the panel and its container have real sizes. */
+				requestedPosition = position;
+				panel.UnregisterCallback<GeometryChangedEvent>(OnPanelGeometryChanged);
+				panel.RegisterCallback<GeometryChangedEvent>(OnPanelGeometryChanged);
 			}
+		}
+
+		/// <summary>
+		/// Keeps the panel fully on screen once its size is known.
+		/// </summary>
+		private void OnPanelGeometryChanged(GeometryChangedEvent evt)
+		{
+			if (panel == null || panel.parent == null)
+			{
+				return;
+			}
+
+			float containerWidth = panel.parent.contentRect.width;
+			float containerHeight = panel.parent.contentRect.height;
+			float panelWidth = panel.resolvedStyle.width;
+			float panelHeight = panel.resolvedStyle.height;
+
+			if (float.IsNaN(containerWidth) || float.IsNaN(containerHeight) ||
+				float.IsNaN(panelWidth) || float.IsNaN(panelHeight) ||
+				containerWidth <= 0.0f || containerHeight <= 0.0f)
+			{
+				return;
+			}
+
+			float left = Mathf.Clamp(requestedPosition.x, 0.0f, Mathf.Max(0.0f, containerWidth - panelWidth));
+			float top = Mathf.Clamp(requestedPosition.y, 0.0f, Mathf.Max(0.0f, containerHeight - panelHeight));
+
+			panel.style.left = left;
+			panel.style.top = top;
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
@@ -393,6 +393,12 @@ namespace FishMMO.Client
 		private Button editNoticeButton;
 		/// <summary>Disband button.</summary>
 		private Button disbandButton;
+		/// <summary>Create-guild button.</summary>
+		private Button createButton;
+		/// <summary>Invite-to-guild button.</summary>
+		private Button inviteButton;
+		/// <summary>Leave-guild button.</summary>
+		private Button leaveButton;
 
 		/// <summary>Roster search field.</summary>
 		private TextField searchField;
@@ -499,22 +505,22 @@ namespace FishMMO.Client
 				hoverCard.pickingMode = PickingMode.Ignore;
 			}
 
-			Button create = root.Q<Button>(CREATE_BUTTON_NAME);
-			if (create != null)
+			createButton = root.Q<Button>(CREATE_BUTTON_NAME);
+			if (createButton != null)
 			{
-				create.clicked += OnButtonCreateGuild;
+				createButton.clicked += OnButtonCreateGuild;
 			}
 
-			Button leave = root.Q<Button>(LEAVE_BUTTON_NAME);
-			if (leave != null)
+			leaveButton = root.Q<Button>(LEAVE_BUTTON_NAME);
+			if (leaveButton != null)
 			{
-				leave.clicked += OnButtonLeaveGuild;
+				leaveButton.clicked += OnButtonLeaveGuild;
 			}
 
-			Button invite = root.Q<Button>(INVITE_BUTTON_NAME);
-			if (invite != null)
+			inviteButton = root.Q<Button>(INVITE_BUTTON_NAME);
+			if (inviteButton != null)
 			{
-				invite.clicked += OnButtonInviteToGuild;
+				inviteButton.clicked += OnButtonInviteToGuild;
 			}
 
 			if (rosterTabButton != null)
@@ -1505,6 +1511,31 @@ namespace FishMMO.Client
 			if (disbandButton != null)
 			{
 				disbandButton.style.display = leaderDisplay;
+			}
+
+			/* The footer used to show Create, Invite and Leave at all times, so a player with no
+			 * guild was offered two actions that cannot do anything — there is nothing to invite
+			 * anyone to and nothing to leave. Membership decides which of the three can apply,
+			 * and Invite additionally answers to the same permission the server enforces. */
+			bool inGuild = Character != null &&
+						   Character.TryGet(out IGuildController membership) &&
+						   membership.ID > 0;
+
+			if (createButton != null)
+			{
+				createButton.style.display = inGuild ? DisplayStyle.None : DisplayStyle.Flex;
+			}
+
+			if (leaveButton != null)
+			{
+				leaveButton.style.display = inGuild ? DisplayStyle.Flex : DisplayStyle.None;
+			}
+
+			if (inviteButton != null)
+			{
+				inviteButton.style.display = inGuild && (permissions & GuildPermissions.Invite) == GuildPermissions.Invite
+					? DisplayStyle.Flex
+					: DisplayStyle.None;
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Party/UITKParty.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Party/UITKParty.cs
@@ -116,6 +116,12 @@ namespace FishMMO.Client
 		private Label emptyLabel;
 		/// <summary>Column caption strip, hidden while the roster is empty.</summary>
 		private VisualElement columns;
+		/// <summary>Create-party button.</summary>
+		private Button createButton;
+		/// <summary>Invite-to-party button.</summary>
+		private Button inviteButton;
+		/// <summary>Leave-party button.</summary>
+		private Button leaveButton;
 
 		/// <summary>
 		/// Queries the member list and wires up the action buttons.
@@ -141,22 +147,22 @@ namespace FishMMO.Client
 			emptyLabel = root.Q<Label>(EMPTY_NAME);
 			columns = root.Q(COLUMNS_NAME);
 
-			Button create = root.Q<Button>(CREATE_BUTTON_NAME);
-			if (create != null)
+			createButton = root.Q<Button>(CREATE_BUTTON_NAME);
+			if (createButton != null)
 			{
-				create.clicked += OnButtonCreateParty;
+				createButton.clicked += OnButtonCreateParty;
 			}
 
-			Button leave = root.Q<Button>(LEAVE_BUTTON_NAME);
-			if (leave != null)
+			leaveButton = root.Q<Button>(LEAVE_BUTTON_NAME);
+			if (leaveButton != null)
 			{
-				leave.clicked += OnButtonLeaveParty;
+				leaveButton.clicked += OnButtonLeaveParty;
 			}
 
-			Button invite = root.Q<Button>(INVITE_BUTTON_NAME);
-			if (invite != null)
+			inviteButton = root.Q<Button>(INVITE_BUTTON_NAME);
+			if (inviteButton != null)
 			{
-				invite.clicked += OnButtonInviteToParty;
+				inviteButton.clicked += OnButtonInviteToParty;
 			}
 		}
 
@@ -676,6 +682,25 @@ namespace FishMMO.Client
 			{
 				// Column captions over an empty list name fields that are not there.
 				columns.style.display = inParty ? DisplayStyle.Flex : DisplayStyle.None;
+			}
+
+			/* Same argument as the columns above, applied to the footer. OnButtonCreateParty
+			 * already refuses unless ID < 1, and Leave and Invite unless ID > 0, so showing all
+			 * three at once offers two buttons that are guaranteed no-ops. Draw what membership
+			 * actually permits instead. */
+			if (createButton != null)
+			{
+				createButton.style.display = inParty ? DisplayStyle.None : DisplayStyle.Flex;
+			}
+
+			if (leaveButton != null)
+			{
+				leaveButton.style.display = inParty ? DisplayStyle.Flex : DisplayStyle.None;
+			}
+
+			if (inviteButton != null)
+			{
+				inviteButton.style.display = inParty ? DisplayStyle.Flex : DisplayStyle.None;
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
@@ -162,12 +162,18 @@ namespace FishMMO.Client
 		/// </summary>
 		public void Deinitialize()
 		{
-			if (Character == null)
-			{
-				return;
-			}
-
-			if (Character.KCCPlayer != null)
+			/* Unsubscribing is NOT conditional on Character.
+			 *
+			 * PlayerControls is static and outlives this component, but the handlers registered
+			 * against it are instance methods — so a teardown that skips the unsubscribe leaves
+			 * the static action holding a delegate over a component that is destroyed moments
+			 * later. Returning early on a null Character, which a despawn or scene transfer can
+			 * produce, therefore leaks one dead subscriber per character for the session.
+			 *
+			 * The failure this produces is easy to misread: movement is polled through
+			 * ReadValue and keeps working, while everything routed through a "performed"
+			 * callback — interact, jump, crouch, sprint — is the half that suffers. */
+			if (Character != null && Character.KCCPlayer != null)
 			{
 				Character.KCCPlayer.OnHandleCharacterInput -= KCCPlayer_OnHandleCharacterInput;
 			}

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Interactable/Interactable.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Interactable/Interactable.cs
@@ -107,7 +107,13 @@ namespace FishMMO.Shared
 #if !UNITY_SERVER
 			GameObject.name = GameObject.name.Replace("(Clone)", "");
 			ICharacter character = Transform.GetComponent<ICharacter>();
+			/* CharacterGuildLabel is optional — it is assigned from a prefab's label object and a
+			 * character without one leaves it null. PlayerCharacter.SetGuildName already tests for
+			 * that; this did not, so any titled interactable lacking the label threw out of Awake.
+			 * The throw aborts the rest of this method, which is how walking into a zone produced
+			 * a NullReferenceException per NPC. */
 			if (character != null &&
+				character.CharacterGuildLabel != null &&
 				!string.IsNullOrWhiteSpace(Title))
 			{
 				string hex = TitleColor.ToHex();


### PR DESCRIPTION
Fixes found while play testing a local dev server. Every change here was
reproduced in-game and verified against client and server logs.

Branched from current `dev` and carries only these four commits.

## Chat window and channel picker

Right-clicking a chat tab opened a picker whose every label rendered
black-on-black — the "Tab Name" caption and all nine channel names.
Neither is styled by accident. The `.fish-input` text rule is scoped
through `#unity-text-input` deliberately, because matching
`.unity-text-element` under `.fish-input` also matches a field's own
label and gives it `flex-grow`, so the label expands and squeezes the
field it belongs to. Correct scoping, but it leaves the label with no
colour and it falls back to UITK's near-black default. The channel names
fail from the other direction: they are `BaseField` labels from
`new Toggle(name)`, and the theme only colours toggle labels under
`.fish-toggle`, which the picker's toggles never carried.

Also in this commit:

- The picker was positioned at the raw click point with no clamp and no
  height cap, so it ran off the bottom of the screen. It now clamps on
  the first geometry pass (position cannot be computed in `Activate`,
  where `resolvedStyle` is still `NaN`), caps against the viewport, and
  scrolls.
- Renaming a tab did nothing at all. The Return handler sat on the
  bubble phase where the `TextField` consumes Return first, so the only
  gesture that committed a rename never ran — and nothing committed on
  click-away, while the panel dismisses itself as soon as the pointer
  leaves.
- Trade chat was `Color.black` and Region was `Color.blue`, both
  effectively invisible on the dark chat panel.
- **Sending a chat message left the input focused.**
  `UIManager.InputControlHasFocus` gates *all* player input — movement,
  hotkeys and interaction — so one chat line disabled the game until the
  player pressed Escape or clicked the world. Escape already called
  `Blur` for precisely this reason; Return did not.
- A channel selector now sits left of the input. There was no persistent
  "current channel" concept, so this adds one; it prefixes the command
  only when the line does not already begin with `/`, leaving
  `/leaveinstance` and friends untouched.

## Guild and party footers

Both showed Create, Invite and Leave unconditionally, so a player in
neither was offered two buttons that cannot act. The handlers already
knew this — `OnButtonCreateParty` refuses unless `ID < 1`, Leave and
Invite unless `ID > 0` — so they were guaranteed no-ops. Membership now
decides what is drawn, and guild Invite additionally answers to
`GuildPermissions.Invite`, matching what the server enforces.

This is the same argument the party panel already applied to its column
captions, extended to the footer.

## Interactable NullReferenceException

`CharacterGuildLabel` is optional and left null on a character without a
label object. `Interactable.Awake` null-checked the character but not the
label, so any interactable with a `Title` and no label threw — aborting
the rest of `Awake` and leaving the object half-initialised. Walking into
a zone produced one exception per NPC. `PlayerCharacter.SetGuildName`
already guards this exact field.

## Leaked input subscriber

`PlayerControls` is static and outlives `PlayerInputController`, but its
handlers are instance methods. `Deinitialize` returned early whenever
`Character` was null — which a despawn or scene transfer readily produces
— skipping the unsubscribe and leaving the static action holding a
delegate over a component destroyed moments later.

Worth flagging for anyone chasing the symptom: movement is polled through
`ReadValue` and keeps working, while interact, jump, crouch and sprint
are raised through `performed` callbacks. The player walks around
normally with half their controls dead, which does not present as an
input-subscription problem.

## Not included

Diagnostic instrumentation from this session is deliberately left out, as
is unverified work. Two issues are diagnosed but not fixed here, because
both need a judgement call rather than a patch:

- **Resource regen runs during prediction replay.** Measured 380 stamina
  regen calls in 131 seconds against a 5-second cadence. The monotonic
  guard in `Regenerate()` is documented in-file as what prevents this,
  and it is not holding, so gains are applied on replayed ticks and then
  reconciled away. Fixing it means changing replay semantics.
- **`BodyVisibilityManager` logs 12 errors per character model spawn**,
  because no model in the project has the `BodyHead`/`BodyTorso`/... split
  it requires. Cosmetic, but it fires on every spawn and every zone
  transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
