### PR TITLE
Fix IL2CPP client unable to connect: native WebTransport callbacks marshal instance methods

### DIFF
--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ClientSocket.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ClientSocket.cs
@@ -147,6 +147,35 @@ namespace FishNet.Transporting.WebTransport.Client
 		private IntPtr pinnedCallbacksPtr = IntPtr.Zero;
 
 		/// <summary>
+		/// Maps a native context token to the socket that owns it. Looked up from the
+		/// static [AOT.MonoPInvokeCallback] trampolines below, for the same reason the
+		/// WebGL path keeps <see cref="webglSockets"/>: IL2CPP cannot marshal an instance
+		/// method or a lambda to native code, so the entry points must be static and have
+		/// no other way to reach their socket.
+		/// </summary>
+		private static readonly ConcurrentDictionary<IntPtr, ClientSocket> nativeSockets =
+			new ConcurrentDictionary<IntPtr, ClientSocket>();
+
+		/// <summary>
+		/// Source of the token handed to the native library as its callback context.
+		/// A counter rather than a GCHandle so that a callback arriving after teardown
+		/// resolves to nothing instead of dereferencing freed memory.
+		/// </summary>
+		private static long nativeContextCounter;
+
+		/// <summary>
+		/// This socket's key in <see cref="nativeSockets"/>, or zero when unregistered.
+		/// </summary>
+		private IntPtr nativeContext = IntPtr.Zero;
+
+		// Rooted for the process lifetime so the GC cannot collect the delegates while
+		// the native library holds their function pointers.
+		private static readonly NativeCallbacks.ClientConnectDelegate nativeStaticOnConnect = NativeOnConnect;
+		private static readonly NativeCallbacks.ClientDisconnectDelegate nativeStaticOnDisconnect = NativeOnDisconnect;
+		private static readonly NativeCallbacks.ClientStreamDataDelegate nativeStaticOnStreamData = NativeOnStreamData;
+		private static readonly NativeCallbacks.ClientDatagramDelegate nativeStaticOnDatagram = NativeOnDatagram;
+
+		/// <summary>
 		/// Finalizer -- drains the incoming event queue without invoking actions.
 		/// The .NET finalizer runs on an arbitrary thread, not the Unity main thread.
 		/// The queued actions call FishNet transport callbacks which must execute
@@ -202,6 +231,8 @@ namespace FishNet.Transporting.WebTransport.Client
 				System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 				this.pinnedCallbacksPtr = IntPtr.Zero;
 			}
+
+			ReleaseNativeContext();
 #endif
 
 			GC.SuppressFinalize(this);
@@ -360,12 +391,22 @@ namespace FishNet.Transporting.WebTransport.Client
 				return false;
 			}
 
+			/* The table must hold the STATIC trampolines, not the instance handlers.
+			 * IL2CPP refuses to marshal a delegate over an instance method to native code
+			 * ("IL2CPP does not support marshaling delegates that point to instance
+			 * methods to native code"), and it throws at the point the table is written
+			 * to unmanaged memory — so a player on an IL2CPP build could not connect at
+			 * all. The context token below is what carries the identity that `this`
+			 * used to. */
+			nativeContext = new IntPtr(System.Threading.Interlocked.Increment(ref nativeContextCounter));
+			nativeSockets[nativeContext] = this;
+
 			pinnedCallbacks = new NativeCallbacks.ClientCallbacks
 			{
-				OnConnect = new NativeCallbacks.ClientConnectDelegate(HandleNativeConnect),
-				OnDisconnect = new NativeCallbacks.ClientDisconnectDelegate(HandleNativeDisconnect),
-				OnStreamData = new NativeCallbacks.ClientStreamDataDelegate(HandleNativeStreamData),
-				OnDatagram = new NativeCallbacks.ClientDatagramDelegate(HandleNativeDatagram),
+				OnConnect = nativeStaticOnConnect,
+				OnDisconnect = nativeStaticOnDisconnect,
+				OnStreamData = nativeStaticOnStreamData,
+				OnDatagram = nativeStaticOnDatagram,
 			};
 
 			// Copy the callback table to unmanaged memory so that the native
