### PR TITLE
Report a missing health resource as a Warning, not an Error

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterDamageController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterDamageController.cs
@@ -227,7 +227,17 @@ namespace FishMMO.Shared
 						if (!loggedMissingResource)
 						{
 							loggedMissingResource = true;
-							Log.Error("CharacterDamageController",
+
+							/* Warning, not Error. This is a content-authoring fault in a prefab, not a
+							 * runtime failure of this code: the entity is already handled safely,
+							 * because Damage and Kill both return early on a null resource. Error is
+							 * the level that says "an engineer should look at the running system
+							 * now", and reserving it for that is what keeps it worth reading -- a
+							 * misconfigured NPC firing Error means every real fault competes with it
+							 * during triage. It stays a Warning rather than Info because the entity
+							 * genuinely cannot be damaged or killed, which is not something to
+							 * discover from a player report. */
+							Log.Warning("CharacterDamageController",
 								$"{gameObject.name} is missing ICharacterAttributeController or Health Resource Attribute. " +
 								"It cannot be damaged or killed. Further occurrences on this object are suppressed until it resolves.");
 						}

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/MissingHealthResourceTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/MissingHealthResourceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
 using FishMMO.Shared;
@@ -80,6 +81,50 @@ namespace FishMMO.UnitTests
 
 			LogAssert.IsTrue(ReportedFlag(),
 				"the report stays suppressed for every later access -- this is what #157 was");
+		}
+
+		[Test]
+		public void TheMissingHealthReport_IsAWarning_NotAnError()
+		{
+			/* Pinned in source, because the level is not observable from the property: the report
+			 * fires through FishMMO.Logging, and a test that captured it would be asserting on the
+			 * logger rather than on this decision.
+			 *
+			 * The decision is that a prefab authored without a health attribute is a content fault,
+			 * not a runtime failure of this code -- Damage and Kill both return early on a null
+			 * resource, so the entity is already handled safely. Error is the level that means "an
+			 * engineer should look at the running system now", and one misconfigured NPC firing it
+			 * makes every genuine fault compete for attention during triage. That is most of what
+			 * made issue #157 painful: not only the volume, but that the volume was Errors. */
+			string source = ReadSource(
+				"Assets/Scripts/Shared/Implementation/Entity/Prediction/CharacterAttribute/CharacterDamageController.cs");
+
+			const string message = "is missing ICharacterAttributeController";
+			int report = source.IndexOf(message, StringComparison.Ordinal);
+			LogAssert.IsTrue(report >= 0,
+				"the missing-health report must still exist in CharacterDamageController");
+
+			/* The call opens several lines above the message text, so look back over a bounded window
+			 * for whichever level opened it. Matching an exact rendering of the call would pin the
+			 * formatting rather than the decision, and would break on a reflow that changed nothing. */
+			int from = Math.Max(0, report - 400);
+			string call = source.Substring(from, report - from);
+
+			int warning = call.LastIndexOf("Log.Warning(", StringComparison.Ordinal);
+			int error = call.LastIndexOf("Log.Error(", StringComparison.Ordinal);
+
+			LogAssert.IsTrue(warning >= 0,
+				"the missing-health report must be raised through Log.Warning");
+			LogAssert.IsTrue(warning > error,
+				"the missing-health report must be a Warning, not an Error -- see #157");
+		}
+
+		/// <summary>Reads a project source file, so a decision that lives in code can be pinned.</summary>
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path);
 		}
 
 		[Test]


### PR DESCRIPTION
Follow-up on #157 / #160. The log-once gate that stopped the flood is already on `dev` and looks
correct, so this changes only what remains: the level.

## What this changes

`CharacterDamageController` reports an entity with no health resource through `Log.Warning`
instead of `Log.Error`.

An entity whose prefab has no health attribute is a content-authoring fault, not a runtime
failure of this code. `Damage` and `Kill` both return early on a null resource, so the entity is
already handled safely -- it simply cannot be damaged or killed.

Error is the level that means "an engineer should look at the running system now", and reserving
it for that is what keeps it worth reading. One misconfigured NPC firing Error makes every
genuine fault compete with it during triage, which is much of what made #157 painful: not only
the volume, but that the volume was Errors.

It stays a Warning rather than dropping to Info because the entity genuinely cannot be damaged
or killed, and that is not something to first discover from a player report.

## On the gate itself

I went in expecting to re-fix the spam and found nothing to fix. Worth stating plainly, since the
log I started from looks like evidence the gate fails:

- The 72,153-error session I had in hand ran **28 Aug 04:47-04:57 UTC**, on a client built
  **27 Aug 20:26**. The log-once fix landed in `5b883452` at **28 Aug 01:28 UTC** -- after that
  client was built. So that log is the *unfixed* code, not the fix failing.
- Current logs show zero occurrences on both server and client. That is not proof either, only
  because those NPCs did not spawn in the session I have.
- `ResetState(bool asServer)` re-arms the flag, and I checked it is FishNet's pool-return hook
  (documented as resetting the behaviour so it may be pooled; called from `NetworkObject.cs`
  419-420 and 476-477), **not** a per-reconcile call. So re-arming is once per pooled respawn,
  which is what you want -- a recycled object may be a different character.

If the spam has actually recurred on a build that contains `5b883452`, that is a separate defect
and I would want the log; I did not find grounds to touch the gate here.

## Tests

Adds `TheMissingHealthReport_IsAWarning_NotAnError` to the existing `MissingHealthResourceTests`,
which already pins the log-once behaviour. The level is not observable from the property, so it
is pinned in source -- but matched on the message text with a look-back for whichever level
opened the call, rather than an exact rendering, so a reflow does not break it.

Verified against a negative control: restoring `Log.Error` fails that test and only that test
(4 tests, 3 passed, 1 failed). With the change in place, 4/4 pass, and the full suite is green.
