### PR TITLE
Add a look sensitivity slider

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
@@ -62,6 +62,11 @@
                     <ui:Label name="brightness-value" text="100%" class="fish-hint options-row-value" />
                 </ui:VisualElement>
                 <ui:VisualElement class="options-row">
+                    <ui:Label text="Look Sensitivity" class="fish-label options-row-label" />
+                    <ui:Slider name="look-sensitivity-slider" low-value="0.1" high-value="1" class="options-row-field" />
+                    <ui:Label name="look-sensitivity-value" text="0.50" class="fish-hint options-row-value" />
+                </ui:VisualElement>
+                <ui:VisualElement class="options-row">
                     <ui:Label text="Frame Rate Limit" class="fish-label options-row-label" />
                     <ui:DropdownField name="framerate-dropdown" class="fish-dropdown options-row-field" />
                 </ui:VisualElement>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
@@ -90,6 +90,8 @@ namespace FishMMO.Client
 		private const string VSYNC_TOGGLE_NAME = "vsync-toggle";
 		private const string BRIGHTNESS_SLIDER_NAME = "brightness-slider";
 		private const string BRIGHTNESS_VALUE_NAME = "brightness-value";
+		private const string LOOK_SENSITIVITY_SLIDER_NAME = "look-sensitivity-slider";
+		private const string LOOK_SENSITIVITY_VALUE_NAME = "look-sensitivity-value";
 		private const string RESOLUTION_DROPDOWN_NAME = "resolution-dropdown";
 		private const string REFRESHRATE_DROPDOWN_NAME = "refreshrate-dropdown";
 		private const string FULLSCREEN_DROPDOWN_NAME = "fullscreen-dropdown";
@@ -292,6 +294,8 @@ namespace FishMMO.Client
 
 		private Toggle vsyncToggle;
 		private Slider brightnessSlider;
+		private Slider lookSensitivitySlider;
+		private Label lookSensitivityValueLabel;
 		private Label brightnessValueLabel;
 		private DropdownField resolutionDropdown;
 		private DropdownField refreshRateDropdown;
@@ -439,6 +443,8 @@ namespace FishMMO.Client
 			vsyncToggle = Root.Q<Toggle>(VSYNC_TOGGLE_NAME);
 			brightnessSlider = Root.Q<Slider>(BRIGHTNESS_SLIDER_NAME);
 			brightnessValueLabel = Root.Q<Label>(BRIGHTNESS_VALUE_NAME);
+			lookSensitivitySlider = Root.Q<Slider>(LOOK_SENSITIVITY_SLIDER_NAME);
+			lookSensitivityValueLabel = Root.Q<Label>(LOOK_SENSITIVITY_VALUE_NAME);
 			resolutionDropdown = Root.Q<DropdownField>(RESOLUTION_DROPDOWN_NAME);
 			refreshRateDropdown = Root.Q<DropdownField>(REFRESHRATE_DROPDOWN_NAME);
 			fullscreenDropdown = Root.Q<DropdownField>(FULLSCREEN_DROPDOWN_NAME);
@@ -469,6 +475,7 @@ namespace FishMMO.Client
 			InitializeDisplaySettings();
 			InitializeQualityLevel();
 			InitializeBrightness();
+			InitializeLookSensitivity();
 			InitializeFrameRateLimit();
 			InitializeVSync();
 			InitializeAudioSettings();
@@ -1178,6 +1185,65 @@ namespace FishMMO.Client
 				ClientDisplaySettings.ApplyBrightness(value);
 				UpdatePercentLabel(brightnessValueLabel, value);
 			});