@@ -376,7 +417,7 @@ namespace FishNet.Transporting.WebTransport.Client
 
 			clientHandle = WebTransportNative.wt_client_create(
 				this.pinnedCallbacksPtr,
-				IntPtr.Zero);
+				this.nativeContext);
 
 			if (clientHandle == null || clientHandle.IsInvalid)
 			{
@@ -386,6 +427,7 @@ namespace FishNet.Transporting.WebTransport.Client
 					System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 					this.pinnedCallbacksPtr = IntPtr.Zero;
 				}
+				ReleaseNativeContext();
 				base.SetConnectionState(LocalConnectionState.Stopped, false);
 				return false;
 			}
@@ -408,6 +450,7 @@ namespace FishNet.Transporting.WebTransport.Client
 					System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 					this.pinnedCallbacksPtr = IntPtr.Zero;
 				}
+				ReleaseNativeContext();
 				base.SetConnectionState(LocalConnectionState.Stopped, false);
 				return false;
 			}
@@ -878,6 +921,65 @@ namespace FishNet.Transporting.WebTransport.Client
 #endif
 
 		#region Native Callbacks (invoked from QUIC worker threads)
+
+		/// <summary>
+		/// Resolves the socket a native callback belongs to from its context token.
+		/// </summary>
+		/// <remarks>
+		/// A miss is normal rather than exceptional: the native library may complete a
+		/// callback that was already in flight when the socket tore down and removed its
+		/// token, and dropping that event is exactly the right response.
+		/// </remarks>
+		private static bool TryGetNativeSocket(IntPtr context, out ClientSocket socket)
+		{
+			return nativeSockets.TryGetValue(context, out socket) && socket != null;
+		}
+
+		/// <summary>
+		/// Drops this socket's context token so no further native callback can reach it.
+		/// </summary>
+		/// <remarks>
+		/// Called only after the native client has been destroyed, so that a callback
+		/// still in flight during teardown can complete against a live socket. Once the
+		/// token is gone the trampolines discard events rather than dispatching them,
+		/// which is the desired behaviour for a socket that is going away.
+		/// </remarks>
+		private void ReleaseNativeContext()
+		{
+			if (this.nativeContext != IntPtr.Zero)
+			{
+				nativeSockets.TryRemove(this.nativeContext, out _);
+				this.nativeContext = IntPtr.Zero;
+			}
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ClientConnectDelegate))]
+		private static void NativeOnConnect(IntPtr context)
+		{
+			if (TryGetNativeSocket(context, out ClientSocket socket))
+				socket.HandleNativeConnect(context);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ClientDisconnectDelegate))]
+		private static void NativeOnDisconnect(IntPtr context, int errorCode)
+		{
+			if (TryGetNativeSocket(context, out ClientSocket socket))
+				socket.HandleNativeDisconnect(context, errorCode);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ClientStreamDataDelegate))]
+		private static void NativeOnStreamData(IntPtr context, ulong streamId, IntPtr dataPtr, int length)
+		{
+			if (TryGetNativeSocket(context, out ClientSocket socket))
+				socket.HandleNativeStreamData(context, streamId, dataPtr, length);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ClientDatagramDelegate))]
+		private static void NativeOnDatagram(IntPtr context, IntPtr dataPtr, int length)
+		{
+			if (TryGetNativeSocket(context, out ClientSocket socket))
+				socket.HandleNativeDatagram(context, dataPtr, length);
+		}
 
 		/// <summary>
 		/// Called by the native library when the client connection is established.

--- a/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ServerSocket.cs
+++ b/FishMMO-Unity/Assets/Plugins/FishNet/Plugins/WebTransport/Core/ServerSocket.cs
@@ -178,6 +178,34 @@ namespace FishNet.Transporting.WebTransport.Server
 		private IntPtr pinnedCallbacksPtr = IntPtr.Zero;
 
 		/// <summary>
