### PR TITLE
Give NPCs their name labels, and guard the namer against not having one

### DIFF
--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/AbilityCrafter/HumanAbilityCrafter.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/AbilityCrafter/HumanAbilityCrafter.prefab
@@ -251,6 +251,8 @@ MonoBehaviour:
   _componentIndexCache: 2
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -294,11 +296,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -398,13 +402,19 @@ MonoBehaviour:
   _componentIndexCache: 7
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 2183261051225038217}
+  characterGuildLabel: {fileID: 182486481576893756}
+  meshRoot: {fileID: 1810834502184966116}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 0
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 0}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -820,6 +830,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &2183261051225038217 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2609186560834504426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &2183261051225038219 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -959,6 +981,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &182486481576893756 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4103170126109918815}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &182486481576893758 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Banker/HumanBanker.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Banker/HumanBanker.prefab
@@ -236,6 +236,8 @@ MonoBehaviour:
   _componentIndexCache: 2
   _addedNetworkObject: {fileID: 7250114663715075110}
   _networkObjectCache: {fileID: 7250114663715075110}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -279,11 +281,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -383,13 +387,19 @@ MonoBehaviour:
   _componentIndexCache: 7
   _addedNetworkObject: {fileID: 7250114663715075110}
   _networkObjectCache: {fileID: 7250114663715075110}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 7801955724479932321}
+  characterGuildLabel: {fileID: 5985189574007265885}
+  meshRoot: {fileID: 5076809899322280303}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 0
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 0}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -820,6 +830,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &7801955724479932321 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 6214734821412240578}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &7801955724479932323 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -959,6 +981,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &5985189574007265885 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 7599432074871062846}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &5985189574007265887 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Merchants/GeneralGoods/HumanGeneralMerchant.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Merchants/GeneralGoods/HumanGeneralMerchant.prefab
@@ -237,6 +237,8 @@ MonoBehaviour:
   _componentIndexCache: 2
   _addedNetworkObject: {fileID: 6349228138187238843}
   _networkObjectCache: {fileID: 6349228138187238843}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -280,11 +282,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -384,13 +388,19 @@ MonoBehaviour:
   _componentIndexCache: 7
   _addedNetworkObject: {fileID: 6349228138187238843}
   _networkObjectCache: {fileID: 6349228138187238843}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 308152107889211198}
+  characterGuildLabel: {fileID: 8706110007537972994}
+  meshRoot: {fileID: 8610693803234203897}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 0
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 0}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -744,6 +754,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4485576106668420189}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &308152107889211198 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4485576106668420189}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!1001 &4804041099325959265
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -883,6 +905,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4804041099325959265}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8706110007537972994 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4804041099325959265}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!1001 &8610693803233813603
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
@@ -205,6 +205,8 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -248,11 +250,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,13 +356,19 @@ MonoBehaviour:
   _componentIndexCache: 5
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 2183261051225038217}
+  characterGuildLabel: {fileID: 182486481576893756}
+  meshRoot: {fileID: 1810834502184966116}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 1
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 0f2ff92179a6d1b4c9dde7ad6a4afdb0, type: 2}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -805,6 +815,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &2183261051225038217 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2609186560834504426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &2183261051225038219 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -944,6 +966,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &182486481576893756 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4103170126109918815}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &182486481576893758 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
@@ -205,6 +205,8 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -248,11 +250,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -354,13 +358,19 @@ MonoBehaviour:
   _componentIndexCache: 5
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 2183261051225038217}
+  characterGuildLabel: {fileID: 182486481576893756}
+  meshRoot: {fileID: 1810834502184966116}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 1
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 0f2ff92179a6d1b4c9dde7ad6a4afdb0, type: 2}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -807,6 +817,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &2183261051225038217 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2609186560834504426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &2183261051225038219 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -946,6 +968,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &182486481576893756 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4103170126109918815}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &182486481576893758 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
@@ -205,6 +205,8 @@ MonoBehaviour:
   _componentIndexCache: 0
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -248,11 +250,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -353,13 +357,19 @@ MonoBehaviour:
   _componentIndexCache: 5
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
-  meshRoot: {fileID: 0}
+  characterNameLabel: {fileID: 2183261051225038217}
+  characterGuildLabel: {fileID: 182486481576893756}
+  meshRoot: {fileID: 1810834502184966116}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 1
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 7c33d6280baf6d94b8eee0548a749deb, type: 2}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -806,6 +816,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &2183261051225038217 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2609186560834504426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &2183261051225038219 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -945,6 +967,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &182486481576893756 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4103170126109918815}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &182486481576893758 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
@@ -5043,6 +5043,8 @@ MonoBehaviour:
   _componentIndexCache: 3
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: -4468559157413045786}
+  StuckTimeout: 2.5
+  StuckWarpTimeout: 8
   SweepHits:
   - {fileID: 0}
   - {fileID: 0}
@@ -5086,11 +5088,13 @@ MonoBehaviour:
   AggressionDecayRate: 3
   AggressionStaleTimeout: 30
   AggressionVarietyChance: 0.15
+  TurnRate: 8
   RepathInterval: 0.5
   eyeTransform: {fileID: 0}
   LookTarget: {fileID: 0}
   RandomizeState: 0
   Waypoints: []
