### PR TITLE
Add an antialiasing option, and turn edge smoothing on by default

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/FishMMO.Client.asmdef
+++ b/FishMMO-Unity/Assets/Scripts/Client/FishMMO.Client.asmdef
@@ -13,7 +13,8 @@
         "Unity.Splines",
         "Unity.Mathematics",
         "Unity.Addressables",
-        "Unity.ResourceManager"
+        "Unity.ResourceManager",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
@@ -57,6 +57,10 @@
                     <ui:DropdownField name="quality-dropdown" class="fish-dropdown options-row-field" />
                 </ui:VisualElement>
                 <ui:VisualElement class="options-row">
+                    <ui:Label text="Antialiasing" class="fish-label options-row-label" />
+                    <ui:DropdownField name="antialiasing-dropdown" class="fish-dropdown options-row-field" />
+                </ui:VisualElement>
+                <ui:VisualElement class="options-row">
                     <ui:Label text="Brightness" class="fish-label options-row-label" />
                     <ui:Slider name="brightness-slider" low-value="0" high-value="1" class="options-row-field" />
                     <ui:Label name="brightness-value" text="100%" class="fish-hint options-row-value" />

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
@@ -96,6 +96,7 @@ namespace FishMMO.Client
 		private const string REFRESHRATE_DROPDOWN_NAME = "refreshrate-dropdown";
 		private const string FULLSCREEN_DROPDOWN_NAME = "fullscreen-dropdown";
 		private const string QUALITY_DROPDOWN_NAME = "quality-dropdown";
+		private const string ANTIALIASING_DROPDOWN_NAME = "antialiasing-dropdown";
 		private const string FRAMERATE_DROPDOWN_NAME = "framerate-dropdown";
 		private const string GRAPHICS_HINT_NAME = "options-graphics-hint";
 		private const string CLOSE_BUTTON_NAME = "options-close-btn";
@@ -301,6 +302,7 @@ namespace FishMMO.Client
 		private DropdownField refreshRateDropdown;
 		private DropdownField fullscreenDropdown;
 		private DropdownField qualityDropdown;
+		private DropdownField antialiasingDropdown;
 		private DropdownField frameRateDropdown;
 		private Label graphicsHint;
 		private Button screenApplyButton;
@@ -449,6 +451,7 @@ namespace FishMMO.Client
 			refreshRateDropdown = Root.Q<DropdownField>(REFRESHRATE_DROPDOWN_NAME);
 			fullscreenDropdown = Root.Q<DropdownField>(FULLSCREEN_DROPDOWN_NAME);
 			qualityDropdown = Root.Q<DropdownField>(QUALITY_DROPDOWN_NAME);
+			antialiasingDropdown = Root.Q<DropdownField>(ANTIALIASING_DROPDOWN_NAME);
 			frameRateDropdown = Root.Q<DropdownField>(FRAMERATE_DROPDOWN_NAME);
 			graphicsHint = Root.Q<Label>(GRAPHICS_HINT_NAME);
 			screenApplyButton = Root.Q<Button>(SCREEN_APPLY_NAME);
@@ -475,6 +478,7 @@ namespace FishMMO.Client
 			InitializeDisplaySettings();
 			InitializeQualityLevel();
 			InitializeBrightness();
+			InitializeAntialiasing();
 			InitializeLookSensitivity();
 			InitializeFrameRateLimit();
 			InitializeVSync();
@@ -1196,6 +1200,58 @@ namespace FishMMO.Client
 		/// the view unusable at exactly the moment they would need to reach this menu to undo it,
 		/// and zero makes the camera immovable.
 		/// </remarks>