+		/// Maps a native context token to the socket that owns it, so the static
+		/// [AOT.MonoPInvokeCallback] trampolines below can find their server. IL2CPP
+		/// cannot marshal an instance method to native code, so those entry points have
+		/// no other route back to the instance.
+		/// </summary>
+		private static readonly System.Collections.Concurrent.ConcurrentDictionary<IntPtr, ServerSocket> nativeSockets =
+			new System.Collections.Concurrent.ConcurrentDictionary<IntPtr, ServerSocket>();
+
+		/// <summary>
+		/// Source of the token handed to the native library as its callback context.
+		/// A counter rather than a GCHandle so a callback arriving after teardown
+		/// resolves to nothing instead of dereferencing freed memory.
+		/// </summary>
+		private static long nativeContextCounter;
+
+		/// <summary>
+		/// This socket's key in <see cref="nativeSockets"/>, or zero when unregistered.
+		/// </summary>
+		private IntPtr nativeContext = IntPtr.Zero;
+
+		// Rooted for the process lifetime so the GC cannot collect the delegates while
+		// the native library holds their function pointers.
+		private static readonly NativeCallbacks.ServerConnectDelegate nativeStaticOnConnect = NativeOnConnect;
+		private static readonly NativeCallbacks.ServerDisconnectDelegate nativeStaticOnDisconnect = NativeOnDisconnect;
+		private static readonly NativeCallbacks.ServerStreamDataDelegate nativeStaticOnStreamData = NativeOnStreamData;
+		private static readonly NativeCallbacks.ServerDatagramDelegate nativeStaticOnDatagram = NativeOnDatagram;
+
+		/// <summary>
 		/// Finalizer -- drains the incoming event queue without invoking actions.
 		/// The .NET finalizer runs on an arbitrary thread, not the Unity main thread.
 		/// The queued actions call FishNet transport callbacks which must execute
@@ -203,6 +231,7 @@ namespace FishNet.Transporting.WebTransport.Server
 				System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 				this.pinnedCallbacksPtr = IntPtr.Zero;
 			}
+			ReleaseNativeContext();
 			// serverHandle is a SafeHandle; its own finalizer will release it
 			// via ReleaseHandle (which has the IsLibraryDeinitialized guard).
 		}
@@ -243,6 +272,7 @@ namespace FishNet.Transporting.WebTransport.Server
 				System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 				this.pinnedCallbacksPtr = IntPtr.Zero;
 			}
+			ReleaseNativeContext();
 
 			GC.SuppressFinalize(this);
 		}
@@ -301,13 +331,23 @@ namespace FishNet.Transporting.WebTransport.Server
 			this.maximumClients = maximumClients;
 			ResetQueues();
 
+			/* The table must hold the STATIC trampolines, not the instance handlers.
+			 * IL2CPP refuses to marshal a delegate over an instance method to native code
+			 * and throws where the table is written to unmanaged memory. The server
+			 * currently builds under Mono so this never fired here, but it is the same
+			 * defect that stopped the IL2CPP client connecting, and it would surface the
+			 * moment the server is built with IL2CPP. The context token below carries the
+			 * identity that the instance receiver used to supply. */
+			this.nativeContext = new IntPtr(System.Threading.Interlocked.Increment(ref nativeContextCounter));
+			nativeSockets[this.nativeContext] = this;
+
 			// Pin callback delegates (struct field roots managed delegates).
 			this.pinnedCallbacks = new NativeCallbacks.ServerCallbacks
 			{
-				OnConnect = new NativeCallbacks.ServerConnectDelegate(HandleNativeConnect),
-				OnDisconnect = new NativeCallbacks.ServerDisconnectDelegate(HandleNativeDisconnect),
-				OnStreamData = new NativeCallbacks.ServerStreamDataDelegate(HandleNativeStreamData),
-				OnDatagram = new NativeCallbacks.ServerDatagramDelegate(HandleNativeDatagram),
+				OnConnect = nativeStaticOnConnect,
+				OnDisconnect = nativeStaticOnDisconnect,
+				OnStreamData = nativeStaticOnStreamData,
+				OnDatagram = nativeStaticOnDatagram,
 			};
 
 			// Copy the callback table to unmanaged memory so that the native
@@ -347,7 +387,7 @@ namespace FishNet.Transporting.WebTransport.Server
 				(uint)maximumClients,
 				string.IsNullOrEmpty(this.allowedOrigins) ? null : this.allowedOrigins,
 				this.pinnedCallbacksPtr,
