### PR TITLE
Stop reporting every token key refresh as a Warning

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/Authentication/BaseServerAuthenticator.cs
@@ -1328,6 +1328,40 @@ namespace FishMMO.Server.Implementation
 		/// The database is the ONLY source — no environment variable or .cfg file fallbacks exist.
 		/// If the database is unavailable, connection token verification will fail.
 		/// </summary>
+		/// <summary>
+		/// Whether the loaded key set differs from the one already held.
+		/// </summary>
+		/// <remarks>
+		/// Compares key identifiers only, not the secrets. A rotation issues a new key id, so the
+		/// ids are what change; comparing the bytes as well would mean touching secret material on
+		/// a timer to answer a question about logging.
+		/// </remarks>
+		/// <param name="previous">The previously held keys, or null if none were loaded yet.</param>
+		/// <param name="current">The keys just loaded.</param>
+		private static bool KeySetChanged(Dictionary<string, byte[]>? previous, Dictionary<string, byte[]> current)
+		{
+			// The first successful load is a change: nothing was held before it.
+			if (previous == null)
+			{
+				return true;
+			}
+
+			if (previous.Count != current.Count)
+			{
+				return true;
+			}
+
+			foreach (KeyValuePair<string, byte[]> entry in current)
+			{
+				if (!previous.ContainsKey(entry.Key))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		private async Task LoadConnectionTokenKeysFromDbAsync()
 		{
 			try
@@ -1370,11 +1404,33 @@ namespace FishMMO.Server.Implementation
 						}
 					}
 
+					Dictionary<string, byte[]>? previous;
 					lock (s_dbConnectionTokenKeyMapLock)
 					{
+						previous = s_dbConnectionTokenKeyMap;
 						s_dbConnectionTokenKeyMap = map;
 					}
-					await Log.Warning(LogPrefix, $"Loaded {map.Count} active connection token key(s) from database.");
+
+					/* A refresh that loads the same keys it loaded a minute ago is not news.
+					 *
+					 * This runs on the periodic loop and reported success at Warning every time, so
+					 * three roles produced better than five hundred Warnings in three hours saying
+					 * that nothing had changed -- which was most of what the server logs contained.
+					 * A level used for the routine case cannot also mean "look at this".
+					 *
+					 * The event that IS worth seeing is the key set changing, because that is a
+					 * rotation and it explains why tokens that verified a moment ago stop doing so.
+					 * That keeps a level a reader can act on; the unchanged case drops to Debug. */
+					if (KeySetChanged(previous, map))
+					{
+						await Log.Info(LogPrefix,
+							$"Connection token keys changed: now {map.Count} active key(s) " +
+							$"(was {(previous == null ? "none loaded" : previous.Count + " key(s)")}).");
+					}
+					else
+					{
+						await Log.Debug(LogPrefix, $"Connection token keys unchanged: {map.Count} active key(s).");
+					}
 				}
 				else if (result.IsSuccess)
 				{

--- a/FishMMO-Unity/Assets/UnitTests/ConnectionTokenKeyRefreshTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/ConnectionTokenKeyRefreshTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Reflection;
+using FishMMO.Server.Implementation;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the decision that stopped the connection token key refresh from reporting every
+	/// poll as a Warning.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The refresh runs on a timer and logged its success at Warning each time, so three server
+	/// roles produced better than five hundred Warnings across three hours to say that nothing had
+	/// changed. That was most of what the server logs contained. A level used for the routine case
+	/// cannot also mean "look at this", which is the same defect as the missing-health report in
+	/// #157 and the body region report in #158.
+	/// </para>
+	/// <para>
+	/// The signal that was worth keeping is a key set that actually changed, because that is a
+	/// rotation and it explains why tokens which verified a moment ago stop doing so. These tests
+	/// exist to hold that line exactly: silence when nothing moved, and a report when it did.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class ConnectionTokenKeyRefreshTests
+	{
+		/// <summary>Calls the private comparison the refresh uses to choose its log level.</summary>
+		private static bool KeySetChanged(
+			Dictionary<string, byte[]> previous,
+			Dictionary<string, byte[]> current)
+		{
+			MethodInfo method = typeof(BaseServerAuthenticator).GetMethod(
+				"KeySetChanged",
+				BindingFlags.Static | BindingFlags.NonPublic);
+
+			LogAssert.IsNotNull(method, "the refresh must still decide whether the key set changed.");
+			return (bool)method.Invoke(null, new object[] { previous, current });
+		}
+
+		private static Dictionary<string, byte[]> Keys(params string[] ids)
+		{
+			Dictionary<string, byte[]> keys = new Dictionary<string, byte[]>();
+			for (int i = 0; i < ids.Length; i++)
+			{
+				keys[ids[i]] = new byte[32];
+			}
+			return keys;
+		}
+
+		[Test]
+		public void ReloadingTheSameKeys_IsNotAChange()
+		{
+			/* The case that produced the flood. It is the normal outcome of every poll, so it has
+			 * to be the quiet one or nothing else in the log can be seen. */
+			LogAssert.IsFalse(KeySetChanged(Keys("key-a"), Keys("key-a")),
+				"a refresh that loaded the same key it already held has nothing to report");
+		}
+
+		[Test]
+		public void TheFirstLoad_IsAChange()
+		{
+			/* Nothing was held before it, and the server going from no keys to holding them is
+			 * worth one line -- it is the difference between able and unable to verify a token. */
+			LogAssert.IsTrue(KeySetChanged(null, Keys("key-a")),
+				"the first successful load must be reported");
+		}
+
+		[Test]
+		public void ARotatedKey_IsAChange()
+		{
+			/* The signal the old code buried. A rotation is exactly what explains tokens that
+			 * verified a moment ago and now do not. */
+			LogAssert.IsTrue(KeySetChanged(Keys("key-a"), Keys("key-b")),
+				"a different key id is a rotation and must be visible");
+		}
+
+		[Test]
+		public void AnAddedKey_IsAChange()
+		{
+			// Overlapping validity during a rotation: the new key appears before the old retires.
+			LogAssert.IsTrue(KeySetChanged(Keys("key-a"), Keys("key-a", "key-b")),
+				"an additional active key changes what can verify");
+		}
+
+		[Test]
+		public void ARetiredKey_IsAChange()
+		{
+			LogAssert.IsTrue(KeySetChanged(Keys("key-a", "key-b"), Keys("key-a")),
+				"a key dropping out changes what can verify");
+		}
+
+		[Test]
+		public void TheSameKeysInADifferentOrder_AreNotAChange()
+		{
+			/* Guards against comparing sequences rather than sets. The database returns rows in no
+			 * guaranteed order, so an order-sensitive comparison would call every second poll a
+			 * rotation and reintroduce the flood in a form that looks like a real signal -- which
+			 * would be worse than the original noise. */
+			LogAssert.IsFalse(KeySetChanged(Keys("key-a", "key-b"), Keys("key-b", "key-a")),
+				"key order is not meaningful and must not read as a rotation");
+		}
+
+		[Test]
+		public void ASwappedKeySet_OfTheSameSize_IsAChange()
+		{
+			/* Guards against comparing counts alone, which is the cheap implementation and would
+			 * miss the most important case: a full rotation that happens to keep the same number
+			 * of active keys. */
+			LogAssert.IsTrue(KeySetChanged(Keys("key-a", "key-b"), Keys("key-c", "key-d")),
+				"an entirely different key set is a rotation, however many keys it holds");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/ConnectionTokenKeyRefreshTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/ConnectionTokenKeyRefreshTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63c0cbd5a4fb8b840b70c405d6fc7c2a


### PR DESCRIPTION
Found while reading a live server log. The connection token key refresh runs on a timer and logged
its success at Warning every time.

Across three hours, three roles produced **527 Warnings** saying nothing had changed:

```
176  [ServerAuthenticator]       Loaded 1 active connection token key(s) from database.
176  [WorldServerAuthenticator]  Loaded 1 active connection token key(s) from database.
175  [SceneServerAuthenticator]  Loaded 1 active connection token key(s) from database.
```

That was very nearly the entire contents of the server logs. The only other entries above Debug in
the whole window were two genuine one-offs: a Linux-only hardening skip, and one stale-auth sweep
note.

A level used for the routine case cannot also mean "look at this". This is the same defect as the
missing-health report in #157 and the body region report in #158 -- a message that fires
unconditionally carries no information, and teaches people to stop reading the level it fires at.

## What changed

The event worth seeing is the key set **changing**, because that is a rotation and it is what
explains tokens that verified a moment ago and now do not. That is reported at Info, naming the
count before and after. An unchanged refresh drops to Debug.

The other three Warnings in this method are deliberately untouched -- a key too short to use, zero
active keys, and a failed fetch are all real faults that leave token verification broken.

`KeySetChanged` compares key identifiers rather than the secrets. A rotation issues a new key id,
so the ids are what change; comparing the bytes as well would mean touching secret material on a
timer to answer a question about logging.

## Tests

`ConnectionTokenKeyRefreshTests` covers silence when nothing moved, and a report for each way the
set can move: first load, rotation, an added key (overlapping validity), and a retired key.

Two of them exist specifically to catch the ways a cheap implementation goes wrong:

- **Comparing counts alone** misses a full rotation that happens to keep the same number of active
  keys -- the most important case, silently.
- **Comparing order** would call every other poll a rotation, because the database returns rows in
  no guaranteed order. That reintroduces the flood in a form that looks like a real signal, which
  is worse than the original noise.

Verified with a negative control: substituting the count-only comparison fails exactly those two
tests and nothing else.

Full EditMode suite: **1185 tests, 1185 passed, 0 failed**, no compile errors.
