### PR TITLE
Switch on the AI level-of-detail system that already exists

### DIFF
--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/AbilityCrafter/HumanAbilityCrafter.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/AbilityCrafter/HumanAbilityCrafter.prefab
@@ -291,7 +291,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Banker/HumanBanker.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Banker/HumanBanker.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Merchants/GeneralGoods/HumanGeneralMerchant.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Interactables/Human/Merchants/GeneralGoods/HumanGeneralMerchant.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
@@ -245,7 +245,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
@@ -245,7 +245,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
@@ -245,7 +245,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: cd98f591a3445c5a50a6e478001853a1, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
@@ -5083,7 +5083,7 @@ MonoBehaviour:
   AbilityRotation: {fileID: 0}
   Personality: {fileID: 0}
   BehaviorTree: {fileID: 0}
-  LodSettings: {fileID: 0}
+  LodSettings: {fileID: 11400000, guid: 4309ac96576cac0277c5f220a221a5a2, type: 2}
   BossScript: {fileID: 0}
   AggressionDamageWeight: 1
   AggressionHealingWeight: 0.6

--- a/FishMMO-Unity/Assets/UnitTests/AI/AILodAssignmentTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/AI/AILodAssignmentTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using FishMMO.Shared;
+
+namespace FishMMO.UnitTests.AI
+{
+	/// <summary>
+	/// Asserts that every NPC prefab with a brain has AI level-of-detail settings assigned.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The LOD system is opt-in by reference: <see cref="AIController.LodSettings"/> is a plain
+	/// field, and when it is null <see cref="AIController"/> keeps <c>currentLodTier</c> at
+	/// <see cref="AILodTier.Active"/> and a tick interval of 1. Every NPC then runs the full
+	/// pipeline — sweep, leash, behaviour tree, boss script, state machine, aggression — on every
+	/// AI tick, whether or not a player is within three hundred metres of it.
+	/// </para>
+	/// <para>
+	/// That is what makes this worth a test rather than a convention. A missing reference produces
+	/// no error, no warning and no visible misbehaviour: the NPC is simply more attentive than it
+	/// needs to be, and the cost is invisible until there are thousands of them. The whole system
+	/// shipped switched off this way, with its settings assets authored and unreferenced.
+	/// </para>
+	/// <para>
+	/// EditMode only — it uses <see cref="AssetDatabase"/> to find the shipped prefabs.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class AILodAssignmentTests
+	{
+		/// <summary>Folder the NPC prefabs live in.</summary>
+		private const string NPC_PREFAB_FOLDER = "Assets/Prefabs/Shared/Entity/NPCs";
+
+		/// <summary>Folder the LOD settings assets live in.</summary>
+		private const string LOD_FOLDER = "Assets/Templates/Entity/NPCs/AI/LOD";
+
+		/// <summary>Every NPC prefab that carries an <see cref="AIController"/>.</summary>
+		private static List<GameObject> brains;
+
+		[OneTimeSetUp]
+		public void LoadPrefabs()
+		{
+			brains = new List<GameObject>();
+
+			string[] guids = AssetDatabase.FindAssets("t:Prefab", new[] { NPC_PREFAB_FOLDER });
+			for (int i = 0; i < guids.Length; i++)
+			{
+				string path = AssetDatabase.GUIDToAssetPath(guids[i]);
+				GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+				if (prefab == null)
+				{
+					continue;
+				}
+
+				if (prefab.GetComponentInChildren<AIController>(true) != null)
+				{
+					brains.Add(prefab);
+				}
+			}
+		}
+
+		[Test]
+		public void EveryNPCWithABrain_HasLodSettingsAssigned()
+		{
+			Assert.Greater(brains.Count, 0,
+				$"No NPC prefab with an AIController was found under {NPC_PREFAB_FOLDER}. " +
+				"The test is looking in the wrong place rather than passing.");
+
+			StringBuilder missing = new StringBuilder();
+
+			for (int i = 0; i < brains.Count; i++)
+			{
+				AIController controller = brains[i].GetComponentInChildren<AIController>(true);
+				if (controller.LodSettings == null)
+				{
+					missing.AppendLine($"  {brains[i].name}");
+				}
+			}
+
+			Assert.IsEmpty(missing.ToString(),
+				"These NPC prefabs have no AI LOD settings, so their brains run the full pipeline " +
+				"at every AI tick no matter how far away every player is:\n" + missing);
+		}
+
+		[Test]
+		public void EveryAssignedLodSettings_SuspendsFartherThanItSimplifies()
+		{
+			/* The tiers have to be ordered or the thresholds mean nothing: an NPC cannot become
+			 * dormant closer in than it becomes simplified. Inverting two numbers in the inspector
+			 * produces a settings asset that reads plausibly and quietly never reaches a tier. */
+			for (int i = 0; i < brains.Count; i++)
+			{
+				AILodSettings settings = brains[i].GetComponentInChildren<AIController>(true).LodSettings;
+				if (settings == null)
+				{
+					continue;
+				}
+
+				Assert.Less(settings.ActiveDistanceSqr, settings.NearbyDistanceSqr,
+					$"{settings.name}: Active must end before Nearby begins.");
+				Assert.Less(settings.NearbyDistanceSqr, settings.FarDistanceSqr,
+					$"{settings.name}: Nearby must end before Far begins.");
+			}
+		}
+
+		[Test]
+		public void EveryAssignedLodSettings_ThinksLessOftenTheFartherOutItGets()
+		{
+			/* The intervals are what the distances buy. A Far tier that ticks as often as Active is
+			 * a tier in name only, and the ordering is easy to break by editing one field. */
+			for (int i = 0; i < brains.Count; i++)
+			{
+				AILodSettings settings = brains[i].GetComponentInChildren<AIController>(true).LodSettings;
+				if (settings == null)
+				{
+					continue;
+				}
+
+				Assert.LessOrEqual(settings.GetTickInterval(AILodTier.Active), settings.GetTickInterval(AILodTier.Nearby),
+					$"{settings.name}: Nearby should not think more often than Active.");
+				Assert.LessOrEqual(settings.GetTickInterval(AILodTier.Nearby), settings.GetTickInterval(AILodTier.Far),
+					$"{settings.name}: Far should not think more often than Nearby.");
+				Assert.LessOrEqual(settings.GetTickInterval(AILodTier.Far), settings.GetTickInterval(AILodTier.Dormant),
+					$"{settings.name}: Dormant should not wake more often than Far thinks.");
+			}
+		}
+
+		[Test]
+		public void TheShippedLodAssets_AreAllReachableFromSomePrefab()
+		{
+			/* The failure this whole fixture exists for, from the other direction: three LOD assets
+			 * were authored and none of them was referenced by anything. An asset nobody points at
+			 * is indistinguishable from one that was never made. */
+			string[] guids = AssetDatabase.FindAssets("t:AILodSettings", new[] { LOD_FOLDER });
+			Assert.Greater(guids.Length, 0, $"No AILodSettings assets found under {LOD_FOLDER}.");
+
+			HashSet<AILodSettings> referenced = new HashSet<AILodSettings>();
+			for (int i = 0; i < brains.Count; i++)
+			{
+				AILodSettings settings = brains[i].GetComponentInChildren<AIController>(true).LodSettings;
+				if (settings != null)
+				{
+					referenced.Add(settings);
+				}
+			}
+
+			StringBuilder orphans = new StringBuilder();
+			for (int i = 0; i < guids.Length; i++)
+			{
+				string path = AssetDatabase.GUIDToAssetPath(guids[i]);
+				AILodSettings settings = AssetDatabase.LoadAssetAtPath<AILodSettings>(path);
+				if (settings != null && !referenced.Contains(settings))
+				{
+					orphans.AppendLine($"  {settings.name}");
+				}
+			}
+
+			/* Reported rather than failed. A profile authored ahead of the content that will use it
+			 * is legitimate; a profile nobody ever wired up is the bug. Only the assertion above
+			 * can tell those apart, so this one only says what is unused. */
+			if (orphans.Length > 0)
+			{
+				TestContext.WriteLine("AI LOD assets not referenced by any NPC prefab:\n" + orphans);
+			}
+
+			Assert.Pass();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/AI/AILodAssignmentTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/AI/AILodAssignmentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01866377cb2b3c747bfd4795849967e9


### PR DESCRIPTION
> Opened as the "dormancy" change. It turned out dormancy is already built and already good — it was simply never switched on.

`AIController.LodSettings` is null on **every** NPC prefab in the project, and three LOD profiles sit authored under `Templates/Entity/NPCs/AI/LOD` with nothing referencing them.

That one reference is what the whole system hangs on:

```csharp
int tickInterval = 1;
if (LodSettings != null)
{
    // ... evaluate tier, set tickInterval ...
}
```

With it null, `currentLodTier` stays at its initial `Active`, `tickInterval` stays 1, the `if (currentLodTier == AILodTier.Dormant) return;` branch is unreachable, and the switch below dispatches every NPC to `UpdateActive` on every AI tick — enemy sweep, leash, behaviour tree, boss script, state machine, aggression, facing. Distance to the nearest player never enters into it. An orc alone in an empty zone thinks exactly as hard as one being fought.

## It gates the physics sweep, not just the tick rate

Worth stating separately, because it is the larger half and is easy to miss.

`SweepForEnemies` is called from **`UpdateActive` only** — `UpdateNearby` and `UpdateFar` do not call it, and `OnThreatReceived` exists so those tiers enter combat on being hit instead of by looking. It runs a `PhysicsScene.OverlapSphere` plus a `GetComponent<ICharacter>()` per hit, every `EnemySweepRate` (1.5 s by default).

`AIController`'s own comment on that method says it eliminates *"thousands of per-NPC physics OverlapSphere calls every EnemySweepRate seconds"*, and that "Nearby/Far tier NPCs rely entirely on this event to detect combat."

None of that elimination is happening. With `LodSettings` null every NPC is Active tier, so every NPC in the world runs the sweep every 1.5 seconds whether or not a player is anywhere near it. The event-driven path was built, the tiers that depend on it were built, and nothing reaches them.

## What changes

| prefab | profile |
| --- | --- |
| an orc, an orc mage, an orc warrior | Standard AI LOD |
| HumanBanker, HumanGeneralMerchant, HumanAbilityCrafter | Standard AI LOD |
| a lesser fire elemental | Companion AI LOD |

At the default 8 Hz AI tick, **Standard** takes an NPC with no player within 300 m from the full pipeline eight times a second to a wake-up check every five seconds — a fortieth of the ticks, each doing nothing but the LOD re-evaluation — and simplifies the two tiers in between. A companion is nearly always beside its owner, so its profile keeps generous distances and tighter intervals.

**No code changes.** This is the data the code was written to read.

## The vendors are a judgement call

The three human interactables are included because they have brains and the same argument applies, but a dormant vendor is a behaviour question rather than a performance one. `OnLodTierChanged` only disengages combat on the way out, which a vendor is never in, and interaction is handled by `InteractableSystem` rather than the AI — so I believe it is safe. Worth your eye rather than mine, and easy to drop from this PR if you would rather they stayed awake.

## Testing

Four tests, because a null here produces no error, no warning and no visible misbehaviour — only an NPC more attentive than it needs to be, at a cost that stays invisible until there are thousands of them. This system shipped switched off and nothing caught it.

- every NPC prefab with an `AIController` has a profile assigned
- tiers are ordered, so an NPC cannot go dormant closer in than it goes simplified
- intervals are ordered, so a Far tier cannot think as often as Active
- any profile no prefab references is reported — which is the state this PR found the project in

The first is the one that matters, and it fails on `dev` today for all seven prefabs. It also guards against passing vacuously: it asserts it found at least one prefab with a brain, so a wrong search folder fails rather than reports success.

Suite is 896 / 894. The two failures are `MapSystemTests.Filter_ExactMarker_IsMarkedAsTrackingItsTransform` and `Filter_ThrottledMarker_PublishesACoarsePositionAndForbidsLiveReads`, which fail identically on clean `dev`.

## What I have not measured

The tick-count reduction is arithmetic from the profiles, not a benchmark — a fortieth of the ticks, each doing strictly less. I have not measured what an `UpdateActive` pass actually costs, so I cannot put a millisecond figure on the saving. If you want one before merging, `SpawnerPollCostTests` is the shape that would give it.