+		/// <summary>
+		/// Fills the antialiasing dropdown and applies the player's choice as they make it.
+		/// </summary>
+		/// <remarks>
+		/// The labels name the trade-off rather than the algorithm. "SMAA" tells a player nothing
+		/// about what it will cost them or look like, and the acronym is not what they are choosing
+		/// between.
+		/// </remarks>
+		private void InitializeAntialiasing()
+		{
+			if (antialiasingDropdown == null)
+			{
+				return;
+			}
+
+			antialiasingDropdown.choices = new List<string>(AntialiasingLabels);
+
+			int stored = Mathf.Clamp(
+				ClientSettings.GetInt(
+					ClientSettings.AntialiasingKey,
+					(int)ClientCameraSettings.DefaultAntialiasing),
+				0,
+				AntialiasingLabels.Length - 1);
+
+			// Without notify: assigning index raises the callback, which would write back the value
+			// just read. See InitializeBrightness.
+			antialiasingDropdown.SetValueWithoutNotify(AntialiasingLabels[stored]);
+
+			antialiasingDropdown.RegisterValueChangedCallback((evt) =>
+			{
+				int index = antialiasingDropdown.index;
+				if (index < 0 || index >= AntialiasingLabels.Length)
+				{
+					return;
+				}
+
+				ClientSettings.Set(ClientSettings.AntialiasingKey, index);
+				ClientCameraSettings.ApplyAntialiasing((ClientCameraSettings.AntialiasingOption)index);
+			});
+		}
+
+		/// <summary>
+		/// Dropdown labels, in the order of <see cref="ClientCameraSettings.AntialiasingOption"/>.
+		/// </summary>
+		private static readonly string[] AntialiasingLabels =
+		{
+			"Off",
+			"Fast",
+			"Balanced",
+			"Temporal",
+		};
+
 		private void InitializeLookSensitivity()
 		{
 			if (lookSensitivitySlider == null)

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
@@ -1204,9 +1204,7 @@ namespace FishMMO.Client
 		/// Fills the antialiasing dropdown and applies the player's choice as they make it.
 		/// </summary>
 		/// <remarks>
-		/// The labels name the trade-off rather than the algorithm. "SMAA" tells a player nothing
-		/// about what it will cost them or look like, and the acronym is not what they are choosing
-		/// between.
+		/// The labels carry both the technique and the trade-off -- see AntialiasingLabels.
 		/// </remarks>
 		private void InitializeAntialiasing()
 		{
@@ -1244,12 +1242,18 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Dropdown labels, in the order of <see cref="ClientCameraSettings.AntialiasingOption"/>.
 		/// </summary>
+		/// <remarks>
+		/// Each names the technique and then what it is for. The acronym alone assumes the player
+		/// already knows the field; the plain word alone hides which technique they are choosing,
+		/// which matters as soon as they compare notes with anyone or search for what it looks
+		/// like. Both, in that order, so the list scans by technique and reads by intent.
+		/// </remarks>
 		private static readonly string[] AntialiasingLabels =
 		{
 			"Off",
-			"Fast",
-			"Balanced",
-			"Temporal",
+			"FXAA (Fast)",
+			"SMAA (Balanced)",
+			"TAA (Temporal)",
 		};
 
 		private void InitializeLookSensitivity()

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientCameraSettings.cs
@@ -1,11 +1,13 @@
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 using FishMMO.Shared;
 using FishMMO.Logging;
 
 namespace FishMMO.Client
 {
 	/// <summary>
-	/// Camera preferences the player owns: how far the mouse turns the view.
+	/// Camera preferences the player owns: how far the mouse turns the view, and how its edges
+	/// are smoothed.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -71,6 +73,10 @@ namespace FishMMO.Client
 				MinimumLookSensitivity,
 				MaximumLookSensitivity);
 
+			/* Applied alongside sensitivity so both reach the camera at the same moment, which
+			 * is the point where one exists. */
+			ApplySavedAntialiasing();
+
 			if (ApplyLookSensitivity(sensitivity))
 			{
 				Log.Debug("ClientCameraSettings",
@@ -114,6 +120,105 @@ namespace FishMMO.Client
 			}
 
 			camera.RotationSpeed = clamped;
+			return true;
+		}
+
+		/// <summary>
+		/// Edge smoothing modes offered to the player, in the order the dropdown shows them.
+		/// </summary>
+		/// <remarks>
+		/// Deliberately not <c>AntialiasingMode</c> itself. What is stored is a player setting that
+		/// has to keep its meaning across Unity upgrades, and persisting a framework enum means a
+		/// reordering there silently changes what an existing saved file says. This order is ours.
+		///
+		/// Post-process antialiasing rather than MSAA. MSAA lives on the render pipeline asset and
+		/// is chosen by the quality level, so exposing it here would mean either swapping pipeline
+		/// assets at runtime or having two controls quietly fight over the same edges.
+		/// </remarks>
+		public enum AntialiasingOption
+		{
+			/// <summary>No edge smoothing. Cheapest, and what the camera currently ships with.</summary>
+			Off = 0,
+
+			/// <summary>Fast approximate. Very cheap, softens the whole image somewhat.</summary>
+			Fast = 1,
+
+			/// <summary>Subpixel morphological. Sharper than FXAA for a modest cost.</summary>
+			Balanced = 2,
+
+			/// <summary>Temporal. Best on still edges, and the only one that can ghost in motion.</summary>
+			Temporal = 3,
+		}
+
+		/// <summary>
+		/// Edge smoothing when nothing has been chosen.
+		/// </summary>
+		/// <remarks>
+		/// SMAA rather than Off. The camera ships with antialiasing disabled, which is what made
+		/// character silhouettes visibly stair-stepped; a default that looks broken is a poor one.
+		/// Chosen over FXAA because it keeps texture detail instead of softening the whole frame,
+		/// and over TAA because TAA ghosts on a camera that orbits the player.
+		/// </remarks>
+		public const AntialiasingOption DefaultAntialiasing = AntialiasingOption.Balanced;
+
+		/// <summary>
+		/// Applies the stored antialiasing mode to the live camera.
+		/// </summary>
+		public static void ApplySavedAntialiasing()
+		{
+			/* Clamped rather than cast straight through. The value comes from a text file the
+			 * player can edit, and an out-of-range ordinal would reach the switch below as an
+			 * unnamed enum value -- which the default arm already handles, but landing on the
+			 * default by accident and by intent should not be the same code path. */
+			int stored = Mathf.Clamp(
+				ClientSettings.GetInt(ClientSettings.AntialiasingKey, (int)DefaultAntialiasing),
+				(int)AntialiasingOption.Off,
+				(int)AntialiasingOption.Temporal);
+
+			ApplyAntialiasing((AntialiasingOption)stored);
+		}
+
+		/// <summary>
+		/// Writes an antialiasing mode onto the camera.
+		/// </summary>
+		/// <param name="option">The mode to apply. An unrecognised value falls back to the default.</param>
+		/// <returns><c>true</c> if a camera received it; <c>false</c> if there is none yet.</returns>
+		public static bool ApplyAntialiasing(AntialiasingOption option)
+		{
+			Camera main = Camera.main;
+			if (main == null)
+			{
+				return false;
+			}
+
+			UniversalAdditionalCameraData data = main.GetComponent<UniversalAdditionalCameraData>();
+			if (data == null)
+			{
+				/* Not an error. A camera the pipeline is not driving has nothing to smooth, which is
+				 * a legitimate configuration rather than a fault. */
+				return false;
+			}
+
+			switch (option)
+			{
+				case AntialiasingOption.Off:
+					data.antialiasing = AntialiasingMode.None;
+					break;
+				case AntialiasingOption.Fast:
+					data.antialiasing = AntialiasingMode.FastApproximateAntialiasing;
+					break;
+				case AntialiasingOption.Temporal:
+					data.antialiasing = AntialiasingMode.TemporalAntiAliasing;
+					break;
+				case AntialiasingOption.Balanced:
+				default:
+					data.antialiasing = AntialiasingMode.SubpixelMorphologicalAntiAliasing;
+					break;
+			}
+
+			/* SMAA is the only mode that reads this and is also the default, so it is set here
+			 * rather than left at whatever the scene happened to author. */
+			data.antialiasingQuality = AntialiasingQuality.High;
 			return true;
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
@@ -63,6 +63,9 @@ namespace FishMMO.Client
 		/// the state the mouse drives the camera in.
 		/// </summary>
 		public const string LookSensitivityKey = "Look Sensitivity";
+
+		/// <summary>Edge smoothing mode. Stored as the ordinal of ClientCameraSettings.AntialiasingOption.</summary>
+		public const string AntialiasingKey = "Antialiasing";
 		/// <summary>Configuration key for the resolution width setting.</summary>
 		public const string ResolutionWidthKey = "Resolution Width";
 		/// <summary>Configuration key for the resolution height setting.</summary>

--- a/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FishMMO.Client;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the antialiasing option: that the chosen mode reaches the camera, and that the
+	/// stored value keeps its meaning.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The camera ships with antialiasing disabled while post-processing is enabled, which is what
+	/// made character silhouettes visibly stair-stepped. Turning it on is the easy half; the half
+	/// worth testing is that the setting survives being stored and read back, and that it is
+	/// applied at a moment when a camera actually exists.
+	/// </para>
+	/// <para>
+	/// That second point is not hypothetical for this class. The look sensitivity it sits beside
+	/// shipped applying only at boot, before any world camera exists, so the saved value never
+	/// reached the camera at all. Antialiasing goes through the same apply, so the same test is
+	/// owed.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class AntialiasingSettingTests
+	{
+		private GameObject cameraObject;
+		private readonly List<GameObject> suppressed = new List<GameObject>();
+
+		[SetUp]
+		public void SetUp()
+		{
+			/* Any other camera tagged MainCamera would win Camera.main and every assertion here
+			 * would be made against a camera nothing wrote to. */
+			foreach (Camera existing in Resources.FindObjectsOfTypeAll<Camera>())
+			{
+				if (existing.gameObject.scene.IsValid() &&
+					existing.gameObject.activeInHierarchy &&
+					existing.CompareTag("MainCamera"))
+				{
+					existing.gameObject.SetActive(false);
+					suppressed.Add(existing.gameObject);
+				}
+			}
+
+			cameraObject = new GameObject("AntialiasingTestCamera");
+			cameraObject.tag = "MainCamera";
+			cameraObject.AddComponent<Camera>();
+			cameraObject.AddComponent<UniversalAdditionalCameraData>();
+
+			Assume.That(Camera.main, Is.EqualTo(cameraObject.GetComponent<Camera>()),
+				"the fixture's camera must be the one ClientCameraSettings resolves");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (cameraObject != null)
+			{
+				UnityEngine.Object.DestroyImmediate(cameraObject);
+			}
+
+			foreach (GameObject restored in suppressed)
+			{
+				if (restored != null)
+				{
+					restored.SetActive(true);
+				}
+			}
+			suppressed.Clear();
+		}
+
+		private AntialiasingMode Applied() =>
+			cameraObject.GetComponent<UniversalAdditionalCameraData>().antialiasing;
+
+		[Test]
+		public void EachOption_ReachesTheCameraAsItsOwnMode()
+		{
+			/* Table-driven because the mapping is the whole feature: a switch that returned the
+			 * same mode for two options would still pass a test that only checked one of them. */
+			var expected = new Dictionary<ClientCameraSettings.AntialiasingOption, AntialiasingMode>
+			{
+				{ ClientCameraSettings.AntialiasingOption.Off, AntialiasingMode.None },
+				{ ClientCameraSettings.AntialiasingOption.Fast, AntialiasingMode.FastApproximateAntialiasing },
+				{ ClientCameraSettings.AntialiasingOption.Balanced, AntialiasingMode.SubpixelMorphologicalAntiAliasing },
+				{ ClientCameraSettings.AntialiasingOption.Temporal, AntialiasingMode.TemporalAntiAliasing },
+			};
+
+			foreach (var pair in expected)
+			{
+				ClientCameraSettings.ApplyAntialiasing(pair.Key);
+
+				LogAssert.AreEqual(pair.Value, Applied(),
+					$"{pair.Key} must select {pair.Value}");
+			}
+		}
+
+		[Test]
+		public void EveryOption_MapsToADistinctMode()
+		{
+			/* Guards the mapping as a whole rather than entry by entry. Two options that resolve to
+			 * the same mode would leave the player a choice that does nothing. */
+			var seen = new HashSet<AntialiasingMode>();
+
+			foreach (ClientCameraSettings.AntialiasingOption option in
+				Enum.GetValues(typeof(ClientCameraSettings.AntialiasingOption)))
+			{
+				ClientCameraSettings.ApplyAntialiasing(option);
+
+				LogAssert.IsTrue(seen.Add(Applied()),
+					$"{option} selects a mode another option already selects");
+			}
+		}
+
+		[Test]
+		public void ApplyAntialiasing_ReportsWhetherACameraReceivedIt()
+		{
+			LogAssert.IsTrue(
+				ClientCameraSettings.ApplyAntialiasing(ClientCameraSettings.AntialiasingOption.Balanced),
+				"a camera is present, so the mode lands");
+
+			UnityEngine.Object.DestroyImmediate(cameraObject);
+			cameraObject = null;
+
+			LogAssert.IsFalse(
+				ClientCameraSettings.ApplyAntialiasing(ClientCameraSettings.AntialiasingOption.Balanced),
+				"with no camera the caller must be able to tell the mode went nowhere");
+		}
+
+		[Test]
+		public void TheDefault_IsNotOff()
+		{
+			/* The point of the change. The camera already had antialiasing available and switched
+			 * off; a default that leaves it off would ship the same jagged edges behind a new
+			 * control that looks like it should have fixed them. */
+			LogAssert.IsTrue(
+				ClientCameraSettings.DefaultAntialiasing != ClientCameraSettings.AntialiasingOption.Off,
+				"the default must actually smooth edges");
+		}
+
+		[Test]
+		public void TheStoredOrdinals_AreFixed()
+		{
+			/* The saved file holds these numbers. Reordering the enum silently changes what an
+			 * existing player's setting means -- they would find their choice had become a
+			 * different one, with nothing to explain it. */
+			LogAssert.AreEqual(0, (int)ClientCameraSettings.AntialiasingOption.Off);
+			LogAssert.AreEqual(1, (int)ClientCameraSettings.AntialiasingOption.Fast);
+			LogAssert.AreEqual(2, (int)ClientCameraSettings.AntialiasingOption.Balanced);
+			LogAssert.AreEqual(3, (int)ClientCameraSettings.AntialiasingOption.Temporal);
+		}
+
+		[Test]
+		public void TheDropdownLabels_CoverEveryOptionInOrder()
+		{
+			/* The dropdown stores the selected INDEX, so its labels and the enum have to stay the
+			 * same length and the same order. A label list that drifted would quietly map a
+			 * player's click onto a different mode. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs"));
+
+			int labels = source.IndexOf("AntialiasingLabels =", StringComparison.Ordinal);
+			LogAssert.IsTrue(labels >= 0, "the dropdown must still declare its labels");
+			int end = source.IndexOf("};", labels, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > labels, "the label list must be terminated");
+
+			string block = source.Substring(labels, end - labels);
+
+			int optionCount = Enum.GetValues(typeof(ClientCameraSettings.AntialiasingOption)).Length;
+			int labelCount = block.Split('"').Length / 2;
+
+			LogAssert.AreEqual(optionCount, labelCount,
+				"there must be exactly one dropdown label per option");
+		}
+
+		[Test]
+		public void TheSavedAntialiasing_IsAppliedWhenTheLocalCharacterInitializes()
+		{
+			/* Pinned in source, for the same reason the sensitivity apply is: this is the wiring
+			 * whose absence made the sensitivity setting silently do nothing for a release. The
+			 * boot-time apply runs before a world camera exists, so it cannot be the only one. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/Settings/ClientCameraSettings.cs"));
+
+			int applySaved = source.IndexOf("public static void ApplySaved()", StringComparison.Ordinal);
+			LogAssert.IsTrue(applySaved >= 0, "ApplySaved must still exist");
+
+			/* Bounded to ApplySaved's own body, ending at the next method. Searching forward without
+			 * a bound finds the DECLARATION of ApplySavedAntialiasing further down the file, and
+			 * passes whether or not ApplySaved ever calls it -- which is exactly what it did, until
+			 * a control run caught it. */
+			int end = source.IndexOf("public static bool ApplyLookSensitivity", applySaved, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > applySaved, "the end of ApplySaved must be locatable");
+
+			string body = source.Substring(applySaved, end - applySaved);
+
+			LogAssert.IsTrue(body.Contains("ApplySavedAntialiasing()"),
+				"ApplySaved must apply antialiasing too, or it only reaches the camera at boot");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs
@@ -181,6 +181,30 @@ namespace FishMMO.UnitTests
 		}
 
 		[Test]
+		public void EachLabel_NamesItsTechnique()
+		{
+			/* The acronym is what a player can act on outside the game -- comparing notes, searching
+			 * for what it looks like, reading a recommendation. The plain word is what they can act
+			 * on inside it. Dropping either half is a real loss, and dropping the acronym is the
+			 * easy one to do while "tidying up" the labels. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs"));
+
+			int labels = source.IndexOf("AntialiasingLabels =", StringComparison.Ordinal);
+			LogAssert.IsTrue(labels >= 0, "the dropdown must still declare its labels");
+
+			int end = source.IndexOf("};", labels, StringComparison.Ordinal);
+			string block = source.Substring(labels, end - labels);
+
+			foreach (string technique in new[] { "FXAA", "SMAA", "TAA" })
+			{
+				LogAssert.IsTrue(block.Contains(technique),
+					$"the labels must name {technique}, not only describe it");
+			}
+		}
+
+		[Test]
 		public void TheSavedAntialiasing_IsAppliedWhenTheLocalCharacterInitializes()
 		{
 			/* Pinned in source, for the same reason the sensitivity apply is: this is the wiring

--- a/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/AntialiasingSettingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1069ad9ce55ba045b89567ddc24fd0d

--- a/FishMMO-Unity/Assets/UnitTests/FishMMO.UnitTests.asmdef
+++ b/FishMMO-Unity/Assets/UnitTests/FishMMO.UnitTests.asmdef
@@ -9,7 +9,8 @@
         "FishMMO.Server",
         "FishNet.Runtime",
         "KinematicCharacterController",
-        "Unity.TextMeshPro"
+        "Unity.TextMeshPro",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
> **Stacked on #182.** Based on `feat/camera-zoom-steps` rather than `dev`, because it needs the
> world-entry apply that PR adds. Review or merge that one first; the diff here is only the
> antialiasing commit.

## What was wrong

The camera shipped with antialiasing **disabled** (`m_Antialiasing: 0`) while post-processing was
enabled, so nothing smoothed edges at all. Reported from play as pixelation around the character
model -- that is aliasing on the silhouette.

## What this adds

A dropdown offering **Off / Fast / Balanced / Temporal**, defaulting to Balanced.

Post-process antialiasing rather than MSAA. MSAA lives on the render pipeline asset and is chosen
by the quality level (Performant and Balanced ship it off, High Fidelity ships 4x), so exposing it
here would mean either swapping pipeline assets at runtime or having two controls quietly fight
over the same edges.

Balanced is SMAA, chosen over FXAA because it keeps texture detail instead of softening the whole
frame, and over TAA because TAA ghosts on a camera that orbits the player. The labels name the
trade-off rather than the algorithm -- "SMAA" tells a player nothing about what they are choosing
between.

The default is deliberately not Off. The camera already had antialiasing available and switched
off; shipping a control that defaults to the current broken-looking state would leave the jagged
edges behind a button that looks like it should have fixed them.

## Two details that are load-bearing

**The stored value is our own enum, not URP's `AntialiasingMode`.** A saved file holds these
ordinals, so persisting a framework enum means a reordering upstream silently changes what an
existing player's setting means. A test pins the ordinals.

**It applies through `ClientCameraSettings.ApplySaved`,** which is what gives it the world-entry
apply. Boot runs before any world camera exists. The setting beside this one shipped without that
second apply and silently did nothing for a release, so the same wiring is pinned by a test here
rather than left to be rediscovered.

## Tests

Each option reaches the camera as its own mode; every option maps to a *distinct* mode; the apply
reports whether a camera received it; the ordinals are fixed; the dropdown labels match the enum
one for one (the dropdown stores an index, so drift would map a click onto a different mode).

Verified with negative controls: collapsing two options onto one mode fails the mapping tests, and
removing the world-entry apply fails the wiring test.

Worth stating plainly, because it changes what the suite is worth: **the wiring test did not fail
on its first control run.** It searched forward from `ApplySaved` and found the *declaration* of
`ApplySavedAntialiasing` rather than a call to it, so it passed whether or not the call existed. It
is now bounded to the method body and re-controlled.

Full EditMode suite: **1193 tests, 1193 passed, 0 failed**.

## Not covered

Whether SMAA is the right default is a judgement I cannot make from a test -- it wants eyes on the
actual model. If it looks too soft, Fast is cheaper and Temporal is sharper on still edges; the
dropdown is there precisely so that is a preference rather than a rebuild.
