### PR TITLE
Stop discarding a whole session of item writes after a relog

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/CharacterInventory/CharacterInventorySystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/CharacterInventory/CharacterInventorySystem.cs
@@ -248,24 +248,42 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		private sealed class ItemWriteJournal
 		{
 			private readonly object gate = new object();
-			private readonly Dictionary<long, long> nextSequence = new Dictionary<long, long>();
+			/* One counter for the journal rather than one per character.
+			 *
+			 * Per character, it had to be reset by ForgetCharacter to bound memory, and that reset
+			 * raced the very flush that triggered it: ForgetCharacter runs when the despawn flush is
+			 * CAPTURED, while the flush claims its sequence later on the worker thread. The claim
+			 * therefore landed after the forget and put the watermark back -- so the next session
+			 * started issuing sequence 1 against a watermark left by the previous one, and every
+			 * write it made was discarded as superseded by a session that had already ended.
+			 *
+			 * Observed live: an equip logged 'skipped superseded ... Seq=1' followed by 'skipped
+			 * superseded ItemSnapshot ... Seq=2', and the database kept none of it while the client
+			 * showed the item equipped.
+			 *
+			 * Sequences only ever need to be comparable within one character, so making them global
+			 * costs nothing and removes the reset entirely. ForgetCharacter still drops everything it
+			 * held for the character; there is simply no longer a counter that can go backwards. */
+			private long nextSequence;
 			private readonly Dictionary<long, long> lastAppliedAny = new Dictionary<long, long>();
 			private readonly Dictionary<long, long> lastAppliedSnapshot = new Dictionary<long, long>();
 			private readonly Dictionary<long, CharacterSessionInfo> lastKnownLease = new Dictionary<long, CharacterSessionInfo>();
 			private readonly HashSet<long> reconcileRequests = new HashSet<long>();
 
 			/// <summary>
-			/// Allocates the next capture sequence number for a character. Main thread only, which is
-			/// what makes the numbers a faithful record of the order the mutations happened in.
+			/// Allocates the next capture sequence number. Main thread only, which is what makes the
+			/// numbers a faithful record of the order the mutations happened in.
+			/// </summary>
+			/// <remarks>
+			/// Journal-wide and never reset, so a number is issued at most once for the life of the
+			/// process. Only comparisons within one character are meaningful, so the gaps another
+			/// character's writes leave in the run carry no meaning and are not a problem.
 			/// </summary>
 			public long NextSequence(long characterID)
 			{
 				lock (gate)
 				{
-					nextSequence.TryGetValue(characterID, out long current);
-					current++;
-					nextSequence[characterID] = current;
-					return current;
+					return ++nextSequence;
 				}
 			}
 
@@ -443,7 +461,6 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 			{
 				lock (gate)
 				{
-					nextSequence.Remove(characterID);
 					lastAppliedAny.Remove(characterID);
 					lastAppliedSnapshot.Remove(characterID);
 					lastKnownLease.Remove(characterID);
@@ -458,7 +475,6 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 			{
 				lock (gate)
 				{
-					nextSequence.Clear();
 					lastAppliedAny.Clear();
 					lastAppliedSnapshot.Clear();
 					lastKnownLease.Clear();
@@ -1373,12 +1389,16 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 			// sequence number and its own ownership triple — so dropping the journal entry now
 			// cannot affect it.
 			//
-			// Resetting the sequence counter here is safe ONLY because of the ownership assertion.
-			// If this character comes back to this same scene server, it comes back under a NEW
-			// session token, so any batch still in flight from the previous visit quotes a triple
-			// that no longer matches and is refused rather than applied out of order. Without that
-			// guard this reset would be a resurrection bug, which is why the two changes belong
-			// together and neither should be removed on its own.
+			// This drops the character's watermarks but NOT the capture counter, which is journal-wide
+			// and never reset. That asymmetry is deliberate and load-bearing: the flush captured just
+			// above claims its sequence later, on the worker thread, so its claim lands after this
+			// call and writes a watermark back. A counter that restarted here would then issue
+			// sequence 1 against that watermark and the whole of the next session would be discarded
+			// as superseded -- which is exactly what it did.
+			//
+			// A batch still in flight from a previous visit is refused by the ownership assertion,
+			// since the character returns under a new session token; that guard is what keeps a late
+			// arrival from being applied out of order, and it is unaffected by any of this.
 			if (character != null && character.ID > 0)
 			{
 				itemWriteJournal.ForgetCharacter(character.ID);

--- a/FishMMO-Unity/Assets/UnitTests/ItemWriteSequenceTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/ItemWriteSequenceTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Reflection;
+using FishMMO.Server.Implementation.World.SceneServer;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the capture sequence that decides whether an item write is still worth applying.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The journal skips a write that a later one has already superseded. That decision compares a
+	/// batch's capture sequence against a per-character watermark, so the two have to move together:
+	/// if sequences can restart while a watermark survives, every write in the next session is
+	/// judged superseded by a session that has already ended, and is dropped.
+	/// </para>
+	/// <para>
+	/// That is not hypothetical. It was observed live: a character equipped an item, and the server
+	/// logged
+	/// </para>
+	/// <code>
+	/// ApplyItemBatchAsync: skipped superseded EquipFromInventory (CharID=18, Seq=1, Snapshot=False)
+	/// ApplyItemBatchAsync: skipped superseded ItemSnapshot       (CharID=18, Seq=2, Snapshot=True)
+	/// </code>
+	/// <para>
+	/// Sequences 1 and 2 -- the first two of the session -- both discarded, and the database left
+	/// untouched while the client showed the item equipped. Silent divergence between server memory
+	/// and the database is the ground state that item duplication reports grow out of, because the
+	/// next write to land publishes whichever side happens to win.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class ItemWriteSequenceTests
+	{
+		private const long CharacterId = 18;
+
+		private object journal;
+		private MethodInfo nextSequence;
+		private MethodInfo shouldApply;
+		private MethodInfo tryClaimSequence;
+		private MethodInfo forgetCharacter;
+
+		[SetUp]
+		public void SetUp()
+		{
+			Type type = typeof(CharacterInventorySystem).GetNestedType(
+				"ItemWriteJournal",
+				BindingFlags.NonPublic);
+
+			LogAssert.IsNotNull(type, "the item write journal must still exist.");
+
+			journal = Activator.CreateInstance(type, nonPublic: true);
+			nextSequence = type.GetMethod("NextSequence");
+			shouldApply = type.GetMethod("ShouldApply");
+			tryClaimSequence = type.GetMethod("TryClaimSequence");
+			forgetCharacter = type.GetMethod("ForgetCharacter");
+
+			LogAssert.IsNotNull(nextSequence, "NextSequence must still exist.");
+			LogAssert.IsNotNull(shouldApply, "ShouldApply must still exist.");
+			LogAssert.IsNotNull(tryClaimSequence, "TryClaimSequence must still exist.");
+			LogAssert.IsNotNull(forgetCharacter, "ForgetCharacter must still exist.");
+		}
+
+		private long Next() => (long)nextSequence.Invoke(journal, new object[] { CharacterId });
+
+		private bool ShouldApply(long sequence, bool isSnapshot) =>
+			(bool)shouldApply.Invoke(journal, new object[] { CharacterId, sequence, isSnapshot });
+
+		private bool Claim(long sequence, bool isSnapshot) =>
+			(bool)tryClaimSequence.Invoke(journal, new object[] { CharacterId, sequence, isSnapshot });
+
+		private void Forget() => forgetCharacter.Invoke(journal, new object[] { CharacterId });
+
+		/// <summary>
+		/// Plays a session: some writes, then the despawn flush, which is captured and only
+		/// afterwards applied.
+		/// </summary>
+		/// <remarks>
+		/// The order matters and is the whole point. ForgetCharacter runs when the flush is
+		/// CAPTURED, while the flush claims its sequence later, on the worker thread -- so the claim
+		/// lands after the forget and puts the watermark back.
+		/// </remarks>
+		private void PlayASessionAndLogOut()
+		{
+			Claim(Next(), false);
+			Claim(Next(), false);
+
+			long flush = Next();
+			Forget();
+			Claim(flush, true);
+		}
+
+		[Test]
+		public void AfterALogout_TheNextSessionsFirstWriteIsStillApplied()
+		{
+			/* The live failure. Every write of the new session was discarded as superseded by a
+			 * session that had already ended, so nothing the player did was stored. */
+			PlayASessionAndLogOut();
+
+			long first = Next();
+
+			LogAssert.IsTrue(ShouldApply(first, false),
+				"the first write after logging back in must not be treated as superseded");
+		}
+
+		[Test]
+		public void AfterALogout_TheNextSessionsSnapshotIsStillApplied()
+		{
+			/* The snapshot is the repair path -- it re-states the character's items in full, so it
+			 * is what would otherwise correct a dropped incremental. Losing it too is why the
+			 * divergence persisted rather than being cleaned up by the next periodic save. */
+			PlayASessionAndLogOut();
+
+			Next();
+			long snapshot = Next();
+
+			LogAssert.IsTrue(ShouldApply(snapshot, true),
+				"the snapshot that would repair the divergence must not be dropped as well");
+		}
+
+		[Test]
+		public void AfterALogout_TheNextSessionsWriteCanActuallyClaim()
+		{
+			// ShouldApply is only the pre-filter; the binding decision is the claim.
+			PlayASessionAndLogOut();
+
+			LogAssert.IsTrue(Claim(Next(), false),
+				"the write must be able to claim its sequence, not merely pass the pre-filter");
+		}
+
+		[Test]
+		public void ASequenceIsNeverReissuedAfterALogout()
+		{
+			/* The root cause stated directly. A number that has already been used as a watermark
+			 * must never be handed out again, or the comparison is meaningless. */
+			PlayASessionAndLogOut();
+
+			long reissued = Next();
+
+			LogAssert.IsTrue(reissued > 3,
+				$"sequence {reissued} was already used before the logout and must not be reissued");
+		}
+
+		// --- What the journal is FOR must keep working ----------------------------------------
+
+		[Test]
+		public void ASupersededSnapshotIsStillSkipped()
+		{
+			/* The guard's real job. A snapshot prunes and upserts ungated, so one that lands after a
+			 * newer incremental would delete the row that incremental wrote. */
+			long stale = Next();
+			long newer = Next();
+			Claim(newer, false);
+
+			LogAssert.IsFalse(ShouldApply(stale, true),
+				"a snapshot older than an applied write must still be skipped");
+		}
+
+		[Test]
+		public void AnIncrementalIsSkippedOnlyByALaterSnapshot()
+		{
+			/* Two incrementals can touch different slots, so one must not be dropped merely because
+			 * the other landed first -- that would lose a delete and resurrect an item. */
+			long first = Next();
+			long second = Next();
+			Claim(second, false);
+
+			LogAssert.IsTrue(ShouldApply(first, false),
+				"an earlier incremental is not superseded by a later incremental");
+
+			long snapshot = Next();
+			Claim(snapshot, true);
+
+			LogAssert.IsFalse(ShouldApply(first, false),
+				"but a later snapshot does supersede it");
+		}
+
+		[Test]
+		public void WithinOneSession_SequencesStillIncrease()
+		{
+			LogAssert.IsTrue(Next() < Next(), "capture order must remain observable");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/ItemWriteSequenceTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/ItemWriteSequenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6b477d7804f5294080a5d778a0b1b21


### PR DESCRIPTION
Found by testing #179 directly. Very likely a large part of it.

## What happened

Dragging an item onto an equipment slot changed nothing in the database, while the client showed
the item equipped. The server had logged:

```
skipped superseded EquipFromInventory (CharID=18, Seq=1, Snapshot=False)
skipped superseded ItemSnapshot       (CharID=18, Seq=2, Snapshot=True)
```

Sequences **1 and 2** -- the first two of the session -- both discarded as superseded.

## Why

The journal skips a batch that a later one has superseded, comparing the batch's capture sequence
against a per-character watermark. The sequence counter was per-character too, and
`ForgetCharacter` reset it on despawn to bound memory.

That reset races the flush that triggers it. `ForgetCharacter` runs when the despawn flush is
**captured**, while the flush claims its sequence later on the worker thread -- so the claim lands
*after* the forget and writes the watermark back. The next session then issues sequence 1 against
a watermark left by the previous one, and every write it makes is judged superseded by a session
that has already ended.

The snapshot being dropped too is why nothing repaired it: the snapshot is the path that re-states
the character's items in full, so it is exactly what would otherwise have corrected the divergence
on the next periodic save.

## Why this matters for #179

Server memory and the database silently disagreeing is the ground state that duplication grows out
of. The client is told one thing, the database holds another, and the next write to land publishes
whichever side wins. It also explains the `UNIQUE_VIOLATION` rollbacks seen earlier on
`EquipFromInventory`: writes that collide on `(character_id, container, slot)` are what you get
once the two sides have drifted apart.

I am not claiming this closes #179 -- I have not reproduced a duplicate from this specific path.
It is a confirmed, reproducible mechanism for losing item writes entirely, which is worth fixing
on its own merits.

## The fix

The counter is journal-wide and never reset, so a number is issued at most once per process. Only
comparisons within one character are meaningful, so the gaps other characters leave in the run
carry no meaning. `ForgetCharacter` still drops everything it held for the character -- there is
simply no longer a counter that can go backwards.

The comment at the despawn site claimed the reset was safe because of the ownership assertion.
That assertion does protect against a *stale* batch from a previous visit, but the batch that
re-populates the watermark here is the current session's own legitimate flush, which passes
ownership. The comment is corrected rather than left to mislead the next reader.

## Tests

`ItemWriteSequenceTests` was written **before** the fix and failed against the old code on exactly
this -- four failures, including:

```
sequence 1 was already used before the logout and must not be reissued
```

Three of the seven cover what the journal is *for*: a superseded snapshot is still skipped, an
incremental is skipped only by a later snapshot (never merely by a later incremental, which would
lose a delete), and capture order stays observable. Those passed **both before and after**, so the
guard has been fixed rather than weakened into silence -- which is the obvious way to make this
symptom disappear while making things worse.

Full EditMode suite: **1185 tests, 1185 passed, 0 failed**.

## Correction: how much is lost, precisely

An earlier draft of this said every write of the next session is discarded. That overstates it, and
the real shape is worth being exact about.

The stale watermark is the last sequence the previous session used. The new session starts at 1,
so its writes are dropped until the counter climbs back past that number -- **the next session
loses roughly as many writes as the previous one made**, and only then starts persisting normally.

That matches what was observed: the drag was dropped at sequences 1 and 2, and the same change
reached the database later in the session once the counter had caught up.

So the damage is bounded but scales with how long the previous session was, and the window is
exactly the period right after logging in -- when a player is most likely to equip and rearrange
things. During that window the client and the database disagree, which is the condition that makes
a duplicate visible.