+		}
+
+		/// <summary>
+		/// Binds the look sensitivity slider.
+		/// </summary>
+		/// <remarks>
+		/// The stored value is clamped on the way in, for the same reason brightness is: it is a
+		/// float in a file the player can edit, and it multiplies raw mouse delta. A large one makes
+		/// the view unusable at exactly the moment they would need to reach this menu to undo it,
+		/// and zero makes the camera immovable.
+		/// </remarks>
+		private void InitializeLookSensitivity()
+		{
+			if (lookSensitivitySlider == null)
+			{
+				Log.Error("UITKOptions", "Look sensitivity slider is missing.");
+				return;
+			}
+
+			lookSensitivitySlider.lowValue = ClientCameraSettings.MinimumLookSensitivity;
+			lookSensitivitySlider.highValue = ClientCameraSettings.MaximumLookSensitivity;
+
+			float sensitivity = ClientSettings.GetFloat(
+				ClientSettings.LookSensitivityKey,
+				ClientCameraSettings.DefaultLookSensitivity,
+				ClientCameraSettings.MinimumLookSensitivity,
+				ClientCameraSettings.MaximumLookSensitivity);
+
+			// Without notify: assigning `value` raises the callback, which writes back to the file
+			// this was just read from. See InitializeBrightness.
+			lookSensitivitySlider.SetValueWithoutNotify(sensitivity);
+			UpdateSensitivityLabel(lookSensitivityValueLabel, sensitivity);
+
+			lookSensitivitySlider.RegisterValueChangedCallback((evt) =>
+			{
+				float value = Mathf.Clamp(
+					evt.newValue,
+					ClientCameraSettings.MinimumLookSensitivity,
+					ClientCameraSettings.MaximumLookSensitivity);
+
+				ClientSettings.Set(ClientSettings.LookSensitivityKey, value);
+				ClientCameraSettings.ApplyLookSensitivity(value);
+				UpdateSensitivityLabel(lookSensitivityValueLabel, value);
+			});
+		}
+
+		/// <summary>
+		/// Writes a sensitivity multiplier into its value label.
+		/// </summary>
+		/// <remarks>
+		/// A multiplier rather than a percentage, because that is what it is: the camera turns this
+		/// many times as far per unit of mouse movement. Showing "100%" would read as a ceiling.
+		/// </remarks>
+		private static void UpdateSensitivityLabel(Label label, float value)
+		{
+			if (label != null)
+			{
+				label.text = value.ToString("0.00");
+			}
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
@@ -1,0 +1,107 @@
+using UnityEngine;
+using FishMMO.Shared;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Camera preferences the player owns: how far the mouse turns the view.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Separate from <see cref="ClientDisplaySettings"/> because it writes to a scene object rather
+	/// than to Unity's global state, and that object does not exist for the whole session. The
+	/// camera lives in ClientPreboot and is picked up by <c>KCCPlayer</c> when it takes ownership,
+	/// so a value applied at boot has to survive until then — it does, because
+	/// <see cref="KCCCamera.RotationSpeed"/> is a plain field on a component that outlives the
+	/// scene loads between boot and play.
+	/// </para>
+	/// <para>
+	/// Sensitivity only has an observable effect while the cursor is locked, which is the state the
+	/// mouse drives the camera in. With mouse mode on the cursor is free and the camera does not
+	/// turn at all, so the slider looks broken if tested there — it is not, there is simply no look
+	/// input to scale.
+	/// </para>
+	/// </remarks>
+	public static class ClientCameraSettings
+	{
+		/// <summary>
+		/// Sensitivity when nothing has been chosen.
+		/// </summary>
+		/// <remarks>
+		/// Half, not the 1.0 authored on the camera. That value turns the view faster than anyone
+		/// tested comfortable — a new player would have to find this slider before the game felt
+		/// right, which is the wrong way round for a default. Only players who have never touched
+		/// the slider are affected; a saved value always wins.
+		/// </remarks>
+		public const float DefaultLookSensitivity = 0.5f;
+
+		/// <summary>Slowest the view may turn. Above zero: zero is a camera that cannot be moved.</summary>
+		public const float MinimumLookSensitivity = 0.1f;
+
+		/// <summary>
+		/// Fastest the view may turn.
+		/// </summary>
+		/// <remarks>
+		/// One, down from an initial five. The camera's authored 1.0 already turns faster than
+		/// comfortable, so everything above it was travel spent on speeds nobody picks — and it
+		/// crammed the usable band into the slider's first tenth. The range a control offers is a
+		/// claim about where the answer lies; this one now spans it rather than hiding it.
+		/// </remarks>
+		public const float MaximumLookSensitivity = 1.0f;
+
+		/// <summary>
+		/// Applies the stored look sensitivity to the live camera.
+		/// </summary>
+		public static void ApplySaved()
+		{
+			ApplyLookSensitivity(ClientSettings.GetFloat(
+				ClientSettings.LookSensitivityKey,
+				DefaultLookSensitivity,
+				MinimumLookSensitivity,
+				MaximumLookSensitivity));
+		}
+
+		/// <summary>
+		/// Writes a look sensitivity onto the camera and remembers it.
+		/// </summary>
+		/// <remarks>
+		/// Clamped rather than trusted. The value is a float in a text file the player can edit, and
+		/// it multiplies raw mouse delta: a large one makes the view unusable at exactly the moment
+		/// the player would need to reach the menu to put it back, and zero makes the camera
+		/// immovable.
+		/// </remarks>
+		/// <param name="value">Sensitivity multiplier. Clamped to the supported range.</param>
+		public static void ApplyLookSensitivity(float value)
+		{
+			float clamped = float.IsNaN(value)
+				? DefaultLookSensitivity
+				: Mathf.Clamp(value, MinimumLookSensitivity, MaximumLookSensitivity);
+
+			KCCCamera camera = ResolveCamera();
+			if (camera == null)
+			{
+				/* Not an error. Boot applies settings before the world exists, and the camera is
+				 * re-resolved on the next apply — which the options panel triggers, and which
+				 * happens again on the following launch. */
+				return;
+			}
+
+			camera.RotationSpeed = clamped;
+		}
+
+		/// <summary>
+		/// Finds the <see cref="KCCCamera"/> on the main camera, if there is one yet.
+		/// </summary>
+		/// <remarks>
+		/// Resolved on each call rather than cached. <c>Camera.main</c> answers differently across
+		/// scene loads, and a cached reference to a camera from a previous session is the kind of
+		/// stale handle that fails silently — the setting appears to save and never applies.
+		/// </remarks>
+		private static KCCCamera ResolveCamera()
+		{
+			Camera main = Camera.main;
+			return main == null ? null : main.GetComponent<KCCCamera>();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3498ef16e9de2b54ea6db59d63f942a7

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
@@ -57,6 +57,12 @@ namespace FishMMO.Client
 		public const string FrameRateKey = "Frame Rate Limit";
 		/// <summary>Configuration key for the brightness setting.</summary>
 		public const string BrightnessKey = "Brightness";
+
+		/// <summary>
+		/// How far the mouse turns the view. Only observable while the cursor is locked, which is
+		/// the state the mouse drives the camera in.
+		/// </summary>
+		public const string LookSensitivityKey = "Look Sensitivity";
 		/// <summary>Configuration key for the resolution width setting.</summary>
 		public const string ResolutionWidthKey = "Resolution Width";
 		/// <summary>Configuration key for the resolution height setting.</summary>
@@ -555,6 +561,7 @@ namespace FishMMO.Client
 			}
 
 			Apply("display", ClientDisplaySettings.ApplySaved);
+			Apply("camera", ClientCameraSettings.ApplySaved);
 			Apply("audio", ClientAudioSettings.ApplySaved);
 			Apply("interface", () => UITKPanelScale.Apply(GetFloat(UIScaleKey, 1.0f, MinimumUIScale, MaximumUIScale)));
 


### PR DESCRIPTION
The camera's turn rate was authored on the prefab and nowhere else, so a player who found the view too fast had no way to change it — and it is too fast. The authored `1.0` reads as hyper-speed in play; comfortable sits nearer `0.4`.

## Range and default

**0.1 to 1.0, defaulting to 0.5.**

An earlier draft of this shipped 0.1–5.0, on the reasoning that a wider range is more accommodating. It isn't: it spent four-fifths of the slider's travel on speeds nobody picks and crammed the usable band into the first tenth, so the difference between "fine" and "unusable" was a few pixels of travel. The range a control offers is a claim about where the answer lies, and that one was wrong. Corrected from play testing, in two passes.

The default moving off the camera's authored value is deliberate. If `1.0` is uncomfortable for one player it is uncomfortable for every new one, and they would each have to find this slider before the game felt right — the wrong way round for a default. Only players who have never touched the slider are affected; **a saved value always wins**.

## One slider, not two

There is one knob — `KCCCamera.RotationSpeed` multiplies both axes — and no aim or zoom state to hang a second one on. The only mode switch is the first-person toggle, which just sets camera distance to zero.

Shown as a multiplier (`0.45`) rather than a percentage, because that is what it is: the view turns this many times as far per unit of mouse movement. A percentage would read as a ceiling.

## Details

**Clamped on read as well as on write.** The value lives in a text file the player can edit and it scales raw mouse delta, so a bad one makes the view unusable at exactly the moment they would need to reach this menu to put it back. The floor is 0.1 rather than 0 for the same reason — zero is a camera that cannot be turned.

**`ClientCameraSettings` is separate from `ClientDisplaySettings`** because it writes to a scene object rather than to Unity's global state, and that object does not exist for the whole session. The camera is resolved on **every** apply rather than cached: `Camera.main` answers differently across scene loads, and a stale handle here fails silently — the setting appears to save and simply never applies.

**Applied at boot**, alongside the other settings, so it takes effect without opening the options panel. That panel ships closed, and its `OnStarting` was historically the only thing applying display settings — which is why a capped frame rate used to be forgotten every session until someone visited the menu. Same trap, avoided.

**It only has an observable effect while the cursor is locked**, which is the state the mouse drives the camera in. With mouse mode on the cursor is free and the view does not turn, so the slider reads as broken if tested there — there is simply no look input to scale.

## Persistence

Verified end to end rather than assumed: `Set` writes the value and requests a save, debounced 0.75 s and pumped once per frame; a pending write is flushed on `OnApplicationQuit`, and `ClientSettingsPump` also flushes on focus loss and pause. The value survives relaunch even if the player quits immediately after moving the slider.

## Testing

Suite is 1175 / 1175 on this branch.

No unit test covers the slider. Its behaviour is "a serialized float reaches a component on `Camera.main`", which needs a live camera and a settings store to observe, and a test standing those up would be asserting on Unity rather than on this. It has been exercised live instead — and the range is the way it is *because* of that testing.
