### PR TITLE
Update Input System to 1.20.0 so action callbacks fire again

### DIFF
--- a/FishMMO-Unity/Packages/manifest.json
+++ b/FishMMO-Unity/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.collections": "2.6.7",
     "com.unity.ide.visualstudio": "2.0.25",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.inputsystem": "1.16.0",
+    "com.unity.inputsystem": "1.20.0",
     "com.unity.memoryprofiler": "1.1.9",
     "com.unity.nuget.newtonsoft-json": "3.2.2",
     "com.unity.postprocessing": "3.5.1",


### PR DESCRIPTION
## The bug this fixes

On 1.16.0, **`performed` callbacks on the Player action map stop firing**, while polled input
on the *same enabled map* keeps working.

The practical effect is that a player can walk around normally with half their controls dead.
Movement is read through `ReadValue` and is unaffected; interact, sprint, jump and crouch are
raised through `performed` callbacks and are silently lost. Nothing is logged, no exception is
thrown, and the action map is enabled and correctly bound throughout — which makes it look like
a gameplay bug rather than an input one.

Reproduced repeatedly against a bindstone and NPCs: pressing **E** produced no reaction, no log
line anywhere, and **no `InteractableBroadcast` reaching the server** — the client was never
sending one.

## Why 1.20.0 fixes it

Two entries in the 1.20.0 changelog describe exactly this:

> "Fixed all `InputAction.WasXxxThisFrame()` and `WasXxxThisDynamicUpdate()` polling APIs to use
> **per-action suppression tracking instead of a map-wide flag**. Previously, when multiple
> events arrived in the same frame with mixed handled/unhandled states, the last event's
> suppression state could incorrectly affect **all actions in the map**."

> "The default event handled policy has been changed from `SuppressStateUpdates` (now deprecated)
> to **`SuppressActionEventNotifications`**, which keeps device state synchronized while
> **suppressing action callbacks** for handled events."

"Device state stays synchronised while action callbacks are suppressed, and suppression leaks
across the whole map" is a precise description of the symptom. The project runs
`InputSystemUIInputModule`, which marks events handled — so under the old map-wide flag a
handled UI event could suppress callbacks for every action in the Player map while leaving the
polled movement path working.

## Verified

Before the update, across several sessions, the diagnostic logging on `OnInteractPerformed` and
`OnSprintPerformed` produced **zero** lines — the callbacks were never invoked.

After updating to 1.20.0 and rebuilding, the same build with the same input produced:

```
17:03:55  OnSprintPerformed fired.
17:04:13  OnInteractPerformed fired.   (x2)
17:04:16  OnInteractPerformed fired.   (x3)
17:04:46  OnSprintPerformed fired.
```

Client and server both build clean at 1.20.0.

## Compatibility

`1.20.0` requires Unity `>= 6000.0`; `dev` is on `6000.3.2f1`, so this stands on its own and
does not depend on any Editor version change.

Only `manifest.json` is touched. `packages-lock.json` is left for the Editor to regenerate on
next open, so the lock reflects whatever the resolver actually picks rather than a hand-edited
version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