-				IntPtr.Zero);
+				this.nativeContext);
 			if (this.serverHandle == null || this.serverHandle.IsInvalid)
 			{
 				transport.NetworkManager?.LogError(
@@ -359,6 +399,7 @@ namespace FishNet.Transporting.WebTransport.Server
 					System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 					this.pinnedCallbacksPtr = IntPtr.Zero;
 				}
+				ReleaseNativeContext();
 				base.SetConnectionState(LocalConnectionState.Stopped, true);
 				return false;
 			}
@@ -378,6 +419,7 @@ namespace FishNet.Transporting.WebTransport.Server
 					System.Runtime.InteropServices.Marshal.FreeHGlobal(this.pinnedCallbacksPtr);
 					this.pinnedCallbacksPtr = IntPtr.Zero;
 				}
+				ReleaseNativeContext();
 				base.SetConnectionState(LocalConnectionState.Stopped, true);
 				return false;
 			}
@@ -687,6 +729,58 @@ namespace FishNet.Transporting.WebTransport.Server
 		#endregion
 
 		#region Native Callbacks (invoked from QUIC worker threads)
+
+		/// <summary>
+		/// Resolves the socket a native callback belongs to from its context token.
+		/// A miss is normal: the native library may complete a callback that was already
+		/// in flight when the socket tore down and removed its token.
+		/// </summary>
+		private static bool TryGetNativeSocket(IntPtr context, out ServerSocket socket)
+		{
+			return nativeSockets.TryGetValue(context, out socket) && socket != null;
+		}
+
+		/// <summary>
+		/// Drops this socket's context token so no further native callback can reach it.
+		/// Called only after the native server has been destroyed, so a callback still in
+		/// flight during teardown can complete against a live socket.
+		/// </summary>
+		private void ReleaseNativeContext()
+		{
+			if (this.nativeContext != IntPtr.Zero)
+			{
+				nativeSockets.TryRemove(this.nativeContext, out _);
+				this.nativeContext = IntPtr.Zero;
+			}
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ServerConnectDelegate))]
+		private static void NativeOnConnect(IntPtr context, ulong connectionId, IntPtr remoteAddress)
+		{
+			if (TryGetNativeSocket(context, out ServerSocket socket))
+				socket.HandleNativeConnect(context, connectionId, remoteAddress);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ServerDisconnectDelegate))]
+		private static void NativeOnDisconnect(IntPtr context, ulong connectionId, int errorCode)
+		{
+			if (TryGetNativeSocket(context, out ServerSocket socket))
+				socket.HandleNativeDisconnect(context, connectionId, errorCode);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ServerStreamDataDelegate))]
+		private static void NativeOnStreamData(IntPtr context, ulong connectionId, ulong streamId, IntPtr dataPtr, int length)
+		{
+			if (TryGetNativeSocket(context, out ServerSocket socket))
+				socket.HandleNativeStreamData(context, connectionId, streamId, dataPtr, length);
+		}
+
+		[AOT.MonoPInvokeCallback(typeof(NativeCallbacks.ServerDatagramDelegate))]
+		private static void NativeOnDatagram(IntPtr context, ulong connectionId, IntPtr dataPtr, int length)
+		{
+			if (TryGetNativeSocket(context, out ServerSocket socket))
+				socket.HandleNativeDatagram(context, connectionId, dataPtr, length);
+		}
 
 		/// <summary>
 		/// Called by the native library when a new client connects.


### PR DESCRIPTION
## The bug

An IL2CPP client cannot connect at all. `StartConnection` throws before a packet is ever sent:

```
System.NotSupportedException: IL2CPP does not support marshaling delegates that point to
instance methods to native code. The method we're attempting to marshal is:
FishNet.Transporting.WebTransport.Client.ClientSocket::HandleNativeConnect
  at FishNet.Transporting.WebTransport.Client.ClientSocket.StartConnection(...)
```

`ProjectSettings.asset` sets `scriptingBackend: Standalone: 1` (IL2CPP), so this is the
**default client configuration**, not an unusual one. It stays hidden under Mono, which
marshals instance methods without complaint — which is why it can go unnoticed in a
Mono-configured working tree.

