### PR TITLE
Default brightness to half scale rather than maximum

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientDisplaySettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientDisplaySettings.cs
@@ -44,8 +44,19 @@ namespace FishMMO.Client
 		public const float MinimumBrightness = 0.0f;
 		/// <summary>Highest brightness the slider offers.</summary>
 		public const float MaximumBrightness = 1.0f;
-		/// <summary>Brightness used when the player has never chosen one.</summary>
-		public const float DefaultBrightness = 1.0f;
+		/// <summary>
+		/// Brightness used when the player has never chosen one.
+		/// </summary>
+		/// <remarks>
+		/// Mid-scale rather than maximum. This scales indirect light (see the class remarks), so
+		/// 1.0 is the top of the slider with no headroom left to raise it — a player who finds the
+		/// world too bright can only go down, and one who finds it too dark has nowhere to go. Half
+		/// way leaves adjustment in both directions.
+		///
+		/// Only applies to a player who has never set a brightness; an existing saved value is
+		/// read in preference to this and is not overwritten.
+		/// </remarks>
+		public const float DefaultBrightness = 0.5f;
 
 		/// <summary>
 		/// The brightness currently in force, kept so a scene load can put it back without


### PR DESCRIPTION
`DefaultBrightness` was `1.0f`, the top of the slider.

The practical problem is unpainted terrain. Where a terrain has no material painted onto it,
the default surface is near-white, and at full ambient it blows out into a flashbang — bright
enough to be genuinely unpleasant rather than merely wrong. A player meeting that on first run
has no idea it is a brightness setting, and the only thing they can do about it is turn the
slider down from a default that was already at maximum.

Half-scale also leaves adjustment in both directions, which a maximum default cannot: at `1.0`
a player who finds the world too dark has nowhere to go.

```csharp
public const float DefaultBrightness = 0.5f;   // was 1.0f
```

## Scope

`ClientDisplaySettings.DefaultBrightness` is the single source — both the options slider
(`UITKOptions.InitializeBrightness`) and the startup path (`ApplySavedBrightness`) read it, so
there is nothing else to change.

This only affects a player who has **never** set a brightness. `ClientSettings.GetFloat` returns
a saved value in preference to the default, so anyone with an existing `Brightness` key in their
configuration keeps exactly what they had; nothing is overwritten. Testing the new default needs
that key removed from `Configuration.cfg` first.

The control scales *indirect* light and is not an exposure control — see the class remarks on
`ClientDisplaySettings` — so this changes the ambient floor rather than washing the whole image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
