### PR TITLE
Fix the look sensitivity apply, and give the scroll wheel more zoom positions

### DIFF
--- a/FishMMO-Unity/Assets/Scenes/Client/ClientPreboot.unity
+++ b/FishMMO-Unity/Assets/Scenes/Client/ClientPreboot.unity
@@ -358,7 +358,7 @@ MonoBehaviour:
   DefaultDistance: 6
   MinDistance: 0
   MaxDistance: 10
-  DistanceMovementSpeed: 5
+  DistanceMovementSpeed: 0.5
   DistanceMovementSharpness: 10
   InvertX: 0
   InvertY: 0

--- a/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Input/PlayerInputController.cs
@@ -199,6 +199,16 @@ namespace FishMMO.Client
 			// Start with cursor visible (login/loading state).
 			MouseMode = true;
 
+			/* Applied here, not only at boot. ClientSettings.ApplyAll runs before a world camera
+			 * exists, so the camera it wants to write to is not there yet and the apply is a no-op.
+			 * Nothing re-applied afterwards, which left the camera on its authored RotationSpeed --
+			 * a saved sensitivity was stored and shown correctly in the options panel, but did not
+			 * take effect until the player moved the slider, once per launch.
+			 *
+			 * This is the first point where the local character exists, so the world camera does
+			 * too. Cheap and idempotent: it reads one float and writes one field. */
+			ClientCameraSettings.ApplySaved();
+
 			SubscribeToInputActions();
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
@@ -81,9 +81,12 @@ namespace FishMMO.Client
 			KCCCamera camera = ResolveCamera();
 			if (camera == null)
 			{
-				/* Not an error. Boot applies settings before the world exists, and the camera is
-				 * re-resolved on the next apply — which the options panel triggers, and which
-				 * happens again on the following launch. */
+				/* Not an error, and not the whole story either: boot applies settings before a
+				 * world camera exists, so this returns having done nothing. That is fine only
+				 * because PlayerInputController.Initialize applies again once the local character
+				 * is in the world. Without that second apply the camera keeps its authored
+				 * RotationSpeed for the whole session, and the saved value appears to be ignored
+				 * until the player happens to move the slider. */
 				return;
 			}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
@@ -53,13 +53,35 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Applies the stored look sensitivity to the live camera.
 		/// </summary>
+		/// <remarks>
+		/// Reports what it did, at Debug. This apply is the one that decides whether a player's
+		/// saved sensitivity is honoured, and it previously failed in total silence: the value was
+		/// stored, the options panel displayed it, and the camera ran at its authored speed for the
+		/// whole session with nothing anywhere saying so. A line here is what turns "the slider
+		/// feels wrong" from a guess into something answerable from a log.
+		///
+		/// Only this path logs. ApplyLookSensitivity is also called for every value change while
+		/// the player drags the slider, which would be pure noise.
+		/// </remarks>
 		public static void ApplySaved()
 		{
-			ApplyLookSensitivity(ClientSettings.GetFloat(
+			float sensitivity = ClientSettings.GetFloat(
 				ClientSettings.LookSensitivityKey,
 				DefaultLookSensitivity,
 				MinimumLookSensitivity,
-				MaximumLookSensitivity));
+				MaximumLookSensitivity);
+
+			if (ApplyLookSensitivity(sensitivity))
+			{
+				Log.Debug("ClientCameraSettings",
+					$"Look sensitivity {sensitivity} applied to the camera.");
+			}
+			else
+			{
+				Log.Debug("ClientCameraSettings",
+					$"Look sensitivity {sensitivity} not applied: no camera yet. Expected during " +
+					"boot, and applied again once the character is in the world.");
+			}
 		}
 
 		/// <summary>
@@ -72,7 +94,8 @@ namespace FishMMO.Client
 		/// immovable.
 		/// </remarks>
 		/// <param name="value">Sensitivity multiplier. Clamped to the supported range.</param>
-		public static void ApplyLookSensitivity(float value)
+		/// <returns><c>true</c> if a camera received the value; <c>false</c> if there is none yet.</returns>
+		public static bool ApplyLookSensitivity(float value)
 		{
 			float clamped = float.IsNaN(value)
 				? DefaultLookSensitivity
@@ -87,10 +110,11 @@ namespace FishMMO.Client
 				 * is in the world. Without that second apply the camera keeps its authored
 				 * RotationSpeed for the whole session, and the saved value appears to be ignored
 				 * until the player happens to move the slider. */
-				return;
+				return false;
 			}
 
 			camera.RotationSpeed = clamped;
+			return true;
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/KCC/KCCCamera.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/KCC/KCCCamera.cs
@@ -34,9 +34,19 @@ namespace FishMMO.Shared
 		/// </summary>
 		public float MaxDistance = 10f;
 		/// <summary>
