### PR TITLE
Stop reporting an unsplit body model as six errors per spawn

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Appearance/BodyVisibilityManager.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Appearance/BodyVisibilityManager.cs
@@ -130,7 +130,18 @@ namespace FishMMO.Shared
 				regionHideCounts[(BodyRegion)i] = 0;
 			}
 
-			// Discover each region renderer by its expected name
+			/* Missing regions are collected rather than reported one by one.
+			 *
+			 * A model with none of them is not a broken model: it is a model that does not use
+			 * per-region hiding, which every shipped race currently is. Reporting that as six Errors
+			 * per spawn said "incorrectly authored" about every character in the game, which is how a
+			 * log stops being read at all.
+			 *
+			 * A model with SOME of them is a different thing and still worth saying out loud, because
+			 * a half-split body will hide the wrong parts once equipment is worn. That distinction is
+			 * the entire point of separating the two cases below. */
+			List<string> missing = new List<string>();
+
 			BodyRegion[] allRegions = (BodyRegion[])System.Enum.GetValues(typeof(BodyRegion));
 			for (int i = 0; i < allRegions.Length; i++)
 			{
@@ -144,26 +155,47 @@ namespace FishMMO.Shared
 					regionTransform = FindChildRecursive(meshRoot, rendererName);
 				}
 
-				if (regionTransform != null)
+				if (regionTransform == null)
 				{
-					SkinnedMeshRenderer renderer = regionTransform.GetComponent<SkinnedMeshRenderer>();
-					if (renderer != null)
-					{
-						regionRenderers[region] = renderer;
-					}
-					else
-					{
-						Log.Error("BodyVisibilityManager",
-							$"Body region '{rendererName}' found but has no SkinnedMeshRenderer. Model is incorrectly authored.");
-					}
+					missing.Add(rendererName);
+					continue;
 				}
-				else
+
+				SkinnedMeshRenderer renderer = regionTransform.GetComponent<SkinnedMeshRenderer>();
+				if (renderer == null)
 				{
-					Log.Error("BodyVisibilityManager",
-						$"Body region '{rendererName}' not found in model. Model is incorrectly authored — " +
-						$"the body mesh must be split into separate GameObjects named BodyHead, BodyTorso, BodyArms, BodyHands, BodyLegs, BodyFeet.");
+					/* Present but unusable. Grouped with the absent ones because the consequence is
+					 * identical -- the region cannot be hidden -- and named separately so whoever
+					 * fixes it knows the object exists and only lacks the renderer. */
+					missing.Add($"{rendererName} (no SkinnedMeshRenderer)");
+					continue;
 				}
+
+				regionRenderers[region] = renderer;
 			}
+
+			if (missing.Count == 0)
+			{
+				return;
+			}
+
+			if (regionRenderers.Count == 0)
+			{
+				/* Not a fault. Equipment simply never hides body parts on this model, and
+				 * HideRegions already no-ops for regions it has no renderer for. */
+				Log.Debug("BodyVisibilityManager",
+					$"{gameObject.name} has no split body regions, so per-region hiding is inactive " +
+					"for it. Split the body mesh into " + string.Join(", ", missing) + " to enable it.");
+				return;
+			}
+
+			/* Warning, not Error: a partly-split body is a content-authoring fault, not a runtime
+			 * failure, and nothing here is left in a broken state -- the regions that exist still
+			 * hide correctly. It stays above Debug because the ones that do not exist will silently
+			 * fail to hide, which is discovered as clipping through armour. */
+			Log.Warning("BodyVisibilityManager",
+				$"{gameObject.name} is partly split: {regionRenderers.Count} body region(s) found, " +
+				$"missing {string.Join(", ", missing)}. Equipment cannot hide the missing ones.");
 		}
 
 		/// <summary>Finds the skeleton root — the first Transform with bone children under the mesh root.</summary>

