### PR TITLE
Bump the Memory Profiler to 1.1.12 so the editor compiles

### DIFF
--- a/FishMMO-Unity/Packages/manifest.json
+++ b/FishMMO-Unity/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.ide.visualstudio": "2.0.27",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.20.0",
-    "com.unity.memoryprofiler": "1.1.9",
+    "com.unity.memoryprofiler": "1.1.12",
     "com.unity.nuget.newtonsoft-json": "3.2.2",
     "com.unity.postprocessing": "3.5.4",
     "com.unity.render-pipelines.universal": "17.4.0",


### PR DESCRIPTION
`com.unity.memoryprofiler` 1.1.9 does not compile against the editor version this project pins,
6000.4.10f1. The package's own editor code fails on a type the newer editor moved:

```
Library\PackageCache\com.unity.memoryprofiler@.../EditorAssetFinderUtility.cs(809,63):
error CS0246: The type or namespace name 'GUID' could not be found
```

It is an **editor** assembly, so this does not fail one test — it takes the editor compile down
and stops the EditMode suite from running at all. That is what makes it worth its own change:
the failure looks like the test runner being broken rather than like a package version being wrong.

## Verified

A/B on a clean checkout of `dev`, same machine, same editor:

| memoryprofiler | Result |
| --- | --- |
| 1.1.9 | Editor compile fails; test run aborts with no results |
| 1.1.12 | Compiles; **485 of 486 tests pass** |

The single remaining failure is the pre-existing `PetSystemAssetTests` asset issue — the *lesser
fire elemental* prefab has no health resource attribute — which is unrelated and untouched here.

## Why it appeared now

The editor pin moved to 6000.4.10f1 without the package moving with it. Nothing else in the
manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **Correction (2026-08-27):** this PR described the `PetSystemAssetTests` failure as a
> pre-existing *content* problem with the lesser fire elemental prefab. That was wrong — I was
> repeating the test's own message without checking it. `644261aa` fixed the **test**: under
> EditMode nothing calls `AddToCache`, so every template ID sits at 0 while the controller
> compares against a real hash, and the assertion could never pass for any pet. The prefab is
> correctly authored (`HealthResourceTemplateID: -2113468379`). The suite is now fully green.