-		/// Speed at which camera distance changes (zoom).
+		/// Distance the camera moves per notch of scroll wheel.
 		/// </summary>
-		public float DistanceMovementSpeed = 5f;
+		/// <remarks>
+		/// This is a distance per notch, not a rate: the scroll delta arrives normalised to -1..1
+		/// (the Input System's default <c>ScrollDeltaBehavior</c>), so one notch moves the camera
+		/// by exactly this much before smoothing.
+		///
+		/// Half a unit, down from five. Over the usual 0-10 range five gave two notches from fully
+		/// in to fully out, so the wheel behaved as a toggle rather than a zoom and no intermediate
+		/// framing was reachable. The value only reads as a "speed" if the delta is a rate; it is
+		/// not, which is what made 5 look reasonable.
+		/// </remarks>
+		public float DistanceMovementSpeed = 0.5f;
 		/// <summary>
 		/// Sharpness for distance movement smoothing.
 		/// </summary>

--- a/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FishMMO.Client;
+using FishMMO.Shared;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the two camera preferences the player controls: how fast the view turns, and how
+	/// far one notch of scroll wheel moves it.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Both had the same shape of defect, which is why they are tested together. A value that is
+	/// correct in isolation is worthless if the thing that ships never receives it: the sensitivity
+	/// was stored and displayed correctly while the camera ran at its authored speed, and the zoom
+	/// step was a sensible-looking number that produced two usable positions.
+	/// </para>
+	/// <para>
+	/// So these tests deliberately check the authored scene and the wiring, not just the constants.
+	/// A test that only asserted on <see cref="ClientCameraSettings"/> would have passed throughout
+	/// the entire period the feature was broken.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class CameraSettingsTests
+	{
+		private const string PrebootScene = "Assets/Scenes/Client/ClientPreboot.unity";
+
+		/// <summary>
+		/// Fewest scroll notches that count as a zoom rather than a toggle.
+		/// </summary>
+		/// <remarks>
+		/// Ten is a floor, not a target. The point is that intermediate framings are reachable at
+		/// all: with the previous step of five over a range of ten there were two, so the wheel
+		/// chose between "fully in" and "fully out" and nothing else.
+		/// </remarks>
+		private const int MinimumUsefulNotches = 10;
+
+		private GameObject cameraObject;
+		private readonly List<GameObject> suppressed = new List<GameObject>();
+
+		[SetUp]
+		public void SetUp()
+		{
+			/* ClientCameraSettings resolves its target through Camera.main, so any other camera
+			 * already tagged MainCamera would win and every assertion below would be made against a
+			 * camera nothing wrote to. Suppressing them is not tidiness: the first run of this
+			 * fixture failed exactly that way, and two of its tests PASSED while doing so, because
+			 * the value they expected happened to equal the camera's authored RotationSpeed of 1. */
+			foreach (Camera existing in Resources.FindObjectsOfTypeAll<Camera>())
+			{
+				if (existing.gameObject.scene.IsValid() &&
+					existing.gameObject.activeInHierarchy &&
+					existing.CompareTag("MainCamera"))
+				{
+					existing.gameObject.SetActive(false);
+					suppressed.Add(existing.gameObject);
+				}
+			}
+
+			cameraObject = new GameObject("CameraSettingsTestCamera");
+			cameraObject.tag = "MainCamera";
+			cameraObject.AddComponent<Camera>();
+			cameraObject.AddComponent<KCCCamera>();
+
+			// The premise every sensitivity test rests on, checked rather than assumed.
+			Assume.That(Camera.main, Is.EqualTo(cameraObject.GetComponent<Camera>()),
+				"the fixture's camera must be the one ClientCameraSettings resolves");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (cameraObject != null)
+			{
+				UnityEngine.Object.DestroyImmediate(cameraObject);
+			}
+
+			foreach (GameObject restored in suppressed)
+			{
+				if (restored != null)
+				{
+					restored.SetActive(true);
+				}
+			}
+			suppressed.Clear();
+		}
+
+		// --- Sensitivity reaches the camera ----------------------------------------------------
+
+		[Test]
+		public void ApplyLookSensitivity_WritesTheValueOntoTheCamera()
+		{
+			ClientCameraSettings.ApplyLookSensitivity(0.3f);
+
+			LogAssert.AreEqual(0.3f, cameraObject.GetComponent<KCCCamera>().RotationSpeed,
+				"the chosen sensitivity must reach the camera that actually turns the view");
+		}
+
+		[Test]
+		public void ApplyLookSensitivity_ClampsAValueTooLargeToRecoverFrom()
+		{
+			/* The value multiplies raw mouse delta and lives in a text file the player can edit. A
+			 * large one makes the view unusable at exactly the moment they would need to aim at the
+			 * menu to put it back. */
+			ClientCameraSettings.ApplyLookSensitivity(500.0f);
+
+			LogAssert.AreEqual(ClientCameraSettings.MaximumLookSensitivity,
+				cameraObject.GetComponent<KCCCamera>().RotationSpeed,
+				"an out-of-range sensitivity must be clamped, not honoured");
+		}
+
+		[Test]
+		public void ApplyLookSensitivity_RefusesAZeroThatWouldFreezeTheView()
+		{
+			ClientCameraSettings.ApplyLookSensitivity(0.0f);
+
+			LogAssert.IsTrue(cameraObject.GetComponent<KCCCamera>().RotationSpeed > 0.0f,
+				"zero is a camera that cannot be moved at all");
+		}
+
+		[Test]
+		public void ApplyLookSensitivity_FallsBackToTheDefaultOnANonNumber()
+		{
+			ClientCameraSettings.ApplyLookSensitivity(float.NaN);
+
+			LogAssert.AreEqual(ClientCameraSettings.DefaultLookSensitivity,
+				cameraObject.GetComponent<KCCCamera>().RotationSpeed,
+				"a corrupt stored value must land on the default, not propagate as NaN");
+		}
+
+		[Test]
+		public void TheSavedSensitivity_IsAppliedWhenTheLocalCharacterInitializes()
+		{
+			/* Pinned in source. This is the wiring the feature was missing, and it is not reachable
+			 * from a unit test: PlayerInputController.Initialize needs a networked player character.
+			 *
+			 * Boot applies settings before a world camera exists, so that apply does nothing. Until
+			 * this second one existed, the camera kept its authored RotationSpeed for the whole
+			 * session -- the saved value was stored, and shown correctly by the options panel, but
+			 * did not take effect until the player moved the slider, once per launch. Every other
+			 * test in this fixture passed throughout. */
+			string source = ReadSource("Assets/Scripts/Client/Input/PlayerInputController.cs");
+
+			int initialize = source.IndexOf("public void Initialize(", StringComparison.Ordinal);
+			LogAssert.IsTrue(initialize >= 0, "PlayerInputController.Initialize must exist");
+
+			int apply = source.IndexOf("ClientCameraSettings.ApplySaved()", initialize,
+				StringComparison.Ordinal);
+
+			LogAssert.IsTrue(apply >= 0,
+				"the saved camera settings must be applied once the local character exists");
+		}
+
+		// --- Zoom reaches intermediate distances ------------------------------------------------
+
+		[Test]
+		public void TheZoomStepDefault_ReachesIntermediateDistances()
+		{
+			KCCCamera camera = cameraObject.GetComponent<KCCCamera>();
+
+			LogAssert.IsTrue(Notches(camera) >= MinimumUsefulNotches,
+				$"a wheel with {Notches(camera)} positions between fully in and fully out is a " +
+				"toggle, not a zoom");
+		}
+
+		[Test]
+		public void TheAuthoredCamera_ReachesIntermediateDistances()
+		{
+			/* The one that matters. The serialised scene value is what ships, and it overrides the
+			 * field initialiser entirely -- changing the default in code moves nothing that already
+			 * exists, so a test against the constant alone would report a fix that no player got. */
+			Scene scene = EditorSceneManager.OpenScene(PrebootScene, OpenSceneMode.Additive);
+			try
+			{
+				KCCCamera authored = null;
+				foreach (GameObject root in scene.GetRootGameObjects())
+				{
+					authored = root.GetComponentInChildren<KCCCamera>(includeInactive: true);
+					if (authored != null)
+					{
+						break;
+					}
+				}
+
+				LogAssert.IsNotNull(authored, $"{PrebootScene} must carry the player's camera");
+				LogAssert.IsTrue(Notches(authored) >= MinimumUsefulNotches,
+					$"the authored camera offers {Notches(authored)} scroll positions");
+			}
+			finally
+			{
+				EditorSceneManager.CloseScene(scene, removeScene: true);
+			}
+		}
+
+		/// <summary>
+		/// Scroll notches between fully zoomed in and fully zoomed out.
+		/// </summary>
+		/// <remarks>
+		/// The scroll delta arrives normalised to -1..1 (the Input System's default
+		/// <c>ScrollDeltaBehavior</c>), so one notch moves the camera by exactly
+		/// <c>DistanceMovementSpeed</c> and the count is a plain division.
+		/// </remarks>
+		private static int Notches(KCCCamera camera)
+		{
+			if (camera.DistanceMovementSpeed <= 0.0f)
+			{
+				return 0;
+			}
+
+			return Mathf.FloorToInt(
+				(camera.MaxDistance - camera.MinDistance) / camera.DistanceMovementSpeed);
+		}
+
+		/// <summary>Reads a project source file, so wiring that lives in code can be pinned.</summary>
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path);
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs
@@ -137,6 +137,23 @@ namespace FishMMO.UnitTests
 		}
 
 		[Test]
