### PR TITLE
Write only the attributes that changed

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Character/CharacterSystem.Saving.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Character/CharacterSystem.Saving.cs
@@ -1003,6 +1003,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 				// would poison the batch upsert with a STALE_STATE rejection.
 				if (attr.Version <= 0)
 					continue;
+				/* Unchanged since the database last confirmed it, so there is nothing to write.
+				 * The row is not merely rejected further down — it is never built, never sent, and
+				 * never probed. */
+				if (!attr.PersistenceDirty)
+					continue;
 				attr.Version++;
 				attributes.Add(new CharacterAttributeData(
 					id: 0,
@@ -1017,6 +1022,8 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 			{
 				var resAttr = kvp.Value;
 				if (resAttr.Version <= 0)
+					continue;
+				if (!resAttr.PersistenceDirty)
 					continue;
 				resAttr.Version++;
 				attributes.Add(new CharacterAttributeData(
@@ -1360,11 +1367,62 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 					return;
 				}
 
-				await BulkWriteReporting.ReportAsync("CharacterSystem", "Attribute save", await attrService.PersistAsync(attributes));
+				bool written = await BulkWriteReporting.ReportAsync("CharacterSystem", "Attribute save", await attrService.PersistAsync(attributes));
+
+				/* Only a write that landed clears the dirty marks, and it clears them back on the
+				 * main thread because that is the only thread the attributes are touched from.
+				 * A failed write leaves everything marked, so the next pass carries it — which is
+				 * the behaviour the unconditional save had by accident and this has to keep on
+				 * purpose, since the periodic path has no other retry. */
+				if (written)
+				{
+					TryEnqueueMainThread(() => MarkAttributesPersisted(attributes));
+				}
 			}
 			catch (Exception ex)
 			{
 				await Log.Error("CharacterSystem", $"SaveAttributesAsync failed: {ex}");
+			}
+		}
+
+		/// <summary>
+		/// Clears the dirty mark on every attribute a completed write covered.
+		/// </summary>
+		/// <remarks>
+		/// Runs on the main thread. Each attribute is cleared only if its version still matches the
+		/// one written: an attribute that moved while the save was in flight has advanced past it
+		/// and stays dirty, so the change that landed mid-write is not mistaken for one already
+		/// stored. A character that has since logged out is simply gone from the map and skipped.
+		/// </remarks>
+		/// <param name="attributes">The snapshot that was written.</param>
+		private void MarkAttributesPersisted(List<CharacterAttributeData> attributes)
+		{
+			if (attributes == null ||
+				Server?.DataContainerRegistry == null ||
+				!Server.DataContainerRegistry.TryGet(out ICharacterMappingData<NetworkConnection> data))
+			{
+				return;
+			}
+
+			for (int i = 0; i < attributes.Count; ++i)
+			{
+				CharacterAttributeData saved = attributes[i];
+
+				if (!data.CharactersByID.TryGetValue(saved.CharacterID, out IPlayerCharacter character) ||
+					character == null ||
+					!character.TryGet(out ICharacterAttributeController attrController))
+				{
+					continue;
+				}
+
+				if (attrController.Attributes.TryGetValue(saved.TemplateID, out CharacterAttribute attribute))
+				{
+					attribute.MarkPersisted(saved.Version);
+				}
+				else if (attrController.ResourceAttributes.TryGetValue(saved.TemplateID, out CharacterResourceAttribute resourceAttribute))
+				{
+					resourceAttribute.MarkPersisted(saved.Version);
+				}
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterAttribute.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterAttribute.cs
@@ -27,6 +27,45 @@ namespace FishMMO.Shared
 		public long Version;
 
 		/// <summary>
+		/// Whether this attribute has changed since the database last confirmed it.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// The periodic save used to write every attribute of every resident character on every
+		/// pass, because it had no way to tell which had moved. Most have not: strength does not
+		/// drift while a player stands in a bank, and a character out of combat at full health
+		/// changes nothing at all between one save and the next.
+		/// </para>
+		/// <para>
+		/// Set from <see cref="Internal_OnAttributeChanged"/>, which is the single funnel every
+		/// real change already passes through — the setters ahead of it compare before they assign,
+		/// so an assignment of the same value never reaches it and never marks anything dirty.
+		/// Cleared only by <see cref="MarkPersisted"/>, once a write has actually landed.
+		/// </para>
+		/// </remarks>
+		public bool PersistenceDirty { get; protected set; }
+
+		/// <summary>
+		/// Clears <see cref="PersistenceDirty"/> if this attribute has not moved on since the
+		/// version that was written.
+		/// </summary>
+		/// <remarks>
+		/// The version check is what makes the save safe to run in the background. A save takes a
+		/// snapshot and completes some time later; if the attribute changed in that window its
+		/// version has advanced past the one written, and it stays dirty so the next pass picks it
+		/// up. A save that fails never calls this at all, so nothing is lost — the attribute is
+		/// simply written again on the following pass.
+		/// </remarks>
+		/// <param name="persistedVersion">The version that was successfully written.</param>
+		public void MarkPersisted(long persistedVersion)
+		{
+			if (Version == persistedVersion)
+			{
+				PersistenceDirty = false;
+			}
+		}
+
+		/// <summary>
 		/// The template that defines this attribute's configuration and formulas.
 		/// </summary>
 		public CharacterAttributeTemplate Template { get; private set; }
@@ -84,6 +123,14 @@ namespace FishMMO.Shared
 		/// <param name="item">The attribute that was changed.</param>
 		protected virtual void Internal_OnAttributeChanged(CharacterAttribute item)
 		{
+			/* Marked on the attribute that moved, not on this one. Propagation calls this on the
+			 * dependent whose value changed, and it is that attribute the database is now behind
+			 * on. */
+			if (item != null)
+			{
+				item.PersistenceDirty = true;
+			}
+
 			if (characterAttributeController != null && characterAttributeController.IsPropagating)
 			{
 				characterAttributeController.EnqueueNotification(item);
@@ -164,7 +211,18 @@ namespace FishMMO.Shared
 		/// <param name="newValue">The new base value.</param>
 		public void SetValueDirect(int newValue)
 		{
+			if (value == newValue)
+			{
+				return;
+			}
+
 			value = newValue;
+
+			/* Marked here as well as in Internal_OnAttributeChanged. This setter exists precisely to
+			 * write the value without raising the change event, so the funnel that normally records
+			 * the change never runs — and an attribute the database is behind on that does not say
+			 * so is one the periodic save silently stops writing. */
+			PersistenceDirty = true;
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterResourceAttribute.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterResourceAttribute.cs
@@ -71,6 +71,12 @@ namespace FishMMO.Shared
 			}
 
 			currentValue = clamped;
+
+			/* Before the updateInternal branch, not inside it. That flag suppresses the change
+			 * NOTIFICATION, which callers turn off to avoid re-entrancy — it does not mean the
+			 * value did not change, and persistence has to follow the value. */
+			PersistenceDirty = true;
+
 			if (updateInternal)
 			{
 				Internal_OnAttributeChanged(this);

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/CharacterAttributePersistenceDirtyTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/CharacterAttributePersistenceDirtyTests.cs
@@ -1,0 +1,255 @@
+using FishMMO.Shared;
+using FishMMO.UnitTests;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the mark that decides whether an attribute is written by the periodic save.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The save used to write every attribute of every resident character on every pass. Skipping
+	/// the ones that have not moved is worth a great deal — measured against the real schema, a
+	/// server holding five hundred characters generated 68.6 MB of write-ahead log and 18.8 MB of
+	/// table growth every ten minutes to store values that were already stored.
+	/// </para>
+	/// <para>
+	/// It is also the kind of change whose failure mode is silence. An attribute that changes
+	/// without saying so is simply never written again, and nothing reports it: the character logs
+	/// out, comes back, and is quietly wrong. Every mutation path therefore has a test here, and
+	/// the two that bypass the change notification have one each, because those are the ones a
+	/// reasonable implementation misses.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class CharacterAttributePersistenceDirtyTests
+	{
+		private CharacterAttributeTemplate template;
+		private CharacterAttributeTemplate resourceTemplate;
+		private GameObject gameObject;
+		private CharacterAttributeController controller;
+
+		[SetUp]
+		public void SetUp()
+		{
+			template = ScriptableObject.CreateInstance<CharacterAttributeTemplate>();
+			template.name = "PersistenceDirtyAttribute";
+			template.InitialValue = 10;
+			template.AddToCache(template.name);
+
+			resourceTemplate = ScriptableObject.CreateInstance<CharacterAttributeTemplate>();
+			resourceTemplate.name = "PersistenceDirtyResource";
+			resourceTemplate.InitialValue = 100;
+			resourceTemplate.AddToCache(resourceTemplate.name);
+
+			gameObject = new GameObject("AttributePersistenceDirtyTest");
+			controller = gameObject.AddComponent<CharacterAttributeController>();
+
+			/* A resource attribute clamps against its character's load flag on construction, so it
+			 * cannot be built without one. Flags stay clear, which reads as "not fully loaded" and
+			 * skips the clamp to FinalValue -- the tests here are about the dirty mark, not about
+			 * clamping. */
+			controller.InitializeOnce(new Harness.StubCharacter());
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (template != null)
+			{
+				template.RemoveFromCache();
+				Object.DestroyImmediate(template);
+			}
+			if (resourceTemplate != null)
+			{
+				resourceTemplate.RemoveFromCache();
+				Object.DestroyImmediate(resourceTemplate);
+			}
+			if (gameObject != null)
+			{
+				Object.DestroyImmediate(gameObject);
+			}
+		}
+
+		private CharacterAttribute NewAttribute(int value = 10)
+		{
+			return new CharacterAttribute(controller, template.ID, value, 0);
+		}
+
+		private CharacterResourceAttribute NewResource(int value = 100, float current = 100.0f)
+		{
+			return new CharacterResourceAttribute(controller, resourceTemplate.ID, value, current, 0);
+		}
+
+		// --- Change marks it -------------------------------------------------------------------
+
+		[Test]
+		public void SetValue_MarksTheAttributeForPersistence()
+		{
+			CharacterAttribute attribute = NewAttribute();
+			attribute.MarkPersisted(attribute.Version);
+			Assume.That(attribute.PersistenceDirty, Is.False);
+
+			attribute.SetValue(42);
+
+			Assert.IsTrue(attribute.PersistenceDirty,
+				"A value the database does not have must be written.");
+		}
+
+		[Test]
+		public void AddValue_MarksTheAttributeForPersistence()
+		{
+			CharacterAttribute attribute = NewAttribute();
+			attribute.MarkPersisted(attribute.Version);
+
+			attribute.AddValue(5);
+
+			Assert.IsTrue(attribute.PersistenceDirty);
+		}
+
+		[Test]
+		public void SetValueDirect_MarksTheAttributeForPersistence()
+		{
+			/* SetValueDirect exists to write the value WITHOUT raising the change event, for the
+			 * two-phase reconcile. The notification funnel therefore never runs, so an
+			 * implementation that only marks there loses every reconciled value silently. */
+			CharacterAttribute attribute = NewAttribute();
+			attribute.MarkPersisted(attribute.Version);
+
+			attribute.SetValueDirect(77);
+
+			Assert.IsTrue(attribute.PersistenceDirty,
+				"A value written past the notification is still a value the database lacks.");
+		}
+
+		[Test]
+		public void SetCurrentValue_MarksTheResourceEvenWhenTheNotificationIsSuppressed()
+		{
+			/* updateInternal: false suppresses the change NOTIFICATION, which callers turn off to
+			 * avoid re-entrancy. It does not mean the value held still, and the attribute
+			 * controller uses exactly this overload when applying a resource from the network. */
+			CharacterResourceAttribute resource = NewResource();
+			resource.MarkPersisted(resource.Version);
+
+			resource.SetCurrentValue(55.0f, false);
+
+			Assert.IsTrue(resource.PersistenceDirty,
+				"Suppressing the event must not suppress the save.");
+		}
+
+		[Test]
+		public void SetCurrentValue_MarksTheResourceNormally()
+		{
+			CharacterResourceAttribute resource = NewResource();
+			resource.MarkPersisted(resource.Version);
+
+			resource.SetCurrentValue(55.0f);
+
+			Assert.IsTrue(resource.PersistenceDirty);
+		}
+
+		// --- No change does not mark it ---------------------------------------------------------
+
+		[Test]
+		public void SettingTheSameValue_LeavesTheAttributeClean()
+		{
+			/* The whole saving. An assignment that changes nothing must not schedule a write, or
+			 * the mark is set on every pass and nothing is skipped. */
+			CharacterAttribute attribute = NewAttribute(10);
+			attribute.MarkPersisted(attribute.Version);
+
+			attribute.SetValue(10);
+
+			Assert.IsFalse(attribute.PersistenceDirty,
+				"Writing a value that is already stored is the cost this exists to avoid.");
+		}
+
+		[Test]
+		public void SettingTheSameCurrentValue_LeavesTheResourceClean()
+		{
+			CharacterResourceAttribute resource = NewResource(100, 100.0f);
+			resource.MarkPersisted(resource.Version);
+
+			resource.SetCurrentValue(100.0f);
+
+			Assert.IsFalse(resource.PersistenceDirty);
+		}
+
+		[Test]
+		public void SetValueDirectWithTheSameValue_LeavesTheAttributeClean()
+		{
+			CharacterAttribute attribute = NewAttribute(10);
+			attribute.MarkPersisted(attribute.Version);
+
+			attribute.SetValueDirect(10);
+
+			Assert.IsFalse(attribute.PersistenceDirty);
+		}
+
+		// --- Clearing is confirmation, not optimism ---------------------------------------------
+
+		[Test]
+		public void MarkPersisted_ClearsWhenTheWrittenVersionIsStillCurrent()
+		{
+			CharacterAttribute attribute = NewAttribute();
+			attribute.SetValue(42);
+			attribute.Version++;                       // as the save snapshot does
+
+			attribute.MarkPersisted(attribute.Version);
+
+			Assert.IsFalse(attribute.PersistenceDirty,
+				"The write landed and nothing has moved since.");
+		}
+
+		[Test]
+		public void MarkPersisted_LeavesItDirtyWhenItChangedWhileTheSaveWasInFlight()
+		{
+			/* A save snapshots on the main thread and completes some time later. A change in that
+			 * window is not covered by the write that is about to be confirmed, and clearing on it
+			 * would drop that change until the attribute happened to move again. */
+			CharacterAttribute attribute = NewAttribute();
+			attribute.SetValue(42);
+			attribute.Version++;
+			long writtenVersion = attribute.Version;
+
+			// The save is in flight; the attribute moves again.
+			attribute.SetValue(99);
+			attribute.Version++;
+
+			attribute.MarkPersisted(writtenVersion);
+
+			Assert.IsTrue(attribute.PersistenceDirty,
+				"The in-flight change was not in the write that just landed.");
+		}
+
+		[Test]
+		public void AFailedSave_LeavesEverythingDirty()
+		{
+			/* MarkPersisted is only reached when the write reports success, so a failure is modelled
+			 * by not calling it. This matters more than it looks: the periodic save has no retry of
+			 * its own -- writing everything every time WAS the retry -- so a change that is dropped
+			 * here is dropped until the value moves again. */
+			CharacterAttribute attribute = NewAttribute();
+			attribute.SetValue(42);
+			attribute.Version++;
+
+			// No MarkPersisted: the write failed.
+
+			Assert.IsTrue(attribute.PersistenceDirty,
+				"A change the database refused must be offered again on the next pass.");
+		}
+
+		[Test]
+		public void AFreshlyLoadedAttribute_IsNotWrittenBackImmediately()
+		{
+			/* An attribute that came from the database and has not been touched is already stored,
+			 * so the first periodic save after login should not write it back. */
+			CharacterAttribute attribute = NewAttribute();
+			attribute.MarkPersisted(attribute.Version);
+
+			Assert.IsFalse(attribute.PersistenceDirty);
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/CharacterAttributePersistenceDirtyTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/CharacterAttributePersistenceDirtyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec3cd8e50f0f26c4d9aea66e5de3a976


### PR DESCRIPTION
The periodic save writes **every attribute of every resident character on every pass**. It has no way to tell which have moved, so it writes all of them.

The version guard looks like it should prevent that. `CharacterAttributeService.PersistAsync` ends its upsert with `WHERE EXCLUDED.version > {Table}.version`, which would skip unchanged rows — except `AppendAttributeData` does `attr.Version++` unconditionally before every write. The version always advances, so the guard always passes. It is doing its real job, rejecting a write from a server that lost ownership, but it was never going to skip an unchanged row.

## Measured

Against the real `character_attributes` schema on a local Postgres, using the same `UNNEST` upsert the service issues. 500 characters × 16 attributes, 20 save cycles — ten minutes at the 30 s `saveRate`, on one scene server:

| | WAL | DB time | table growth |
| --- | --- | --- | --- |
| **today** — every attribute, every save | **68.6 MB** | 3,855 ms | **18.8 MB** |
| this PR — 2 of 16 changed (in combat) | 5.1 MB | 428 ms | 2.5 MB |
| this PR — nothing changed (idle) | **0** | **3 ms** | **0** |

That is roughly **412 MB of write-ahead log per hour, per scene server**, for attributes alone, most of it storing values that were already stored. Postgres writes a new tuple and marks the old one dead even when every column is identical, so the 18.8 MB of growth becomes autovacuum's problem afterwards rather than disappearing.

I also measured leaving the rows in the batch and only advancing `Version` on change, letting the database reject them: that gets WAL to 0.8 MB and growth to zero, but still costs 519 ms because all 8,000 rows are still parsed and probed. Not sending them is strictly better on every axis.

## How it decides

Attributes carry `PersistenceDirty`, set wherever the value actually moves. The setters already compared before assigning, so an assignment of the same value never reaches the change funnel and never marks anything.

**Two paths deliberately skip that funnel and are marked directly**, because marking only at the notification would leave both silently unsaved:

- `SetValueDirect` writes the value *without* raising the change event — that is its whole purpose, for the two-phase reconcile.
- `SetCurrentValue(value, updateInternal: false)` suppresses the event to avoid re-entrancy, but the value still changed. `CharacterAttributeController` uses exactly this overload when applying a resource from the network.

This is the failure mode the change is most exposed to and it is completely silent: an attribute that changes without saying so is never written again, and nothing reports it. The character logs out, comes back, and is quietly wrong.

## Clearing is confirmation, not optimism

`MarkPersisted` runs on the main thread, only after the write reports success, and only clears when the attribute's version still matches the one written. An attribute that moved while the save was in flight has advanced past that version and stays dirty.

A failed write clears nothing, so the next pass carries it. **This property had to be kept deliberately rather than inherited:** the periodic save has no retry of its own — writing everything every time *was* the retry. Clearing on append would have turned every failed save into silent data loss.

## Testing

12 tests. Every mutation path has one, the two funnel-bypassing paths have one each, and the clearing rules have three: cleared on a confirmed write, left dirty when the value moved mid-flight, left dirty when the write failed.

Suite is 904 / 902. The two failures are `MapSystemTests.Filter_ExactMarker_IsMarkedAsTrackingItsTransform` and `Filter_ThrottledMarker_PublishesACoarsePositionAndForbidsLiveReads`, which fail identically on clean `dev`.

## Scope

Attributes only. `AppendAbilityData` has the same `Version++` and the same problem, and known abilities are the purer case — they change when a player learns or crafts something, perhaps once an hour, and are rewritten 120 times an hour. Buffs likewise. Both are left for follow-ups so this one stays reviewable; the mechanism transfers directly.
