### PR TITLE
Run mouse targeting only for the player holding the mouse

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Target/TargetController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Target/TargetController.cs
@@ -115,6 +115,32 @@ namespace FishMMO.Shared
 		/// </summary>
 		void Update()
 		{
+			/* Mouse targeting belongs to the player holding the mouse.
+			 *
+			 * This component sits on every playable character, so without this guard every copy of
+			 * every character runs it: on a client watching fifty other players, fifty instances
+			 * each read the local mouse, build the same ray from the same camera, and trace it.
+			 * They necessarily agree — there is one mouse — so forty-nine of those traces exist
+			 * only to arrive at the answer the fiftieth already had, and each is a physics raycast
+			 * (two, where the first ray starts inside the caster and has to be pushed through).
+			 *
+			 * The events are the more serious half. A non-owner instance that resolves a target
+			 * raises OnChangeTarget and fires the character's target triggers, so ECA logic hung on
+			 * "this character acquired a target" runs on other people's characters, driven by where
+			 * the local player happens to be pointing.
+			 *
+			 * A dedicated server never reaches any of it — this method is inside #if !UNITY_SERVER.
+			 * The editor is the exception that matters: UNITY_SERVER is undefined there, so an
+			 * in-editor scene server runs this for every character against the developer's mouse.
+			 *
+			 * Deliberately not a guard on the whole component. UpdateTarget is still called
+			 * directly, on the server, by the ability and pet systems with their own aim origins,
+			 * and that path — including its lag compensation — is untouched by this. */
+			if (!base.IsOwner)
+			{
+				return;
+			}
+
 			if (Camera.main == null)
 			{
 				return;


### PR DESCRIPTION
`TargetController` sits on every playable character, and its `Update` has no owner guard. Every copy of every character runs it.

On a client watching fifty other players, fifty instances each read the local mouse, build the same ray from the same camera, and trace it. They necessarily agree — there is one mouse — so forty-nine of those traces exist only to arrive at the answer the fiftieth already had. Each is a `physicsScene.Raycast`, or two where the ray starts inside the caster and gets pushed through, plus a `GetComponent<IPlayerCharacter>()` on the hit. At the 20 Hz check rate (`TARGET_UPDATE_RATE = 0.05f`) that is on the order of a thousand raycasts a second where twenty are wanted.

**The events are the more serious half.** A non-owner instance that resolves a target raises `OnChangeTarget` and fires that character's target triggers, so ECA logic hung on "this character acquired a target" runs on other people's characters, driven by wherever the local player happens to be pointing. That is a correctness problem rather than a cost one.

## Where this actually runs

`Update` is inside `#if !UNITY_SERVER`, so a **dedicated server build never compiles it** — that part is already handled and this changes nothing there.

It does run, for every character, in two places that matter: on **clients**, which is where the redundant raycasts are; and in the **editor**, where `UNITY_SERVER` is undefined and the scene server is developed, so an in-editor server has every character resolving targets from the developer's mouse.

## Scope

Deliberately on `Update` only, not the component.

`UpdateTarget` is still called directly, on the server, by `PetSystem` and `AbilityController.Activation` with their own aim origins — that path, including its lag compensation, is untouched by this. `ClearTargetAction` likewise.

Every reader of `Current` is client UI operating on the local player: `UITKTarget`, `UITKParty`, `UITKGuild`, `PlayerInputController`. Nothing reads a remote character's `Current`, so nothing depended on the work this removes.

## Testing

Suite is 892 / 890 on this branch. The two failures are `MapSystemTests.Filter_ExactMarker_IsMarkedAsTrackingItsTransform` and `Filter_ThrottledMarker_PublishesACoarsePositionAndForbidsLiveReads`, which fail identically on clean `dev`.

No test is added: the change is a guard on a `MonoBehaviour` `Update` whose body needs a camera, a mouse and a physics scene, and a test that stood all three up would be asserting on Unity rather than on this. The scoping argument above is the reviewable part, and it is a reading of the call sites rather than something a unit test would confirm.

I have **not** benchmarked this one — the multiplication factor is structural, from the call sites and the prefab list, not a timing I measured.