## Why it happened

The constraint was already known in this file. The WebGL path documents it plainly:

> Looked up from static `[AOT.MonoPInvokeCallback]` entry points because IL2CPP cannot
> marshal instance methods or lambdas to native code.

…and handles it correctly, with static entry points and a `ConcurrentDictionary<int, ClientSocket>`
mapping the session index back to its socket. The **native** path never got the same
treatment and built its callback table directly over instance methods:

```csharp
OnConnect = new NativeCallbacks.ClientConnectDelegate(HandleNativeConnect),
```

IL2CPP throws at the point that table is written to unmanaged memory.

## The fix

Everything required was already present and unused. Every client and server callback takes
an `IntPtr context` as its first parameter, and `wt_client_create` / `wt_server_create` both
accept a context argument that the native library hands back to those callbacks — and both
were being passed `IntPtr.Zero`. That context is precisely the identity the instance
receiver had been supplying implicitly, so the fix is to start using it.

- The four client and four server handlers gain static `[AOT.MonoPInvokeCallback]`
  trampolines that resolve their socket from the context token and forward to the existing
  instance methods. **The instance logic is unchanged** — the trampolines only dispatch.
- Each socket registers under a monotonic token and passes it as the native context.
- The delegates are rooted in `static readonly` fields so the GC cannot collect them while
  the native library holds their function pointers.
- The token is released on teardown and on **both** create-failure paths, always *after*
  the native handle is destroyed.

### Why a token dictionary rather than a `GCHandle`

Both would satisfy IL2CPP. A counter-keyed dictionary was chosen because it fails safe: if
a callback arrives after teardown, it resolves to nothing and the event is dropped. A
`GCHandle` freed at teardown would instead be dereferenced by that late callback. This also
matches the pattern the WebGL path in this same file already uses.

Registration happens *before* `wt_client_create`, so unlike the WebGL path there is no
window in which a callback can arrive before the socket is findable — the `pendingConnect`
fallback that path needs has no equivalent here.

## ServerSocket is fixed too

`ServerSocket` carries the identical defect — its callback table is likewise built over
instance methods. It does **not** fire today only because the server happens to build under
Mono — verified: the server build contains 205 managed DLLs and no `il2cpp_data`. It would
surface the moment the server is built with IL2CPP, which `ProjectSettings.asset` already
requests (`scriptingBackend: Server: 1`). Fixing only the client would leave a live trap.

## Stripping

No `link.xml` change is needed. The plugin already declares
`<assembly fullname="WebTransport" preserve="all"/>`, so the new static entry points survive
managed stripping at the `High` level Standalone uses (`managedStrippingLevel: Standalone: 4`).

## Verification

| Check | Status |
|---|---|
| Reproduced on a clean `dev` checkout, IL2CPP client | Yes — exact exception above |
| Compiles (server build, 0 errors) | Yes |
| IL2CPP client builds with the fix, 0 errors | Yes |
| `NotSupportedException` no longer raised at startup | Yes |
| No instance-method delegates marshaled to native remain | Verified across the whole plugin |
| Delegate lifetime rooted against GC | Yes — `static readonly` fields |
| Token released on teardown + both error paths | Yes, after handle destruction |
| Double `StartConnection` cannot leak a token | Guarded — refuses unless state is `Stopped` |
| **Full end-to-end login against a live server** | **Confirmed** |

Confirmed end to end on an IL2CPP client against live Login / World / Scene servers. The
full chain completes, where previously it threw before sending a packet:

```
StartConnection host=127.0.0.1 port=7770 isWorld=False
  Handshake complete; auth token NOT held, credentials supplied.
  LoginSuccess
StartConnection host=127.0.0.1 port=7780 isWorld=True
  Handshake complete; auth token held, credentials NOT supplied.
  WorldLoginSuccess
StartConnection host=127.0.0.1 port=7790 isWorld=False
  Handshake complete; auth token held, credentials NOT supplied.
  SceneLoginSuccess
```

No `NotSupportedException` anywhere in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
