### PR TITLE
Rebuild the migration snapshot with provider conventions so drift can be detected

### DIFF
--- a/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContextFactory.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/NpgsqlDbContextFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -508,15 +508,62 @@ namespace FishMMO.Database.Npgsql
 			var differ = Microsoft.EntityFrameworkCore.Infrastructure
 				.AccessorExtensions.GetService<Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer>(context);
 
-			var snapshotModel = snapshot.Model;
-			if (snapshotModel is Microsoft.EntityFrameworkCore.Metadata.IMutableModel mutableSnapshot)
+			return differ.HasDifferences(
+				BuildSnapshotRelationalModel(context, snapshot),
+				context.Model.GetRelationalModel());
+		}
+
+		/// <summary>
+		/// Rebuilds the migration snapshot's model with this provider's conventions, so it can be
+		/// compared against the live model.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// <c>ModelSnapshot.Model</c> cannot be used directly. EF builds it with an <em>empty</em>
+		/// convention set, so the relational conventions never run and no relational model is
+		/// attached — <c>GetRelationalModel()</c> on it throws <c>"The database model hasn't been
+		/// initialized"</c>. That is what made this check fail on every startup while reporting
+		/// only that something had gone wrong, which is the least useful thing a schema check can
+		/// say.
+		/// </para>
+		/// <para>
+		/// EF's own tooling solves this with <c>SnapshotModelProcessor</c>, and EF 6 added
+		/// <c>IModelRuntimeInitializer</c> for it. Neither exists here: the first ships in the
+		/// design-time package, which a server does not load, and the second postdates EF Core 5.
+		/// What is left is to do what both of them do — re-run the snapshot's own model definition
+		/// through the provider's conventions.
+		/// </para>
+		/// <para>
+		/// <c>BuildModel</c> is protected, hence the reflection. It is a stable shape — every
+		/// generated snapshot overrides it — but if a future EF renames it this returns null and
+		/// the caller reports an unevaluated check rather than a false clean bill of health.
+		/// </para>
+		/// </remarks>
+		private static Microsoft.EntityFrameworkCore.Metadata.IRelationalModel BuildSnapshotRelationalModel(
+			NpgsqlDbContext context,
+			object snapshot)
+		{
+			var buildModel = snapshot.GetType().GetMethod(
+				"BuildModel",
+				System.Reflection.BindingFlags.Instance |
+				System.Reflection.BindingFlags.NonPublic |
+				System.Reflection.BindingFlags.Public);
+
+			if (buildModel == null)
 			{
-				snapshotModel = mutableSnapshot.FinalizeModel();
+				throw new InvalidOperationException(
+					"ModelSnapshot.BuildModel could not be located, so the snapshot model cannot be " +
+					"rebuilt with provider conventions.");
 			}
 
-			return differ.HasDifferences(
-				snapshotModel.GetRelationalModel(),
-				context.Model.GetRelationalModel());
+			var conventionSet = Microsoft.EntityFrameworkCore.Infrastructure.AccessorExtensions
+				.GetService<Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure.IConventionSetBuilder>(context)
+				.CreateConventionSet();
+
+			var modelBuilder = new ModelBuilder(conventionSet);
+			buildModel.Invoke(snapshot, new object[] { modelBuilder });
+
+			return modelBuilder.FinalizeModel().GetRelationalModel();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #162.

The schema drift check failed identically on **every** server start, on all three game servers. So
the guard against "the entity model no longer matches the database" was absent while appearing to be
present — the worst state for a safety check to be in.

## Cause

`ModelSnapshot.Model` is built by EF with an **empty convention set**. The relational conventions
never run, no relational model is attached, and `GetRelationalModel()` throws *"The database model
hasn't been initialized"*.

`FinalizeModel()` does not help: finalizing a model that was built without relational conventions
still yields one without them.

## Why the standard remedies do not apply here

| Remedy | Why not |
| --- | --- |
| `SnapshotModelProcessor` (what `dotnet ef` uses) | Ships in `Microsoft.EntityFrameworkCore.Design` — a design-time package a server does not load |
| `IModelRuntimeInitializer` | EF Core 6+; this project pins **5.0.17** |
| `DatabaseFacade.HasPendingModelChanges()` | EF Core 8+ |

So the fix does what all three of those do internally: re-run the snapshot's own model definition
through **the provider's** convention set, then take the relational model from that.

`BuildModel` is `protected`, hence the reflection. It is a stable shape — every generated snapshot
overrides it — and if a future EF renames it, the method throws and the caller reports an
*unevaluated* check rather than a false clean bill of health. That direction matters: the failure
mode stays "we could not check", never "we checked and it is fine".

## What was actually at risk

Pending-migration detection worked throughout, so the common case — *you have not run the migration*
— was always caught. What was missed is the case drift detection exists for: someone edits an entity
without generating a migration, nothing is pending, and the schema is quietly wrong. That surfaces
as missing player data, which is exactly what the error message warns about while being unable to
detect it.

## Scope

One file. Nothing else — in particular this is independent of #160 and #161, and can merge in any
order relative to them.

## Testing

Compiles clean; 638/638 EditMode tests pass.

**Runtime verification is pending** — a server rebuild and restart is needed to confirm the startup
error is actually gone, and that is the check that matters here. I will update this PR with the
result rather than leave the claim implied.

Note that a clean start only proves the *negative* case, against a database whose schema currently
matches. Confirming the positive case means manufacturing real drift — editing an entity without
generating a migration — and is worth doing once before trusting this as a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