--- a/FishMMO-Unity/Assets/UnitTests/BodyRegionDiscoveryTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/BodyRegionDiscoveryTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using FishMMO.Shared;
+using NUnit.Framework;
+using UnityEngine;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for how <see cref="BodyVisibilityManager"/> reports a model that cannot be split into
+	/// body regions, which is issue #158.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Discovery used to log one Error per absent region, so every spawn produced six -- and no
+	/// model in the project has ever had these regions, so the log said "incorrectly authored"
+	/// about every character in the game. A message that fires for everything carries no
+	/// information, and worse, it trains people to skip Errors from this system entirely.
+	/// </para>
+	/// <para>
+	/// The distinction these tests exist to hold is between two situations the old code reported
+	/// identically: a model that does not use per-region hiding at all (normal, and what every
+	/// shipped race is), and a model split only halfway (a real fault, because the missing regions
+	/// silently fail to hide and show up as clipping through armour).
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class BodyRegionDiscoveryTests
+	{
+		private static readonly string[] AllRegions =
+		{
+			"BodyHead", "BodyTorso", "BodyArms", "BodyHands", "BodyLegs", "BodyFeet",
+		};
+
+		private GameObject root;
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (root != null)
+			{
+				UnityEngine.Object.DestroyImmediate(root);
+			}
+		}
+
+		/// <summary>
+		/// Builds a character whose mesh root carries the named region objects, each with a
+		/// renderer unless stated otherwise.
+		/// </summary>
+		private BodyVisibilityManager BuildCharacter(bool withRenderers, params string[] regionNames)
+		{
+			root = new GameObject("BodyRegionTestCharacter");
+			BodyVisibilityManager manager = root.AddComponent<BodyVisibilityManager>();
+
+			GameObject meshRoot = new GameObject("MeshRoot");
+			meshRoot.transform.SetParent(root.transform);
+
+			for (int i = 0; i < regionNames.Length; i++)
+			{
+				GameObject region = new GameObject(regionNames[i]);
+				region.transform.SetParent(meshRoot.transform);
+
+				if (withRenderers)
+				{
+					region.AddComponent<SkinnedMeshRenderer>();
+				}
+			}
+
+			typeof(CharacterBehaviour)
+				.GetProperty("Character", BindingFlags.Instance | BindingFlags.Public)
+				.SetValue(manager, new Harness.StubCharacter { MeshRoot = meshRoot.transform });
+
+			return manager;
+		}
+
+		/// <summary>Runs discovery, which is private because nothing outside the component calls it.</summary>
+		private static void Discover(BodyVisibilityManager manager)
+		{
+			MethodInfo discover = typeof(BodyVisibilityManager).GetMethod(
+				"TryDiscoverRegionRenderers",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+
+			LogAssert.IsNotNull(discover, "BodyVisibilityManager must still discover regions.");
+			discover.Invoke(manager, null);
+		}
+
+		/// <summary>How many renderers discovery actually resolved.</summary>
+		private static int DiscoveredCount(BodyVisibilityManager manager)
+		{
+			FieldInfo field = typeof(BodyVisibilityManager).GetField(
+				"regionRenderers",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+
+			LogAssert.IsNotNull(field, "the discovered renderers must still be recorded.");
+			return ((IDictionary<BodyRegion, SkinnedMeshRenderer>)field.GetValue(manager)).Count;
+		}
+
+		[Test]
+		public void AModelWithNoRegions_DiscoversNothingAndThatIsNotAFailure()
+		{
+			/* Every shipped race. The point is that this is a supported configuration: the
+			 * character renders normally and equipment simply never hides anything. */
+			BodyVisibilityManager manager = BuildCharacter(true);
+
+			Discover(manager);
+
+			LogAssert.AreEqual(0, DiscoveredCount(manager),
+				"there is nothing to discover, and that is not a fault");
+		}
+
+		[Test]
+		public void AModelWithNoRegions_StillHandlesEquipmentWithoutThrowing()
+		{
+			/* Why the quiet path is safe. Hiding is driven by worn equipment, which does not know
+			 * whether the model supports regions, so every hide has to be survivable. */
+			BodyVisibilityManager manager = BuildCharacter(true);
+			Discover(manager);
+
+			Assert.DoesNotThrow(
+				() => manager.HideRegions(new[] { BodyRegion.Head, BodyRegion.Torso }, ItemSlot.Head),
+				"equipment must not depend on the model being split");
+		}
+
+		[Test]
+		public void AFullySplitModel_DiscoversEveryRegion()
+		{
+			/* The feature working. Without this, the fixture would pass just as happily against a
+			 * discovery that found nothing at all, ever. */
+			BodyVisibilityManager manager = BuildCharacter(true, AllRegions);
+
+			Discover(manager);
+
+			LogAssert.AreEqual(AllRegions.Length, DiscoveredCount(manager),
+				"a properly split model must resolve all six regions");
+		}
+
+		[Test]
+		public void AFullySplitModel_HidesTheRegionEquipmentCovers()
+		{
+			BodyVisibilityManager manager = BuildCharacter(true, AllRegions);
+			Discover(manager);
+
+			manager.HideRegions(new[] { BodyRegion.Head }, ItemSlot.Head);
+
+			Transform head = root.transform.Find("MeshRoot/BodyHead");
+			LogAssert.IsNotNull(head, "the head region must exist in this fixture");
+			LogAssert.IsFalse(head.GetComponent<SkinnedMeshRenderer>().enabled,
+				"a helmet must hide the head it covers");
+		}
+
+		[Test]
+		public void APartlySplitModel_DiscoversTheRegionsItHas()
+		{
+			/* The case that stays loud. Warning rather than Error because nothing is left broken --
+			 * the regions present still hide correctly -- but the absent ones fail silently, which
+			 * surfaces as armour clipping rather than as anything in a log. */
+			BodyVisibilityManager manager = BuildCharacter(true, "BodyHead", "BodyTorso", "BodyArms");
+
+			Discover(manager);
+
+			LogAssert.AreEqual(3, DiscoveredCount(manager),
+				"a half-split model still resolves what it has");
+		}
+
+		[Test]
+		public void ARegionWithoutARenderer_IsNotCountedAsFound()
+		{
+			/* Present but unusable. It must not count as found, or hiding would silently do nothing
+			 * for a region the code believed it had. */
+			BodyVisibilityManager manager = BuildCharacter(false, "BodyHead");
+
+			Discover(manager);
+
+			LogAssert.AreEqual(0, DiscoveredCount(manager),
+				"an object that cannot render is not a usable region");
+		}
+
+		[Test]
+		public void DiscoveryDoesNotReportAbsentRegionsAsErrors()
+		{
+			/* Pinned in source: the level is the whole subject of #158 and is not observable from
+			 * the component. Every shipped model takes this path, so an Error here fires for every
+			 * character in the game -- which is what made the log unreadable rather than useful. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Shared/Implementation/Entity/Appearance/BodyVisibilityManager.cs"));
+
+			int discovery = source.IndexOf("TryDiscoverRegionRenderers()", StringComparison.Ordinal);
+			LogAssert.IsTrue(discovery >= 0, "discovery must still exist");
+
+			int end = source.IndexOf("Finds the skeleton root", discovery, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > discovery, "the discovery body must still be locatable");
+
+			LogAssert.IsFalse(
+				source.Substring(discovery, end - discovery).Contains("Log.Error"),
+				"a model without split regions is not an error -- see #158");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/BodyRegionDiscoveryTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/BodyRegionDiscoveryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acd7c53c9d80ec043acd3c599831c158

--- a/FishMMO-Unity/Assets/UnitTests/Harness/StubCharacter.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Harness/StubCharacter.cs
@@ -58,7 +58,11 @@ namespace FishMMO.UnitTests.Harness
 		public HashSet<NetworkConnection> Observers => null;
 		public bool IsTeleporting => false;
 		public bool IsSpawned => false;
-		public Transform MeshRoot => null;
+		/// <summary>
+		/// The character's mesh root. Settable so a fixture can hand this stub a real hierarchy;
+		/// still null by default, which is what every existing test expects.
+		/// </summary>
+		public Transform MeshRoot { get; set; }
 
 		public void EnableFlags(CharacterFlags flags) { }
 		public void DisableFlags(CharacterFlags flags) { }


### PR DESCRIPTION
Fixes #158. Takes the "degrade quietly" option the issue offered, because the alternative is
content work (authoring split body meshes for every race) and this does not preclude it.

## What was wrong

Discovery logged one Error per absent body region, so every character spawn produced six. **No
model in the project has ever had these regions** -- not Human, Elf, or Orc -- so the log said
"incorrectly authored" about every character in the game. Confirmed still live: a play session
today produced 13 of these in a few minutes, and they were the only client errors in it.

A message that fires for everything carries no information. Worse, it teaches people to skip
Errors from this system, including a real one if it ever appears.

## The distinction the old code could not make

It reported two very different situations identically:

- **No regions at all** is not a broken model. It is a model that does not use per-region hiding,
  which every shipped race is. Equipment simply never hides body parts, and `HideRegions` already
  no-ops for regions it has no renderer for, so nothing is left in a bad state. Now reported
  **once, at Debug**.
- **Some regions but not all** is a genuine content fault, because the missing ones silently fail
  to hide and surface as clipping through armour. Now reported **once, at Warning**, naming what
  is missing.

Warning rather than Error for the second: it is a content-authoring fault, not a runtime failure,
and the regions that do exist still hide correctly. Same reasoning as the missing-health report in
#157.

An object named correctly but carrying no `SkinnedMeshRenderer` is grouped with the absent ones --
the consequence is identical -- but named distinctly, so whoever fixes it knows the object exists
and only lacks the renderer.

## Tests

`BodyRegionDiscoveryTests` drives discovery against real hierarchies rather than only asserting on
constants: no regions, all six, a half-split model, and a region object with no renderer.

The pair that matters is "no regions resolves 0" alongside "fully split resolves 6" -- neither can
pass trivially if discovery breaks in the other direction, so the quiet path cannot be achieved by
simply making discovery find nothing.

`StubCharacter.MeshRoot` becomes settable so a fixture can hand it a real hierarchy. It still
defaults to null, so no existing test changes behaviour.

Verified with a negative control: restoring `Log.Error` fails the severity test and only that test
(7 tests, 6 passed, 1 failed).

Full EditMode suite: **1185 tests, 1185 passed, 0 failed**, no compile errors.

## What this does not do

It does not make equipment-driven body hiding work -- that still needs split meshes that do not
exist. Discovery picks them up the moment they are authored, and the fully-split tests here cover
that path, so option 1 from the issue remains open and is now tested in advance.
