### PR TITLE
Write only the abilities that changed

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Character/CharacterSystem.Saving.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Character/CharacterSystem.Saving.cs
@@ -1050,6 +1050,14 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 					continue;
 				}
 
+				/* Unchanged since the database last confirmed it. Skipping ahead of the ToList also
+				 * avoids building an event-id list per ability per save for a row nobody will
+				 * write. */
+				if (!ability.PersistenceDirty)
+				{
+					continue;
+				}
+
 				List<int> eventIds = ability.AbilityEvents.Keys.ToList();
 
 				ability.Version++;
@@ -1381,11 +1389,54 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 					return;
 				}
 
-				await BulkWriteReporting.ReportAsync("CharacterSystem", "Ability save", await abilityService.PersistAsync(abilities));
+				bool written = await BulkWriteReporting.ReportAsync("CharacterSystem", "Ability save", await abilityService.PersistAsync(abilities));
+
+				// Only a write that landed clears the marks, and only on the main thread.
+				if (written)
+				{
+					TryEnqueueMainThread(() => MarkAbilitiesPersisted(abilities));
+				}
 			}
 			catch (Exception ex)
 			{
 				await Log.Error("CharacterSystem", $"SaveAbilitiesAsync failed: {ex}");
+			}
+		}
+
+		/// <summary>
+		/// Clears the dirty mark on every ability a completed write covered.
+		/// </summary>
+		/// <remarks>
+		/// Runs on the main thread. Each ability is cleared only if its version still matches the
+		/// one written, so an ability changed while the save was in flight stays dirty. A character
+		/// that has since logged out is gone from the map and skipped.
+		/// </remarks>
+		/// <param name="abilities">The snapshot that was written.</param>
+		private void MarkAbilitiesPersisted(List<CharacterAbilityData> abilities)
+		{
+			if (abilities == null ||
+				Server?.DataContainerRegistry == null ||
+				!Server.DataContainerRegistry.TryGet(out ICharacterMappingData<NetworkConnection> data))
+			{
+				return;
+			}
+
+			for (int i = 0; i < abilities.Count; ++i)
+			{
+				CharacterAbilityData saved = abilities[i];
+
+				if (!data.CharactersByID.TryGetValue(saved.CharacterID, out IPlayerCharacter character) ||
+					character == null ||
+					!character.TryGet(out IAbilityController abilityController))
+				{
+					continue;
+				}
+
+				if (abilityController.KnownAbilities.TryGetValue(saved.ID, out Ability ability) &&
+					ability != null)
+				{
+					ability.MarkPersisted(saved.Version);
+				}
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Ability/Ability.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/Ability/Ability.cs
@@ -25,6 +25,44 @@ namespace FishMMO.Shared
 		public long Version;
 
 		/// <summary>
+		/// Whether this ability has changed since the database last confirmed it.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// The periodic save wrote every known ability of every resident character on every pass,
+		/// because it had no way to tell which had changed. Almost none ever do: what is stored is
+		/// the template and the set of event IDs, and those move only when a player crafts, learns
+		/// or forgets something. Cooldowns are deliberately not persisted, so an ability in constant
+		/// use produces exactly the same row as one that has sat in a hotbar untouched for a week.
+		/// </para>
+		/// <para>
+		/// Set true on construction. That over-writes each ability once after a character loads,
+		/// which is deliberate: it costs one redundant write per ability per login instead of one
+		/// every save, and it does not depend on knowing which constructor the load path uses. An
+		/// ability is never missed, only occasionally written when it need not have been.
+		/// </para>
+		/// </remarks>
+		public bool PersistenceDirty { get; private set; } = true;
+
+		/// <summary>
+		/// Clears <see cref="PersistenceDirty"/> if this ability has not changed since the version
+		/// that was written.
+		/// </summary>
+		/// <remarks>
+		/// The version check is what makes the save safe to run in the background: an ability that
+		/// changed while the write was in flight has moved past the version written and stays dirty.
+		/// A write that fails never calls this, so the next pass carries it.
+		/// </remarks>
+		/// <param name="persistedVersion">The version that was successfully written.</param>
+		public void MarkPersisted(long persistedVersion)
+		{
+			if (Version == persistedVersion)
+			{
+				PersistenceDirty = false;
+			}
+		}
+
+		/// <summary>
 		/// Total activation time for this ability, including all modifiers.
 		/// </summary>
 		public float ActivationTime;
@@ -253,6 +291,8 @@ namespace FishMMO.Shared
 			if (abilityEvent == null || AbilityEvents.ContainsKey(abilityEvent.ID)) return;
 
 			AbilityEvents.Add(abilityEvent.ID, abilityEvent);
+			// The event set is half of what is persisted, so changing it is a change to store.
+			PersistenceDirty = true;
 			AddEventModifiers(abilityEvent);
 			resourceCostsDirty = true;
 			totalResourceCostDirty = true;
@@ -463,6 +503,7 @@ namespace FishMMO.Shared
 			if (AbilityEvents.TryGetValue(eventID, out AbilityEvent abilityEvent))
 			{
 				AbilityEvents.Remove(eventID);
+				PersistenceDirty = true;
 				OnTickEvents.Remove(eventID);
 				OnHitEvents.Remove(eventID);
 				OnPreSpawnEvents.Remove(eventID);

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/AbilityPersistenceDirtyTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/AbilityPersistenceDirtyTests.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using FishMMO.Shared;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the mark that decides whether an ability is written by the periodic save.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Known abilities are the purest case of the periodic save writing what it already stored.
+	/// What is persisted is the template and the set of event IDs; cooldowns are deliberately not,
+	/// so an ability in constant use produces exactly the row it produced an hour ago. Measured
+	/// against the real schema, 500 characters at eight abilities each generated 34.3 MB of
+	/// write-ahead log and 9.9 MB of table growth every ten minutes, none of it a change.
+	/// </para>
+	/// <para>
+	/// Marking starts true and is only ever cleared by a confirmed write, so the failure direction
+	/// is a redundant write rather than a lost one. These tests pin that direction: every path that
+	/// changes what gets stored marks the ability, and clearing happens only when the write landed
+	/// and the ability has not moved since.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class AbilityPersistenceDirtyTests
+	{
+		private AbilityTemplate template;
+
+		[SetUp]
+		public void SetUp()
+		{
+			template = ScriptableObject.CreateInstance<AbilityTemplate>();
+			template.name = "PersistenceDirtyAbility";
+			template.AddToCache(template.name);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (template != null)
+			{
+				template.RemoveFromCache();
+				Object.DestroyImmediate(template);
+			}
+		}
+
+		private Ability NewAbility()
+		{
+			return new Ability(1, template, new List<int>());
+		}
+
+		[Test]
+		public void ANewAbility_StartsDirty()
+		{
+			/* Deliberately optimistic in the safe direction. An ability that has just been built --
+			 * whether crafted this second or loaded from the database a moment ago -- is written
+			 * once and then never again until it changes. The alternative, starting clean, would
+			 * depend on knowing which constructor the load path used, and being wrong there loses
+			 * a crafted ability silently. */
+			Ability ability = NewAbility();
+
+			Assert.IsTrue(ability.PersistenceDirty,
+				"An ability nobody has confirmed stored must be written at least once.");
+		}
+
+		[Test]
+		public void MarkPersisted_ClearsWhenTheWrittenVersionIsStillCurrent()
+		{
+			Ability ability = NewAbility();
+			ability.Version++;
+
+			ability.MarkPersisted(ability.Version);
+
+			Assert.IsFalse(ability.PersistenceDirty,
+				"The write landed and nothing has changed since.");
+		}
+
+		[Test]
+		public void AnAbilityThatHasNotChanged_IsNotWrittenAgain()
+		{
+			/* The whole saving: after one confirmed write, an untouched ability contributes nothing
+			 * to any later save. */
+			Ability ability = NewAbility();
+			ability.Version++;
+			ability.MarkPersisted(ability.Version);
+
+			Assert.IsFalse(ability.PersistenceDirty);
+		}
+
+		[Test]
+		public void AddingAnEvent_MarksTheAbility()
+		{
+			/* The event set is half of what is stored, so changing it has to be stored. */
+			Ability ability = NewAbility();
+			ability.Version++;
+			ability.MarkPersisted(ability.Version);
+			Assume.That(ability.PersistenceDirty, Is.False);
+
+			AbilityOnHitEvent abilityEvent = ScriptableObject.CreateInstance<AbilityOnHitEvent>();
+			try
+			{
+				abilityEvent.name = "PersistenceDirtyEvent";
+				abilityEvent.AddToCache(abilityEvent.name);
+
+				ability.AddEvent(abilityEvent);
+
+				Assert.IsTrue(ability.PersistenceDirty,
+					"A new event is a new row.");
+			}
+			finally
+			{
+				abilityEvent.RemoveFromCache();
+				Object.DestroyImmediate(abilityEvent);
+			}
+		}
+
+		[Test]
+		public void RemovingAnEvent_MarksTheAbility()
+		{
+			Ability ability = NewAbility();
+
+			AbilityOnHitEvent abilityEvent = ScriptableObject.CreateInstance<AbilityOnHitEvent>();
+			try
+			{
+				abilityEvent.name = "PersistenceDirtyRemovedEvent";
+				abilityEvent.AddToCache(abilityEvent.name);
+				ability.AddEvent(abilityEvent);
+
+				ability.Version++;
+				ability.MarkPersisted(ability.Version);
+				Assume.That(ability.PersistenceDirty, Is.False);
+
+				ability.RemoveAbilityEvent(abilityEvent.ID);
+
+				Assert.IsTrue(ability.PersistenceDirty,
+					"Forgetting an event changes the stored row just as learning one does.");
+			}
+			finally
+			{
+				abilityEvent.RemoveFromCache();
+				Object.DestroyImmediate(abilityEvent);
+			}
+		}
+
+		[Test]
+		public void MarkPersisted_LeavesItDirtyWhenItChangedWhileTheSaveWasInFlight()
+		{
+			/* A save snapshots on the main thread and completes later. A change in that window is
+			 * not in the write about to be confirmed, and clearing on it would drop that change
+			 * until the ability happened to change again. */
+			Ability ability = NewAbility();
+			ability.Version++;
+			long writtenVersion = ability.Version;
+
+			// The save is in flight; the ability changes again.
+			ability.Version++;
+
+			ability.MarkPersisted(writtenVersion);
+
+			Assert.IsTrue(ability.PersistenceDirty,
+				"The in-flight change was not in the write that just landed.");
+		}
+
+		[Test]
+		public void AFailedSave_LeavesTheAbilityDirty()
+		{
+			/* MarkPersisted is only reached when the write reports success, so a failure is modelled
+			 * by not calling it. The periodic save has no retry of its own -- writing everything
+			 * every time WAS the retry -- so this had to be kept deliberately. */
+			Ability ability = NewAbility();
+			ability.Version++;
+
+			// No MarkPersisted: the write failed.
+
+			Assert.IsTrue(ability.PersistenceDirty,
+				"A row the database refused must be offered again on the next pass.");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/AbilityPersistenceDirtyTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/AbilityPersistenceDirtyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 23a430365acdc16408634cbb66c6523d


### PR DESCRIPTION
> Follow-up to #168, which does the same for attributes. Independent branches — either can merge first, though both touch `CharacterSystem.Saving.cs`.

Same defect as the attribute save, in its purest form. `AppendAbilityData` increments `Version` on every known ability of every resident character on every pass, so the upsert's `WHERE EXCLUDED.version > version` guard always passes and every row is written.

**Nothing in those rows moves.** What is persisted is the template and the set of event IDs. Cooldowns are deliberately not persisted — the method's own comment says so — which means an ability in constant use produces exactly the row it produced an hour ago. They change when a player crafts, learns or forgets something, and they are rewritten a hundred and twenty times an hour.

## Measured

Against the real `character_abilities` schema on a local Postgres, using the same `UNNEST` upsert the service issues. 500 characters × 8 abilities, 20 save cycles — ten minutes at the 30 s `saveRate`, on one scene server:

| | WAL | DB time | table growth |
| --- | --- | --- | --- |
| **today** | **34.3 MB** | 1,930 ms | **9.9 MB** |
| this PR | **0** | **3 ms** | **0** |

Zero, not "less" — unlike attributes there is no in-combat case where these legitimately change.

## How it decides

`PersistenceDirty` is set on construction and wherever the event set changes: `AddEvent` and `RemoveAbilityEvent`, which between them are the only places `AbilityEvents` is mutated anywhere in the project.

**Starting dirty is deliberate.** It writes each ability once after a character loads rather than once every save, and it does not depend on knowing which of the three constructors the load path uses. Being wrong in the other direction loses a crafted ability silently; that is not a trade worth making to avoid eight writes per login.

Clearing is confirmation, not optimism — `MarkPersisted` runs on the main thread only after the write reports success, and only clears when the version still matches the one written. A failed write clears nothing, so the next pass carries it. That matters because the periodic save has no retry of its own: writing everything every time *was* the retry.

The skip also sits ahead of `ability.AbilityEvents.Keys.ToList()`, so a clean ability no longer allocates an event-id list per save either — 4,000 allocations per save cycle at the scale above.

## Buffs: examined, deliberately not changed

I looked at `AppendBuffData` as part of this and it should be left alone.

A buff row carries `remainingTime` and `tickTime`, both computed from the current tick, so it **genuinely differs on every save by construction**. Dirty tracking would add bookkeeping and skip nothing. The save also already returns early for characters with no buffs, so the cost is proportional to buffs that actually exist, and buffs are mostly short-lived combat state.

There is a real change available there, but it is a different one: store an absolute expiry instead of a relative remaining time, so the row only moves when the buff is applied, refreshed or stacked. That is a schema change and a design decision, not a follow-up to this.

## Testing

7 tests: both mutation paths, the starts-dirty guarantee, and the three clearing rules — cleared on a confirmed write, left dirty when changed mid-flight, left dirty when the write failed.

Suite is 899 / 897. The two failures are `MapSystemTests.Filter_ExactMarker_IsMarkedAsTrackingItsTransform` and `Filter_ThrottledMarker_PublishesACoarsePositionAndForbidsLiveReads`, which fail identically on clean `dev`.
