### PR TITLE
Keep an item's creation time when the save replaces its row

### DIFF
--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterItemService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterItemService.cs
@@ -596,7 +596,7 @@ namespace FishMMO.Database.Npgsql.Services
 						u.template_id,
 						u.seed,
 						u.amount,
-						{{8}},
+						u.time_created,
 						FALSE,
 						NULL
 					FROM UNNEST(
@@ -607,8 +607,9 @@ namespace FishMMO.Database.Npgsql.Services
 						{{4}}::bigint[],
 						{{5}}::integer[],
 						{{6}}::integer[],
-						{{7}}::bigint[]
-					) AS u(id, character_id, container, slot, version, template_id, seed, amount)
+						{{7}}::bigint[],
+						{{8}}::timestamp[]
+					) AS u(id, character_id, container, slot, version, template_id, seed, amount, time_created)
 					RETURNING id, container, slot";
 
 				var written = await ExecuteReturningManyAsync(

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterItemService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Character/CharacterItemService.cs
@@ -273,6 +273,31 @@ namespace FishMMO.Database.Npgsql.Services
 		}
 
 		/// <summary>
+		/// Array parameters for the replace path, carrying each row's own creation time.
+		/// </summary>
+		/// <remarks>
+		/// A row that already exists keeps the time it was created; one arriving without an
+		/// identity, or whose id no longer resolves, is new and takes the save time. Passing a
+		/// single timestamp for the whole batch is what made every item look created at the moment
+		/// of the last save.
+		/// </remarks>
+		private static object[] BuildReplaceArrayParameters(
+			IReadOnlyList<CharacterItemData> rows,
+			IReadOnlyDictionary<long, DateTime> existingCreationTimes,
+			DateTime now)
+		{
+			var parameters = BuildArrayParameters(rows, now);
+
+			parameters[8] = rows
+				.Select(i => i.ID > 0 && existingCreationTimes.TryGetValue(i.ID, out DateTime created)
+					? created
+					: now)
+				.ToArray();
+
+			return parameters;
+		}
+
+		/// <summary>
 		/// Builds the UNNEST + UPSERT statement for a batch of rows.
 		/// </summary>
 		/// <remarks>
@@ -514,6 +539,35 @@ namespace FishMMO.Database.Npgsql.Services
 				 *
 				 * Identities survive because they are supplied explicitly below. An item keeps its
 				 * id across this; only rows that never had one draw a new value. */
+				/* Creation times are read before the delete, because the delete is what would
+				 * otherwise lose them.
+				 *
+				 * This path replaces rows rather than updating them, so time_created was being
+				 * stamped with the save time on every write -- every item in a character's
+				 * inventory ended up sharing the timestamp of the last save, which is not when any
+				 * of them was created. The single-item upsert above never had this problem: it
+				 * leaves time_created out of its DO UPDATE, and so preserves it.
+				 *
+				 * Worth more than tidiness. time_created is the only record of when an item came
+				 * into existence, which is exactly what an investigation into duplicated items has
+				 * to work from -- and with every row rewritten each save, there was nothing left to
+				 * investigate. */
+				var existingCreationTimes = new Dictionary<long, DateTime>();
+				var knownIds = snapshot.Where(i => i.ID > 0).Select(i => i.ID).ToArray();
+				if (knownIds.Length > 0)
+				{
+					var existing = await ExecuteReturningManyAsync(
+						dbContext,
+						$"SELECT id, time_created FROM {TableName} WHERE id = ANY({{0}}::bigint[])",
+						new object[] { knownIds },
+						reader => new KeyValuePair<long, DateTime>(reader.GetInt64(0), reader.GetDateTime(1)),
+						cancellationToken).ConfigureAwait(false);
+
+					foreach (var pair in existing)
+					{
+						existingCreationTimes[pair.Key] = pair.Value;
+					}
+				}
 				await dbContext.Database
 					.ExecuteSqlRawAsync(
 						$"DELETE FROM {TableName} WHERE character_id = {{0}} AND container = ANY({{1}}::smallint[])",
@@ -560,7 +614,7 @@ namespace FishMMO.Database.Npgsql.Services
 				var written = await ExecuteReturningManyAsync(
 					dbContext,
 					insertSql,
-					BuildArrayParameters(snapshot, now),
+					BuildReplaceArrayParameters(snapshot, existingCreationTimes, now),
 					reader => new CharacterItemIdAssignment(
 						(ItemContainerType)reader.GetInt16(1),
 						reader.GetInt32(2),


### PR DESCRIPTION
Found while investigating #179 (items duplicating). It is not the duplication fix -- it is the
reason that bug currently cannot be investigated at all.

## What was wrong

`CharacterItemService` has two write paths, and they disagreed about what `time_created` means:

- The **single-item upsert** leaves `time_created` out of its `ON CONFLICT DO UPDATE`, so the
  original value survives. Correct.
- The **bulk replace** deletes the rows and re-inserts them, stamping every row with the save
  time.

So every item a character owns ends up sharing the timestamp of the most recent save. The column
does not record when an item was created; it records when the character last saved.

Observable on the live dev database right now. Character 18 was created at 20:13 with 7 starting
items, and today holds 8 rows -- all claiming an identical `time_created` of 21:29:06, including
one that did not exist an hour earlier:

```
 id | container | slot | template_id |        time_created
----+-----------+------+-------------+----------------------------
 16 |         1 |    1 |  -523909364 | 2026-09-01 21:29:06.397598
 ...
 25 |         0 |    0 |  1324506654 | 2026-09-01 21:29:06.397598
```

## The fix

Creation times are read before the delete, because the delete is what loses them, and each row is
inserted with its own. A row arriving without an identity, or whose id no longer resolves, is new
and takes the save time.

Scoped to the replace path; the upsert path is untouched because it was already right.

## Why it matters beyond tidiness

`time_created` is the only record of when an item came into existence, and that is precisely what
an investigation into duplicated items has to work from. With every row rewritten on each save,
there is nothing left to reconstruct -- I could not tell whether character 18's extra item was
duplicated or legitimately looted, and the data cannot answer it either way.

That is the whole reason this is a separate PR rather than part of a #179 fix: the diagnosis needs
this landed first.

## Verification

- Project builds clean (`dotnet build -c Release`), 0 errors. The one warning is pre-existing in
  `GuildService` and unrelated.
- The new statement shape was executed against the real schema to confirm a `::timestamp[]`
  unnests correctly alongside the existing arrays and each row carries its own value.

I have deliberately **not** claimed this fixes #179. It does not. It makes it diagnosable.

## Observed again, live

A later session moved the timestamp forward on rows that did not change. The same eight item ids,
same containers, same slots, same amounts -- and every `time_created` rewritten from
`21:29:06.397598` to `00:33:51.450772`, three hours later.

Nothing about those items changed. The column simply records the last save, which is the defect
stated above, now shown twice on the same rows.
