### PR TITLE
Add a texture filtering option

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
@@ -57,6 +57,10 @@
                     <ui:DropdownField name="quality-dropdown" class="fish-dropdown options-row-field" />
                 </ui:VisualElement>
                 <ui:VisualElement class="options-row">
+                    <ui:Label text="Texture Filtering" class="fish-label options-row-label" />
+                    <ui:DropdownField name="anisotropic-dropdown" class="fish-dropdown options-row-field" />
+                </ui:VisualElement>
+                <ui:VisualElement class="options-row">
                     <ui:Label text="Brightness" class="fish-label options-row-label" />
                     <ui:Slider name="brightness-slider" low-value="0" high-value="1" class="options-row-field" />
                     <ui:Label name="brightness-value" text="100%" class="fish-hint options-row-value" />

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
@@ -96,6 +96,7 @@ namespace FishMMO.Client
 		private const string REFRESHRATE_DROPDOWN_NAME = "refreshrate-dropdown";
 		private const string FULLSCREEN_DROPDOWN_NAME = "fullscreen-dropdown";
 		private const string QUALITY_DROPDOWN_NAME = "quality-dropdown";
+		private const string ANISOTROPIC_DROPDOWN_NAME = "anisotropic-dropdown";
 		private const string FRAMERATE_DROPDOWN_NAME = "framerate-dropdown";
 		private const string GRAPHICS_HINT_NAME = "options-graphics-hint";
 		private const string CLOSE_BUTTON_NAME = "options-close-btn";
@@ -301,6 +302,7 @@ namespace FishMMO.Client
 		private DropdownField refreshRateDropdown;
 		private DropdownField fullscreenDropdown;
 		private DropdownField qualityDropdown;
+		private DropdownField anisotropicDropdown;
 		private DropdownField frameRateDropdown;
 		private Label graphicsHint;
 		private Button screenApplyButton;
@@ -449,6 +451,7 @@ namespace FishMMO.Client
 			refreshRateDropdown = Root.Q<DropdownField>(REFRESHRATE_DROPDOWN_NAME);
 			fullscreenDropdown = Root.Q<DropdownField>(FULLSCREEN_DROPDOWN_NAME);
 			qualityDropdown = Root.Q<DropdownField>(QUALITY_DROPDOWN_NAME);
+			anisotropicDropdown = Root.Q<DropdownField>(ANISOTROPIC_DROPDOWN_NAME);
 			frameRateDropdown = Root.Q<DropdownField>(FRAMERATE_DROPDOWN_NAME);
 			graphicsHint = Root.Q<Label>(GRAPHICS_HINT_NAME);
 			screenApplyButton = Root.Q<Button>(SCREEN_APPLY_NAME);
@@ -474,6 +477,7 @@ namespace FishMMO.Client
 
 			InitializeDisplaySettings();
 			InitializeQualityLevel();
+			InitializeAnisotropicFiltering();
 			InitializeBrightness();
 			InitializeLookSensitivity();
 			InitializeFrameRateLimit();
@@ -1099,6 +1103,58 @@ namespace FishMMO.Client
 		/// looks like the setting having been forgotten, except the player is now running at a
 		/// quality they did not choose.
 		/// </remarks>
