### PR TITLE
ObjectSpawner: optional one live instance per spawnable

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Spawner/ObjectSpawner.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Spawner/ObjectSpawner.cs
@@ -52,6 +52,23 @@ namespace FishMMO.Shared
 		public int MaxSpawnCount = 1;
 
 		/// <summary>
+		/// When true, at most one live instance of each entry in <see cref="Spawnables"/> may exist
+		/// at a time.
+		/// </summary>
+		/// <remarks>
+		/// Off by default, because the normal case is a spawner filling a zone with several of the
+		/// same creature. Turn it on where each entry names a distinct individual — a zone listing
+		/// several named NPCs would otherwise draw the same one repeatedly and stand two copies of
+		/// it side by side, since the spawn index is chosen without regard to what is already alive.
+		///
+		/// This caps each entry at one, not the spawner: MaxSpawnCount still governs the total, so
+		/// with this on the effective ceiling is the smaller of MaxSpawnCount and the number of
+		/// assigned spawnables.
+		/// </remarks>
+		[Tooltip("Allow at most one live instance of each spawnable. Off by default. Turn on when every entry is a distinct individual that should never be duplicated.")]
+		public bool UniqueSpawnables = false;
+
+		/// <summary>
 		/// The type of spawn selection (Linear, Random, Weighted).
 		/// </summary>
 		public ObjectSpawnType SpawnType = ObjectSpawnType.Linear;
@@ -567,6 +584,63 @@ namespace FishMMO.Shared
 		}
 
 		/// <summary>
+		/// True when a live instance spawned from these settings already exists.
+		/// </summary>
+		/// <param name="spawnableSettings">The settings to look for among the live objects.</param>
+		/// <returns>True when one is already alive.</returns>
+		private bool IsSpawnableLive(SpawnableSettings spawnableSettings)
+		{
+			if (spawnableSettings == null)
+			{
+				return false;
+			}
+
+			foreach (ISpawnable spawned in Spawned.Values)
+			{
+				/* Reference equality against the settings object the spawn was created from, which
+				 * SpawnObject assigns below. Comparing the prefab instead would treat two entries
+				 * that share a prefab but differ in their overrides as the same spawnable. */
+				if (spawned != null &&
+					ReferenceEquals(spawned.SpawnableSettings, spawnableSettings))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Moves <paramref name="spawnIndex"/> onto a spawnable that has no live instance.
+		/// </summary>
+		/// <param name="spawnIndex">The chosen index, adjusted in place when it is already taken.</param>
+		/// <returns>False when every assigned spawnable is already alive.</returns>
+		/// <remarks>
+		/// Searches forward from the chosen index rather than re-rolling, so the configured spawn
+		/// type still decides where the search starts and a full list cannot spin.
+		/// </remarks>
+		private bool TryResolveUniqueSpawnIndex(ref int spawnIndex)
+		{
+			for (int offset = 0; offset < Spawnables.Count; ++offset)
+			{
+				int candidate = (spawnIndex + offset) % Spawnables.Count;
+
+				SpawnableSettings candidateSettings = Spawnables[candidate];
+				if (candidateSettings == null ||
+					candidateSettings.NetworkObject == null)
+				{
+					continue;
+				}
+
+				if (!IsSpawnableLive(candidateSettings))
+				{
+					spawnIndex = candidate;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
 		/// Spawns a new object in the world using the selected spawnable settings and position logic.
 		/// </summary>
 		public void SpawnObject()
@@ -584,7 +658,19 @@ namespace FishMMO.Shared
 				return;
 			}
 
-			SpawnableSettings spawnableSettings = Spawnables[GetSpawnIndex()];
+			int spawnIndex = GetSpawnIndex();
+
+			/* One live instance per entry, when asked for. The spawn index is chosen from the
+			 * configured spawn type alone and knows nothing about what is already alive, so without
+			 * this a list of distinct individuals happily spawns the same one twice. */
+			if (UniqueSpawnables &&
+				!TryResolveUniqueSpawnIndex(ref spawnIndex))
+			{
+				// Every assigned spawnable is already alive; nothing left that may be spawned.
+				return;
+			}
+
+			SpawnableSettings spawnableSettings = Spawnables[spawnIndex];
 			if (spawnableSettings == null ||
 				spawnableSettings.NetworkObject == null)
 			{


### PR DESCRIPTION
Closes #115.

An `ObjectSpawner` picks which entry to spawn from `SpawnType` alone — Linear walks the list,
Random rolls an index, Weighted rolls against the spawn chances. None of them consult what is
already alive. Where each entry names a *distinct individual*, that produces duplicates: a zone
listing several named NPCs will draw the same one again while it is still standing there, and
two copies end up side by side.

`UniqueSpawnables` caps each entry at one live instance at a time.

## Behaviour

Off by default, so nothing changes for existing spawners — the normal case is a spawner filling
a zone with several of the same creature, and that stays exactly as it was. Turned on, the
spawner will not spawn a second copy of a spawnable that is already alive.

It is a plain `[Tooltip]`ed public bool, so it appears in the standard inspector; `ObjectSpawner`
has no custom editor.

## Implementation

`SpawnObject` still asks `GetSpawnIndex()` first, so the configured spawn type continues to
decide where selection starts. When the toggle is on, the chosen index is then moved forward to
the first entry with no live instance:

```csharp
int spawnIndex = GetSpawnIndex();

if (UniqueSpawnables &&
    !TryResolveUniqueSpawnIndex(ref spawnIndex))
{
    // Every assigned spawnable is already alive; nothing left that may be spawned.
    return;
}
```

Two choices worth stating:

- **Liveness is matched on the `SpawnableSettings` reference**, not the prefab. `SpawnObject`
  already assigns `nobSpawnable.SpawnableSettings`, so the link exists. Comparing prefabs
  instead would treat two entries that share a prefab but differ in their overrides as the
  same spawnable, which is not what "one of each" means here.
- **The search walks forward rather than re-rolling.** A re-roll on a nearly-full list can spin;
  a forward scan terminates after at most `Spawnables.Count` steps and still honours the spawn
  type's starting point.

## Interaction with MaxSpawnCount

`MaxSpawnCount` still governs the total. With the toggle on, the effective ceiling becomes the
smaller of `MaxSpawnCount` and the number of assigned spawnables — a spawner with
`MaxSpawnCount: 9` and three entries will hold three. That is the intent for named individuals,
but it is worth knowing before enabling it on a spawner that was relying on a higher count.

`OnStartNetwork` also calls `GetSpawnIndex()` when seeding respawn timers, and is deliberately
left alone: it schedules timers rather than spawning, and `SpawnObject` is the single place the
rule is enforced. With the toggle on, a surplus timer simply finds nothing to spawn and no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