+  AiTickRate: 8
 --- !u!114 &2119787057571980410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5192,13 +5196,19 @@ MonoBehaviour:
   _componentIndexCache: 255
   _addedNetworkObject: {fileID: -4468559157413045786}
   _networkObjectCache: {fileID: 0}
-  characterNameLabel: {fileID: 0}
-  characterGuildLabel: {fileID: 0}
+  characterNameLabel: {fileID: 2183261051225038217}
+  characterGuildLabel: {fileID: 182486481576893756}
   meshRoot: {fileID: 1810834502184966116}
   npcSeed: 0
   npcGender: 0
   IsCharmable: 0
+  MinimumRespawnTime: 30
+  MaximumRespawnTime: 60
   CorpseDecayDuration: 30
+  EmptyCorpseDecayDuration: 5
+  CorpseInteractionRange: 4
+  LootTable: {fileID: 0}
+  onInteractTriggers: []
   AttributeBonuses: {fileID: 0}
   Abilities: []
   objectSpawner: {fileID: 0}
@@ -5647,6 +5657,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2de080fd835ec6747b1b1ff8ed6870f6, type: 3}
+--- !u!114 &2183261051225038217 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2609186560834504426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &2183261051225038219 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: 2de080fd835ec6747b1b1ff8ed6870f6,
@@ -5786,6 +5808,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc8cc64088072ae47872cf54e7cf6b6f, type: 3}
+--- !u!114 &182486481576893756 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4213452809119816547, guid: dc8cc64088072ae47872cf54e7cf6b6f,
+    type: 3}
+  m_PrefabInstance: {fileID: 4103170126109918815}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393abe25c2024ca5a6c1dca89ead0737, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: FishMMO.Shared::FishMMO.Shared.Core.WorldLabel
 --- !u!224 &182486481576893758 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4213452809119816545, guid: dc8cc64088072ae47872cf54e7cf6b6f,

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Naming/SceneObjectNamer.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Naming/SceneObjectNamer.cs
@@ -166,9 +166,18 @@ namespace FishMMO.Shared
 			this.gameObject.name = characterName.Trim();
 
 #if !UNITY_SERVER
-			// If on client, update the character's name label if present
+			/* "if present" applies to the label as well as the character.
+			 *
+			 * CharacterNameLabel is assigned from a prefab's label object and is left null
+			 * on a character that has none — every NPC prefab in the project ships that way,
+			 * and three of them (Banker, General Merchant, Ability Crafter) carry this
+			 * component. Testing only the character therefore threw a NullReferenceException
+			 * per named NPC on the client, out of the middle of naming.
+			 *
+			 * This is the same omission Interactable.Awake had against CharacterGuildLabel. */
 			ICharacter character = transform.GetComponent<ICharacter>();
-			if (character != null)
+			if (character != null &&
+				character.CharacterNameLabel != null)
 			{
 				character.CharacterNameLabel.text = this.gameObject.name;
 			}


### PR DESCRIPTION
Every NPC prefab in the project shipped with `characterNameLabel` and `characterGuildLabel`
unassigned, so NPCs rendered no floating name or guild label at all. The label objects were
already there — each prefab nests `Player Name Label` and `Player Guild Label` under its
`NameLabels` child — the fields simply pointed at nothing.

The three playable races (`Human`, `Elf`, `Orc`) wire both fields. None of the seven NPC
prefabs did:

| Prefab | Before | After |
| --- | --- | --- |
| `HumanBanker` | both null | both wired |
| `HumanGeneralMerchant` | both null | both wired |
| `HumanAbilityCrafter` | both null | both wired |
| `an orc` | both null | both wired |
| `an orc warrior` | both null | both wired |
| `an orc mage` | both null | both wired |
| `a lesser fire elemental` | both null | both wired |

`meshRoot` was unassigned on the same seven and is wired here too.

## The crash it was causing

`SceneObjectNamer` sets the name label after generating a character name:

```csharp
// If on client, update the character's name label if present
ICharacter character = transform.GetComponent<ICharacter>();
if (character != null)
{
    character.CharacterNameLabel.text = this.gameObject.name;
}
```

The comment says *"if present"*, but only the character is tested — not the label. Three of the
prefabs above (`HumanBanker`, `HumanGeneralMerchant`, `HumanAbilityCrafter`) carry
`SceneObjectNamer`, so each one threw a `NullReferenceException` on the client, out of the
middle of naming. It is inside `#if !UNITY_SERVER`, so it is client-only.

This is the same omission `Interactable.Awake` had against `CharacterGuildLabel`, fixed in
`dev` recently. The guard is added here to match.

## Why both halves

Wiring the prefabs alone would stop the exception in practice, and the guard alone would stop
it crashing while leaving NPCs unlabelled. Neither is sufficient on its own:

- The prefabs need wiring because the labels are meant to be there.
- The guard is still correct because the field is genuinely optional — a character with no
  label object leaves it null legitimately, which is exactly why `Interactable` was fixed the
  same way rather than by requiring the field.

Every other `CharacterNameLabel.` / `CharacterGuildLabel.` dereference in the codebase was
checked while here — `UITKPetControl`, `UITKTarget` and `Client.cs` all guard correctly. This
was the only one left unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