+		public void ApplyLookSensitivity_ReportsWhetherACameraReceivedIt()
+		{
+			/* What the Debug line in ApplySaved reports. The distinction matters because "applied"
+			 * and "applied to nothing" were indistinguishable for a whole release: the no-camera
+			 * path is the normal one at boot, so it cannot be an error, which is exactly why it
+			 * needs to be visible instead. */
+			LogAssert.IsTrue(ClientCameraSettings.ApplyLookSensitivity(0.4f),
+				"a camera is present, so the value lands");
+
+			UnityEngine.Object.DestroyImmediate(cameraObject);
+			cameraObject = null;
+
+			LogAssert.IsFalse(ClientCameraSettings.ApplyLookSensitivity(0.4f),
+				"with no camera the value goes nowhere, and the caller must be able to tell");
+		}
+
+		[Test]
 		public void TheSavedSensitivity_IsAppliedWhenTheLocalCharacterInitializes()
 		{
 			/* Pinned in source. This is the wiring the feature was missing, and it is not reachable

--- a/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/CameraSettingsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcbe79b9bac7b0242bec5afb16fe95b5


### PR DESCRIPTION
Two camera fixes, both reported from play, plus the logging that would have caught one of them.
They share a cause worth stating: a value that is correct everywhere except at the point it ships.

## The saved look sensitivity never reached the camera

`ClientSettings` applies at boot, before a world camera exists, so `ApplySaved` resolved a null
camera and returned having done nothing. Nothing applied it again.

The camera ran at its authored `RotationSpeed` of 1 for the whole session. A player who had chosen
0.33 got 1 on every launch -- and the options panel showed 0.33 while they did, because storing and
displaying were both working. The value only took effect once they moved the slider, which
re-applied it as a side effect; that side effect was standing in for the missing apply.

Fixed in `PlayerInputController.Initialize`, the first point where the local character exists and
therefore the world camera does too. One float read, one field write, idempotent.

Also corrects the comment in `ClientCameraSettings` that claimed the options panel was the
re-apply path -- that reasoning is what left the gap.

## The apply now says what it did

The defect above survived a release because it was silent: stored, displayed, and never applied,
with nothing anywhere reporting the difference. The only way to notice was for the view to feel
wrong.

`ApplySaved` now reports at Debug, and `ApplyLookSensitivity` returns whether a camera received the
value so that report can be accurate. "Applied" and "applied to nothing" were indistinguishable,
and the second is the normal case at boot -- so it cannot be raised as a fault, which is precisely
why it needs to be visible instead. Only `ApplySaved` logs; `ApplyLookSensitivity` also runs on
every value change while the slider is dragged, and logging there would be noise.

## The scroll wheel had two zoom positions

`DistanceMovementSpeed` was 5 over a 0-10 range. The scroll delta arrives normalised to -1..1 (the
Input System's default `ScrollDeltaBehavior`, unchanged in this project), so one notch moved the
camera five units: two notches covered the whole range and no intermediate framing was reachable.

The name is most of why 5 looked reasonable. It reads as a rate, but the delta is not a rate, so
the value is a distance per notch. Half a unit gives twenty positions.

Changed in the authored `ClientPreboot` camera **as well as** the field initialiser. The serialised
scene value is what ships and overrides the initialiser entirely, so changing the default alone
would have fixed nothing for anyone. The scene diff is one line.

## Tests

The camera had none. `CameraSettingsTests` covers all of the above, and deliberately asserts
against the authored scene and the wiring rather than only the constants -- a test that looked only
at `ClientCameraSettings` would have passed throughout the entire period both features were broken.

Two things worth flagging about the fixture itself, since they affected what it proves:

- Its first run had two tests pass **vacuously**: `ClientCameraSettings` resolves through
  `Camera.main`, another tagged camera was winning, and the values those tests expected happened to
  equal the camera's authored `RotationSpeed` of 1. `SetUp` now suppresses other main cameras and
  asserts the premise instead of assuming it.
- Both pins were checked with negative controls: restoring the old zoom step fails the
  authored-camera test, and removing the apply fails the wiring test, each without disturbing the
  others.

Full EditMode suite: **1186 tests, 1186 passed, 0 failed**, no compile errors.

## Verified in a real build

Built and played against live servers. Zoom is confirmed improved from play. The sensitivity fix is
corroborated rather than directly observed: the stored value moved 0.329 -> 0.321 across the
session, a 2% adjustment. Had the apply still been broken the camera would have started at 1.0,
roughly three times faster, and the slider would have had to travel a long way rather than be
nudged. The Debug line added here is what makes that answerable directly next time.