+		/// <summary>
+		/// Fills the texture filtering dropdown and applies the player's choice as they make it.
+		/// </summary>
+		private void InitializeAnisotropicFiltering()
+		{
+			if (anisotropicDropdown == null)
+			{
+				return;
+			}
+
+			anisotropicDropdown.choices = new List<string>(AnisotropicLabels);
+
+			int stored = Mathf.Clamp(
+				ClientSettings.GetInt(
+					ClientSettings.AnisotropicFilteringKey,
+					(int)ClientDisplaySettings.DefaultAnisotropicFiltering),
+				0,
+				AnisotropicLabels.Length - 1);
+
+			// Without notify: assigning value raises the callback, which would write back what was
+			// just read. See InitializeBrightness.
+			anisotropicDropdown.SetValueWithoutNotify(AnisotropicLabels[stored]);
+
+			anisotropicDropdown.RegisterValueChangedCallback((evt) =>
+			{
+				int index = anisotropicDropdown.index;
+				if (index < 0 || index >= AnisotropicLabels.Length)
+				{
+					return;
+				}
+
+				ClientSettings.Set(ClientSettings.AnisotropicFilteringKey, index);
+				ClientDisplaySettings.ApplyAnisotropicFiltering(
+					(ClientDisplaySettings.AnisotropicOption)index);
+			});
+		}
+
+		/// <summary>
+		/// Dropdown labels, in the order of <see cref="ClientDisplaySettings.AnisotropicOption"/>.
+		/// </summary>
+		/// <remarks>
+		/// Named for what they do to the picture rather than for the API. "Per Texture" is the
+		/// authored intent and an honest description of Unity's Enable mode, which does not force
+		/// anything -- calling it "On" would promise more than it delivers.
+		/// </remarks>
+		private static readonly string[] AnisotropicLabels =
+		{
+			"Off",
+			"Per Texture",
+			"Forced",
+		};
+
 		private void InitializeQualityLevel()
 		{
 			if (qualityDropdown == null)

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientDisplaySettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientDisplaySettings.cs
@@ -80,6 +80,7 @@ namespace FishMMO.Client
 			ApplySavedQualityLevel();
 			ApplySavedDisplayMode();
 			ApplySavedVSync();
+			ApplySavedAnisotropicFiltering();
 			ApplySavedFrameRate();
 			ApplySavedBrightness();
 			InstallSceneHook();
@@ -167,6 +168,73 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>Applies the saved VSync preference.</summary>
+		/// <summary>
+		/// Texture filtering modes offered to the player, in the order the dropdown shows them.
+		/// </summary>
+		/// <remarks>
+		/// Our own enum rather than Unity's <see cref="AnisotropicFiltering"/>, for the same reason
+		/// the antialiasing setting keeps its own: the stored value is an ordinal in a save file,
+		/// and persisting a framework enum means a reordering upstream silently changes what an
+		/// existing player's setting means.
+		/// </remarks>
+		public enum AnisotropicOption
+		{
+			/// <summary>No anisotropic filtering. Ground textures blur at glancing angles.</summary>
+			Off = 0,
+
+			/// <summary>Whatever level each texture was imported with. The authored intent.</summary>
+			PerTexture = 1,
+
+			/// <summary>Forced on for every texture, regardless of how it was imported.</summary>
+			Forced = 2,
+		}
+
+		/// <summary>
+		/// Texture filtering when nothing has been chosen.
+		/// </summary>
+		/// <remarks>
+		/// Per-texture, which respects what the art was imported with rather than overriding it.
+		/// Forcing it on costs little on any modern GPU but is still a decision about someone
+		/// else's art, so it is offered rather than imposed.
+		/// </remarks>
+		public const AnisotropicOption DefaultAnisotropicFiltering = AnisotropicOption.PerTexture;
+
+		/// <summary>
+		/// Applies the stored anisotropic filtering mode.
+		/// </summary>
+		public static void ApplySavedAnisotropicFiltering()
+		{
+			int stored = Mathf.Clamp(
+				ClientSettings.GetInt(
+					ClientSettings.AnisotropicFilteringKey,
+					(int)DefaultAnisotropicFiltering),
+				(int)AnisotropicOption.Off,
+				(int)AnisotropicOption.Forced);
+
+			ApplyAnisotropicFiltering((AnisotropicOption)stored);
+		}
+
+		/// <summary>
+		/// Writes an anisotropic filtering mode into the quality settings.
+		/// </summary>
+		/// <param name="option">The mode to apply. An unrecognised value falls back to per-texture.</param>
+		public static void ApplyAnisotropicFiltering(AnisotropicOption option)
+		{
+			switch (option)
+			{
+				case AnisotropicOption.Off:
+					QualitySettings.anisotropicFiltering = AnisotropicFiltering.Disable;
+					break;
+				case AnisotropicOption.Forced:
+					QualitySettings.anisotropicFiltering = AnisotropicFiltering.ForceEnable;
+					break;
+				case AnisotropicOption.PerTexture:
+				default:
+					QualitySettings.anisotropicFiltering = AnisotropicFiltering.Enable;
+					break;
+			}
+		}
+
 		public static void ApplySavedVSync()
 		{
 			ApplyVSync(ClientSettings.GetBool(ClientSettings.VSyncKey, false));
@@ -204,13 +272,21 @@ namespace FishMMO.Client
 		{
 			CaptureAuthoredQuality();
 			QualitySettings.SetQualityLevel(index, applyExpensiveChanges);
+
+			/* Both of these are authored per quality level, so switching level overwrites whatever
+			 * the player chose. Restoring them here is what makes them preferences rather than
+			 * things that silently revert the next time somebody touches the quality dropdown. */
 			ApplySavedVSync();
+			ApplySavedAnisotropicFiltering();
 		}
 
 #if UNITY_EDITOR
 		/// <summary>The quality level and VSync count authored in the project, before any change.</summary>
 		private static int authoredQualityLevel;
 		private static int authoredVSyncCount;
+
+		/// <summary>The anisotropic filtering mode authored in the project, before any change.</summary>
+		private static AnisotropicFiltering authoredAnisotropicFiltering;
 
 		/// <summary>True once the authored values above have been captured.</summary>
 		private static bool hasAuthoredQuality;
@@ -247,6 +323,7 @@ namespace FishMMO.Client
 
 			authoredQualityLevel = QualitySettings.GetQualityLevel();
 			authoredVSyncCount = QualitySettings.vSyncCount;
+			authoredAnisotropicFiltering = QualitySettings.anisotropicFiltering;
 			hasAuthoredQuality = true;
 
 			UnityEditor.EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
@@ -267,6 +344,7 @@ namespace FishMMO.Client
 			{
 				QualitySettings.SetQualityLevel(authoredQualityLevel, false);
 				QualitySettings.vSyncCount = authoredVSyncCount;
+				QualitySettings.anisotropicFiltering = authoredAnisotropicFiltering;
 			}
 
 			UnityEditor.EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientSettings.cs
@@ -63,6 +63,9 @@ namespace FishMMO.Client
 		/// the state the mouse drives the camera in.
 		/// </summary>
 		public const string LookSensitivityKey = "Look Sensitivity";
+
+		/// <summary>Texture filtering. Stored as the ordinal of ClientDisplaySettings.AnisotropicOption.</summary>
+		public const string AnisotropicFilteringKey = "Anisotropic Filtering";
 		/// <summary>Configuration key for the resolution width setting.</summary>
 		public const string ResolutionWidthKey = "Resolution Width";
 		/// <summary>Configuration key for the resolution height setting.</summary>

--- a/FishMMO-Unity/Assets/UnitTests/AnisotropicFilteringTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/AnisotropicFilteringTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FishMMO.Client;
+using NUnit.Framework;
+using UnityEngine;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for the texture filtering option.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Anisotropic filtering is authored per quality level -- the three shipped levels use Disable,
+	/// Enable and ForceEnable respectively -- so a player's choice is overwritten every time the
+	/// quality level is set. VSync already had that problem and already solves it by re-applying
+	/// after the level change; this has to do the same or the setting silently reverts the next
+	/// time anyone touches the quality dropdown.
+	/// </para>
+	/// <para>
+	/// The value also lives in a project asset, which is why the editor safeguard that restores
+	/// the authored quality settings after play mode has to cover it too. Without that, running the
+	/// client once leaves a source-control change describing whichever filtering mode the last
+	/// person to press Play happened to prefer.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class AnisotropicFilteringTests
+	{
+		private AnisotropicFiltering original;
+
+		[SetUp]
+		public void SetUp()
+		{
+			original = QualitySettings.anisotropicFiltering;
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			QualitySettings.anisotropicFiltering = original;
+		}
+
+		[Test]
+		public void EachOption_SelectsItsOwnMode()
+		{
+			var expected = new Dictionary<ClientDisplaySettings.AnisotropicOption, AnisotropicFiltering>
+			{
+				{ ClientDisplaySettings.AnisotropicOption.Off, AnisotropicFiltering.Disable },
+				{ ClientDisplaySettings.AnisotropicOption.PerTexture, AnisotropicFiltering.Enable },
+				{ ClientDisplaySettings.AnisotropicOption.Forced, AnisotropicFiltering.ForceEnable },
+			};
+
+			foreach (var pair in expected)
+			{
+				ClientDisplaySettings.ApplyAnisotropicFiltering(pair.Key);
+
+				LogAssert.AreEqual(pair.Value, QualitySettings.anisotropicFiltering,
+					$"{pair.Key} must select {pair.Value}");
+			}
+		}
+
+		[Test]
+		public void EveryOption_MapsToADistinctMode()
+		{
+			/* Two options resolving to the same mode would leave the player a choice that does
+			 * nothing -- which is indistinguishable, from their side, from the setting being
+			 * broken. */
+			var seen = new HashSet<AnisotropicFiltering>();
+
+			foreach (ClientDisplaySettings.AnisotropicOption option in
+				Enum.GetValues(typeof(ClientDisplaySettings.AnisotropicOption)))
+			{
+				ClientDisplaySettings.ApplyAnisotropicFiltering(option);
+
+				LogAssert.IsTrue(seen.Add(QualitySettings.anisotropicFiltering),
+					$"{option} selects a mode another option already selects");
+			}
+		}
+
+		[Test]
+		public void TheStoredOrdinals_AreFixed()
+		{
+			/* The save file holds these numbers. Reordering the enum would silently turn an
+			 * existing player's choice into a different one. */
+			LogAssert.AreEqual(0, (int)ClientDisplaySettings.AnisotropicOption.Off);
+			LogAssert.AreEqual(1, (int)ClientDisplaySettings.AnisotropicOption.PerTexture);
+			LogAssert.AreEqual(2, (int)ClientDisplaySettings.AnisotropicOption.Forced);
+		}
+
+		[Test]
+		public void TheDefault_RespectsHowTheArtWasImported()
+		{
+			/* Per-texture rather than Forced. Forcing costs little on a modern GPU, but it is still
+			 * a decision about someone else's art, so it is offered rather than imposed. */
+			LogAssert.AreEqual(
+				ClientDisplaySettings.AnisotropicOption.PerTexture,
+				ClientDisplaySettings.DefaultAnisotropicFiltering,
+				"the default must not override what each texture was imported with");
+		}
+
+		[Test]
+		public void AQualityLevelChange_ReAppliesTheChoice()
+		{
+			/* The failure this exists to prevent. Every quality level authors its own anisotropic
+			 * mode, so without the re-apply the player's choice survives only until they touch the
+			 * quality dropdown -- and then reverts with nothing to explain it.
+			 *
+			 * Pinned in source: driving it for real would mean switching quality level inside a
+			 * test, which reloads textures and render targets and writes to the project asset. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/Settings/ClientDisplaySettings.cs"));
+
+			int apply = source.IndexOf(
+				"public static void ApplyQualityLevel(", StringComparison.Ordinal);
+			LogAssert.IsTrue(apply >= 0, "ApplyQualityLevel must still exist");
+
+			// Bounded to that method, so the declaration further down cannot satisfy this.
+			int end = source.IndexOf("#if UNITY_EDITOR", apply, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > apply, "the end of ApplyQualityLevel must be locatable");
+
+			string body = source.Substring(apply, end - apply);
+
+			LogAssert.IsTrue(body.Contains("ApplySavedAnisotropicFiltering()"),
+				"a quality change must re-apply the player's filtering choice, as it does for VSync");
+		}
+
+		[Test]
+		public void TheEditorSafeguard_RestoresTheAuthoredMode()
+		{
+			/* QualitySettings is a project asset. The class already captures and restores the
+			 * authored quality level and VSync count so a play-mode session cannot leave a
+			 * source-control change behind; anisotropic filtering is written the same way and needs
+			 * the same treatment, or this feature reintroduces exactly that trap. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/Settings/ClientDisplaySettings.cs"));
+
+			LogAssert.IsTrue(source.Contains("authoredAnisotropicFiltering = QualitySettings.anisotropicFiltering"),
+				"the authored filtering mode must be captured before anything overwrites it");
+
+			LogAssert.IsTrue(source.Contains("QualitySettings.anisotropicFiltering = authoredAnisotropicFiltering"),
+				"the authored filtering mode must be put back");
+		}
+
+		[Test]
+		public void TheDropdownLabels_CoverEveryOption()
+		{
+			/* The dropdown stores the selected index, so labels and enum must stay the same length
+			 * and order or a click maps onto a different mode. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs"));
+
+			int labels = source.IndexOf("AnisotropicLabels =", StringComparison.Ordinal);
+			LogAssert.IsTrue(labels >= 0, "the dropdown must still declare its labels");
+
+			int end = source.IndexOf("};", labels, StringComparison.Ordinal);
+			string block = source.Substring(labels, end - labels);
+
+			int optionCount = Enum.GetValues(typeof(ClientDisplaySettings.AnisotropicOption)).Length;
+			int labelCount = block.Split('"').Length / 2;
+
+			LogAssert.AreEqual(optionCount, labelCount,
+				"there must be exactly one dropdown label per option");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/AnisotropicFilteringTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/AnisotropicFilteringTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8523f53248ffd774b8491e3ff425f056


### PR DESCRIPTION
Anisotropic filtering was fixed by the quality level -- Performant `Disable`, Balanced `Enable`,
High Fidelity `ForceEnable` -- with no way for a player to choose. It decides whether ground
textures blur into mush at glancing angles, which is most of what a player looks at while walking
around.

## What this adds

A **Texture Filtering** dropdown offering Off / Per Texture / Forced, defaulting to Per Texture.

"Per Texture" rather than "On", because that is what Unity's `Enable` mode actually does: it
respects the level each texture was imported with and forces nothing. Calling it On would promise
more than it delivers.

## Two integration details that would otherwise make it look broken

**A quality level change re-applies the choice.** Every level authors its own filtering mode, so
without this the setting survives only until someone touches the quality dropdown, then reverts
with nothing to explain it. VSync already had exactly this problem and already solves it the same
way; the fix here sits beside it.

**The editor safeguard now covers it.** `QualitySettings` is a project asset, and this class
already captures and restores the authored quality level and VSync count so a play-mode session
cannot leave a source-control change behind. Filtering is written the same way, so without this the
feature would reintroduce precisely that trap -- a developer's checked-out project picking up
whichever mode the last person to press Play happened to prefer.

The stored value is our own enum rather than Unity's `AnisotropicFiltering`, for the same reason
the antialiasing setting keeps its own: the save file holds the ordinal, and a reordering upstream
would silently change what an existing player's setting means.

## Tests

Each option selects its own mode; every option maps to a distinct mode; the ordinals are fixed; the
default respects the imported art; the dropdown labels match the enum one for one; the quality
re-apply is present; the editor capture and restore are present.

Verified with negative controls: removing the quality re-apply fails that test, and breaking the
editor restore fails that one, each without disturbing the others.

Full EditMode suite: **1185 tests, 1185 passed, 0 failed**.

## Independent of the other settings PRs

Branched from `dev` and touching `ClientDisplaySettings`, so it does not depend on the camera work
in #182 or #191 and can land in any order.
