### PR TITLE
Add a shared currency API, with the coverage it never had

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Currency/CharacterCurrency.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Currency/CharacterCurrency.cs
@@ -1,0 +1,158 @@
+using System;
+using FishMMO.Logging;
+using FishMMO.Shared.Core;
+
+namespace FishMMO.Shared
+{
+	/// <summary>
+	/// Reads and moves a character's currency.
+	/// </summary>
+	/// <remarks>
+	/// Currency is a <see cref="CharacterAttribute"/> rather than a field of its own, so every
+	/// system that touches it — looting, crafting, merchants, mail, and housing — has to resolve
+	/// the template, find the attribute, check sufficiency, write the balance and persist it. Done
+	/// by hand at each site that is five chances to get it wrong, and it has already gone wrong:
+	/// the crafting path tested <c>FinalValue</c> while writing <c>Value</c>, which let a
+	/// character wearing any currency-boosting buff spend money it did not have, and that was
+	/// fixed in the merchant and ability-learning paths before anyone noticed crafting had the
+	/// same defect.
+	///
+	/// <para>This puts the sequence in one place so a new caller inherits the corrected behaviour
+	/// instead of reimplementing it.</para>
+	/// </remarks>
+	public static class CharacterCurrency
+	{
+		/// <summary>
+		/// Reads a character's currency balance.
+		/// </summary>
+		/// <remarks>
+		/// Deliberately the BASE value, not <see cref="CharacterAttribute.FinalValue"/>.
+		/// <see cref="CharacterAttribute.AddValue"/> writes the base, and FinalValue is the base
+		/// plus every modifier in force — so testing one while writing the other lets a buff be
+		/// spent as though it were money and drives the balance negative by exactly the size of
+		/// the buff.
+		/// </remarks>
+		/// <param name="character">The character to read.</param>
+		/// <param name="template">The currency attribute template.</param>
+		/// <param name="balance">The balance, or zero when it could not be read.</param>
+		/// <returns>True when the character has the attribute.</returns>
+		public static bool TryGetBalance(ICharacter character, CharacterAttributeTemplate template, out long balance)
+		{
+			balance = 0;
+
+			if (character == null || template == null)
+			{
+				return false;
+			}
+
+			if (!character.TryGet(out ICharacterAttributeController attributeController) ||
+				!attributeController.TryGetAttribute(template, out CharacterAttribute currency))
+			{
+				return false;
+			}
+
+			balance = currency.Value;
+			return true;
+		}
+
+		/// <summary>
+		/// True when the character holds at least <paramref name="amount"/>.
+		/// </summary>
+		/// <remarks>
+		/// A non-positive amount is affordable by definition; callers that treat zero as a free
+		/// transaction do not need to special-case it.
+		/// </remarks>
+		public static bool CanAfford(ICharacter character, CharacterAttributeTemplate template, long amount)
+		{
+			if (amount <= 0)
+			{
+				return true;
+			}
+			return TryGetBalance(character, template, out long balance) && balance >= amount;
+		}
+
+		/// <summary>
+		/// Grants currency to a character.
+		/// </summary>
+		/// <param name="amount">Amount to grant. Non-positive amounts are rejected rather than
+		/// silently deducting, so a sign error cannot quietly take money.</param>
+		/// <returns>True when the balance was changed.</returns>
+		public static bool TryAdd(ICharacter character, CharacterAttributeTemplate template, long amount)
+		{
+			if (amount <= 0)
+			{
+				return false;
+			}
+
+			if (character == null || template == null)
+			{
+				return false;
+			}
+
+			if (!character.TryGet(out ICharacterAttributeController attributeController) ||
+				!attributeController.TryGetAttribute(template, out CharacterAttribute currency))
+			{
+				return false;
+			}
+
+			currency.AddValue((int)Math.Min(amount, int.MaxValue));
+			return true;
+		}
+
+		/// <summary>
+		/// Deducts currency, persists the change, and refunds it if persistence is refused.
+		/// </summary>
+		/// <remarks>
+		/// The ordering is deliberate and matches the merchant, ability-learning and crafting
+		/// paths: deduct, then persist, then let the caller grant whatever was bought. Persisting
+		/// snapshots the in-memory values as they stand, so it has to run after the deduction
+		/// rather than before it — and if the write is refused the deduction has to be undone,
+		/// otherwise the player is charged for something they never received.
+		///
+		/// <para>Persistence is supplied by the caller because it differs by context: the scene
+		/// server has its own attribute-write path, and shared code has no business knowing about
+		/// it. Passing null skips persistence for callers that batch their own writes.</para>
+		/// </remarks>
+		/// <param name="character">The character to charge.</param>
+		/// <param name="template">The currency attribute template.</param>
+		/// <param name="amount">Amount to deduct. Non-positive amounts are rejected.</param>
+		/// <param name="persist">Persistence callback; return false to refuse and trigger a refund.</param>
+		/// <returns>True when the character was charged and the change persisted.</returns>
+		public static bool TrySpend(ICharacter character, CharacterAttributeTemplate template, long amount, Func<bool> persist = null)
+		{
+			if (amount <= 0)
+			{
+				return false;
+			}
+
+			if (character == null || template == null)
+			{
+				return false;
+			}
+
+			if (!character.TryGet(out ICharacterAttributeController attributeController) ||
+				!attributeController.TryGetAttribute(template, out CharacterAttribute currency))
+			{
+				return false;
+			}
+
+			int price = (int)Math.Min(amount, int.MaxValue);
+			if (currency.Value < price)
+			{
+				return false;
+			}
+
+			currency.AddValue(-price);
+
+			if (persist != null && !persist())
+			{
+				currency.AddValue(price);
+				Log.Warning("CharacterCurrency",
+					$"Spend of {price} refused by persistence for CharID={character.ID}; refunded.");
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/Currency/CharacterCurrencyTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Currency/CharacterCurrencyTests.cs
@@ -1,0 +1,267 @@
+using System.Collections.Generic;
+using FishMMO.Shared;
+using FishMMO.Shared.Core;
+using FishNet.Connection;
+using FishNet.Managing.Predicting;
+using FishNet.Object;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Tests for <see cref="CharacterCurrency"/>, the shared read/spend/grant path.
+	/// </summary>
+	/// <remarks>
+	/// Currency had no coverage at all before this, while being hand-rolled at nine call sites
+	/// across looting, crafting, merchants and mail. These lock down the behaviour those sites
+	/// are being migrated onto, including the two mistakes the codebase has already made once:
+	/// spending against a buffed total, and deducting without a working persistence path.
+	/// </remarks>
+	[TestFixture]
+	public class CharacterCurrencyTests
+	{
+		private CharacterAttributeTemplate currencyTemplate;
+		private GameObject gameObject;
+		private CharacterAttributeController controller;
+		private MockCharacter character;
+
+		[SetUp]
+		public void SetUp()
+		{
+			currencyTemplate = ScriptableObject.CreateInstance<CharacterAttributeTemplate>();
+			currencyTemplate.name = "CurrencyTestAttribute";
+			currencyTemplate.InitialValue = 100;
+			currencyTemplate.AddToCache(currencyTemplate.name);
+
+			gameObject = new GameObject("CharacterCurrencyTest");
+			controller = gameObject.AddComponent<CharacterAttributeController>();
+
+			character = new MockCharacter(1, controller);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (currencyTemplate != null)
+			{
+				currencyTemplate.RemoveFromCache();
+				Object.DestroyImmediate(currencyTemplate);
+			}
+			if (gameObject != null)
+			{
+				Object.DestroyImmediate(gameObject);
+			}
+		}
+
+		/// <summary>
+		/// Adds the currency attribute to the controller with a starting balance.
+		/// </summary>
+		private CharacterAttribute GiveCurrency(int startingBalance)
+		{
+			CharacterAttribute attribute = new CharacterAttribute(controller, currencyTemplate.ID, startingBalance, 0);
+			controller.AddAttribute(attribute);
+			return attribute;
+		}
+
+		[Test]
+		public void TryGetBalance_ReturnsFalse_WhenCharacterHasNoCurrencyAttribute()
+		{
+			Assert.IsFalse(CharacterCurrency.TryGetBalance(character, currencyTemplate, out long balance));
+			Assert.AreEqual(0, balance);
+		}
+
+		[Test]
+		public void TryGetBalance_ReadsTheBaseValue()
+		{
+			GiveCurrency(250);
+
+			Assert.IsTrue(CharacterCurrency.TryGetBalance(character, currencyTemplate, out long balance));
+			Assert.AreEqual(250, balance);
+		}
+
+		/// <summary>
+		/// The buff trap: a modifier must not be spendable.
+		/// </summary>
+		/// <remarks>
+		/// This is the defect the crafting path shipped with — it tested FinalValue while writing
+		/// the base, so any currency-boosting modifier could be spent as though it were money.
+		/// </remarks>
+		[Test]
+		public void CanAfford_IgnoresModifiers_SoABuffCannotBeSpent()
+		{
+			CharacterAttribute currency = GiveCurrency(50);
+			currency.AddModifier(100);
+
+			Assert.Greater(currency.FinalValue, currency.Value, "test needs a modifier in force");
+			Assert.IsFalse(CharacterCurrency.CanAfford(character, currencyTemplate, 120),
+				"a modifier must not be spendable");
+			Assert.IsTrue(CharacterCurrency.CanAfford(character, currencyTemplate, 50));
+		}
+
+		[Test]
+		public void CanAfford_TreatsNonPositiveAsFree()
+		{
+			Assert.IsTrue(CharacterCurrency.CanAfford(character, currencyTemplate, 0));
+			Assert.IsTrue(CharacterCurrency.CanAfford(character, currencyTemplate, -10));
+		}
+
+		[Test]
+		public void TryAdd_IncreasesTheBalance()
+		{
+			CharacterAttribute currency = GiveCurrency(10);
+
+			Assert.IsTrue(CharacterCurrency.TryAdd(character, currencyTemplate, 15));
+			Assert.AreEqual(25, currency.Value);
+		}
+
+		/// <summary>
+		/// A sign error must not quietly take money.
+		/// </summary>
+		[Test]
+		public void TryAdd_RejectsNonPositiveAmounts()
+		{
+			CharacterAttribute currency = GiveCurrency(10);
+
+			Assert.IsFalse(CharacterCurrency.TryAdd(character, currencyTemplate, -5));
+			Assert.AreEqual(10, currency.Value, "a negative grant must not deduct");
+
+			Assert.IsFalse(CharacterCurrency.TryAdd(character, currencyTemplate, 0));
+			Assert.AreEqual(10, currency.Value);
+		}
+
+		[Test]
+		public void TrySpend_DeductsWhenAffordable()
+		{
+			CharacterAttribute currency = GiveCurrency(100);
+
+			Assert.IsTrue(CharacterCurrency.TrySpend(character, currencyTemplate, 30));
+			Assert.AreEqual(70, currency.Value);
+		}
+
+		[Test]
+		public void TrySpend_RefusesWhenShort_AndLeavesTheBalanceAlone()
+		{
+			CharacterAttribute currency = GiveCurrency(20);
+
+			Assert.IsFalse(CharacterCurrency.TrySpend(character, currencyTemplate, 21));
+			Assert.AreEqual(20, currency.Value);
+		}
+
+		/// <summary>
+		/// A refused persistence write must not leave the player charged.
+		/// </summary>
+		[Test]
+		public void TrySpend_RefundsWhenPersistenceIsRefused()
+		{
+			CharacterAttribute currency = GiveCurrency(100);
+
+			Assert.IsFalse(CharacterCurrency.TrySpend(character, currencyTemplate, 40, () => false));
+			Assert.AreEqual(100, currency.Value, "a refused write must be refunded in full");
+		}
+
+		[Test]
+		public void TrySpend_KeepsTheDeduction_WhenPersistenceSucceeds()
+		{
+			CharacterAttribute currency = GiveCurrency(100);
+			bool persisted = false;
+
+			Assert.IsTrue(CharacterCurrency.TrySpend(character, currencyTemplate, 40, () =>
+			{
+				persisted = true;
+				return true;
+			}));
+
+			Assert.IsTrue(persisted, "persistence must be invoked");
+			Assert.AreEqual(60, currency.Value);
+		}
+
+		/// <summary>
+		/// Persistence runs after the deduction, because it snapshots the values as they stand.
+		/// </summary>
+		[Test]
+		public void TrySpend_PersistsAfterDeducting()
+		{
+			CharacterAttribute currency = GiveCurrency(100);
+			int balanceSeenByPersist = -1;
+
+			CharacterCurrency.TrySpend(character, currencyTemplate, 25, () =>
+			{
+				balanceSeenByPersist = currency.Value;
+				return true;
+			});
+
+			Assert.AreEqual(75, balanceSeenByPersist,
+				"persistence must observe the post-deduction balance");
+		}
+
+		[Test]
+		public void TrySpend_RejectsNonPositiveAmounts()
+		{
+			CharacterAttribute currency = GiveCurrency(100);
+
+			Assert.IsFalse(CharacterCurrency.TrySpend(character, currencyTemplate, 0));
+			Assert.IsFalse(CharacterCurrency.TrySpend(character, currencyTemplate, -50));
+			Assert.AreEqual(100, currency.Value, "a negative spend must not grant money");
+		}
+
+		[Test]
+		public void Operations_AreSafeAgainstNulls()
+		{
+			Assert.IsFalse(CharacterCurrency.TryGetBalance(null, currencyTemplate, out _));
+			Assert.IsFalse(CharacterCurrency.TryGetBalance(character, null, out _));
+			Assert.IsFalse(CharacterCurrency.TryAdd(null, currencyTemplate, 10));
+			Assert.IsFalse(CharacterCurrency.TrySpend(null, currencyTemplate, 10));
+		}
+
+		/// <summary>
+		/// Minimal ICharacter that resolves a single attribute controller.
+		/// </summary>
+		private sealed class MockCharacter : ICharacter
+		{
+			private readonly ICharacterAttributeController attributeController;
+
+			public MockCharacter(long id, ICharacterAttributeController attributeController)
+			{
+				ID = id;
+				this.attributeController = attributeController;
+			}
+
+			public long ID { get; set; }
+			public string Name => "MockCharacter";
+			public Transform Transform => null;
+			public GameObject GameObject => null;
+			public Collider Collider { get; set; }
+			public NetworkConnection Owner => null;
+			public NetworkObject NetworkObject => null;
+			public PredictionManager PredictionManager => null;
+			public HashSet<NetworkConnection> Observers { get; } = new HashSet<NetworkConnection>();
+			public bool IsTeleporting => false;
+			public bool IsSpawned => true;
+			public int Flags { get; set; }
+
+			public WorldLabel CharacterNameLabel { get; set; }
+			public WorldLabel CharacterGuildLabel { get; set; }
+			public Transform MeshRoot => null;
+
+#if !UNITY_SERVER
+			public void InstantiateRaceModelFromIndex(RaceTemplate raceTemplate, int modelIndex) { }
+			public void InstantiateRaceModelFromIndex(RaceTemplate raceTemplate, int modelIndex, CharacterGender gender) { }
+#endif
+
+			public void EnableFlags(CharacterFlags flags) => Flags |= (int)flags;
+			public void DisableFlags(CharacterFlags flags) => Flags &= ~(int)flags;
+			public bool IsFlagged(CharacterFlags flags) => (Flags & (int)flags) != 0;
+			public void RegisterCharacterBehaviour(ICharacterBehaviour characterBehaviour) { }
+			public void UnregisterCharacterBehaviour(ICharacterBehaviour characterBehaviour) { }
+
+			public bool TryGet<T>(out T control) where T : class, ICharacterBehaviour
+			{
+				control = this.attributeController as T;
+				return control != null;
+			}
+
+			public void Invoke(List<Trigger> triggers, EventData eventData) { }
+		}
+	}
+}


### PR DESCRIPTION
Currency is a `CharacterAttribute`, so every system that touches it has to resolve the template,
find the attribute, check sufficiency, write the balance and persist it. That sequence is
currently hand-written at **nine call sites** across looting, crafting, merchants and mail — and
it has already gone wrong once in a way the code itself records:

> "AddValue below writes the BASE value; FinalValue is the base plus every modifier in force.
> Testing one and writing the other let a character carrying any currency-boosting buff craft
> against currency it did not have and go negative by exactly the size of the buff. **The
> merchant purchase and ability-learning paths were already fixed for this; the crafting path
> was not.**"

The same defect, found and fixed twice, missed a third time. That is what a shared entry point
prevents.

## What this adds

`CharacterCurrency` — one place for the read/check/spend/grant sequence:

| Method | Behaviour |
| --- | --- |
| `TryGetBalance` | Reads the **base** value, deliberately — see below |
| `CanAfford` | Sufficiency test; non-positive amounts are free by definition |
| `TryAdd` | Grants; rejects non-positive amounts so a sign error cannot quietly *take* money |
| `TrySpend` | Checks, deducts, persists, and refunds if persistence is refused |

**Base value, not `FinalValue`.** `AddValue` writes the base; `FinalValue` is the base plus every
modifier in force. Testing one while writing the other is exactly the bug quoted above, so the
distinction is documented at the point it matters rather than left for the next caller to
rediscover.

**Persistence is a caller-supplied callback.** The deduct → persist → refund ordering is the
part most easily got wrong: persistence snapshots the in-memory values as they stand, so it has
to run *after* the deduction, and a refused write has to be undone or the player is charged for
something they never received. `TrySpend` owns that ordering, while the callback keeps shared
code from knowing about the scene server's attribute-write path.

## Tests

Currency had **no coverage at all** — 43 test files in the project, none touching it. This adds
13, all passing, locking down the behaviour the call sites will be migrated onto:

- `CanAfford_IgnoresModifiers_SoABuffCannotBeSpent` — the crafting defect above
- `TrySpend_RefundsWhenPersistenceIsRefused` — a refused write must not leave the player charged
- `TrySpend_PersistsAfterDeducting` — persistence observes the post-deduction balance
- `TryAdd_RejectsNonPositiveAmounts` / `TrySpend_RejectsNonPositiveAmounts` — a sign error must
  neither take nor pay out
- Plus balance reads, insufficient funds, and null safety

```
total=13 passed=13 failed=0 skipped=0
```

## Scope

**Deliberately additive.** No existing call site is changed here. Migrating the nine sites is a
follow-up, kept separate so this suite can be reviewed as a safety net *before* live payment
paths move onto it — refactoring money handling with no coverage is how balances quietly go
wrong.

Server builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
