### PR TITLE
Qualify last_update so the guild and party update writes can run

### DIFF
--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Guild/GuildUpdateService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Guild/GuildUpdateService.cs
@@ -53,11 +53,19 @@ namespace FishMMO.Database.Npgsql.Services
 			var now = DateTime.UtcNow;
 			var result = await ExecuteWriteAsync(async dbContext =>
 			{
+				/* The table qualifier is required, not stylistic. Inside ON CONFLICT DO UPDATE a
+				 * bare column name can mean either the existing row or the proposed one, so
+				 * Postgres refuses it outright:
+				 *
+				 *   42702: column reference "last_update" is ambiguous
+				 *
+				 * The statement never ran. It failed on every call, so the guard it implements --
+				 * do not move the timestamp backwards -- was not being applied either. */
 				var sql = $@"INSERT INTO {TableName} (guild_id, time_created, last_update)
 					VALUES ({{0}}, {{1}}, {{1}})
 					ON CONFLICT (guild_id) DO UPDATE
 					SET last_update = EXCLUDED.last_update
-					WHERE last_update < EXCLUDED.last_update";
+					WHERE {TableName}.last_update < EXCLUDED.last_update";
 
 				await dbContext.Database.ExecuteSqlRawAsync(
 					sql,

--- a/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Party/PartyUpdateService.cs
+++ b/FishMMO-Database/FishMMO-DB/Npgsql/Services/Scene/Party/PartyUpdateService.cs
@@ -53,11 +53,19 @@ namespace FishMMO.Database.Npgsql.Services
 			var now = DateTime.UtcNow;
 			var result = await ExecuteWriteAsync(async dbContext =>
 			{
+				/* The table qualifier is required, not stylistic. Inside ON CONFLICT DO UPDATE a
+				 * bare column name can mean either the existing row or the proposed one, so
+				 * Postgres refuses it outright:
+				 *
+				 *   42702: column reference "last_update" is ambiguous
+				 *
+				 * The statement never ran. It failed on every call, so the guard it implements --
+				 * do not move the timestamp backwards -- was not being applied either. */
 				var sql = $@"INSERT INTO {TableName} (party_id, time_created, last_update)
 					VALUES ({{0}}, {{1}}, {{1}})
 					ON CONFLICT (party_id) DO UPDATE
 					SET last_update = EXCLUDED.last_update
-					WHERE last_update < EXCLUDED.last_update";
+					WHERE {TableName}.last_update < EXCLUDED.last_update";
 
 				await dbContext.Database.ExecuteSqlRawAsync(
 					sql,


### PR DESCRIPTION
Found in a live server log during ordinary play.

## What was wrong

`GuildUpdateService` and `PartyUpdateService` both enqueue their update notification with an
upsert whose conflict clause compares the stored timestamp against the proposed one:

```sql
ON CONFLICT (guild_id) DO UPDATE
SET last_update = EXCLUDED.last_update
WHERE last_update < EXCLUDED.last_update
```

Inside `ON CONFLICT DO UPDATE`, a bare column name can mean either the existing row or the
proposed one, so Postgres refuses the statement outright:

```
42702: column reference "last_update" is ambiguous
```

The statement never ran. Guild update notifications failed on **every** call -- observed twice
within a minute of normal play:

```
[WARNING] [GuildSystem] PersistGuildMemberAsync guild update notification failed (GuildID=4):
          DATABASE_ERROR - 42702: column reference "last_update" is ambiguous
```

`PartyUpdateService` has the identical statement, so it fails the same way the moment anyone
forms a party. It simply had not been exercised.

## Two consequences

The obvious one: the notification row is never written, so other servers never learn the guild or
party changed.

The quieter one: the guard that `WHERE` exists to apply -- do not move the timestamp backwards --
was not being applied either, because the statement it guards never executed. Fixing the
qualification turns that guard on for the first time.

## The fix

Qualify with the table name. This is the form `CharacterItemService` already uses for the same
construction (`WHERE {TableName}.deleted = TRUE OR EXCLUDED.version > {TableName}.version`), so
it matches existing practice rather than introducing a style.

Both files get a comment explaining why the qualifier is required rather than stylistic, since it
reads like something a tidy-up would remove.

## Verification

- **Diagnosis proven, not assumed.** Both forms were run against Postgres: the shipped one
  reproduces `42702` with the identical message, and the qualified one performs the update.
- **Confirmed in the compiled assembly.** The comparison no longer appears unqualified, while the
  two unrelated fetch queries that also mention `last_update` (`WHERE last_update >= ...`) are
  untouched.
