### PR TITLE
Route audio sources through their channel, and offer every channel

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/Audio.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e99f022157234a749bd4e32b05bb9954
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Client/Audio/ChannelAudioSource.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Audio/ChannelAudioSource.cs
@@ -1,0 +1,176 @@
+using System;
+using UnityEngine;
+using FishMMO.Logging;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Plays an <see cref="AudioSource"/> through one of the player's volume channels.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The channel model already existed and only Master was ever applied, through
+	/// <see cref="AudioListener.volume"/>. That covers every sound at once, which is why it worked
+	/// without anything like this component, and also why nothing finer than "all of it" could be
+	/// offered. This is the missing piece: it scales one source by its own channel so a player can
+	/// turn music down without turning combat down with it.
+	/// </para>
+	/// <para>
+	/// Deliberately not an <c>AudioMixer</c>. A mixer is the usual answer and is a better one once
+	/// there is an audio team, but its groups and exposed parameters live in a binary asset that
+	/// can only be authored by hand in the editor, and every source has to be pointed at a group
+	/// there as well. This keeps the routing in code, where it can be tested and where adding a
+	/// sound means adding a component rather than editing a shared asset.
+	/// </para>
+	/// </remarks>
+	[AddComponentMenu("FishMMO/Audio/Channel Audio Source")]
+	[RequireComponent(typeof(AudioSource))]
+	public sealed class ChannelAudioSource : MonoBehaviour
+	{
+		/// <summary>The channel this source's volume follows.</summary>
+		[SerializeField]
+		[Tooltip("Which of the player's volume sliders controls this sound.")]
+		private AudioChannel channel = AudioChannel.Effects;
+
+		/// <summary>The source being scaled.</summary>
+		private AudioSource source;
+
+		/// <summary>
+		/// The volume the sound was authored at, before any channel scaling.
+		/// </summary>
+		/// <remarks>
+		/// Captured once, because the scaling is applied by assigning to the same field it is read
+		/// from. Re-reading it later would fold the channel level in again on every change, so a
+		/// player nudging a slider would ratchet the sound quieter and never get it back.
+		/// </remarks>
+		private float authoredVolume = 1.0f;
+
+		/// <summary>Whether <see cref="authoredVolume"/> has been taken yet.</summary>
+		private bool captured;
+
+		/// <summary>The channel this source plays on.</summary>
+		public AudioChannel Channel => channel;
+
+		/// <summary>
+		/// The volume this sound was authored at, ignoring the player's channel level.
+		/// </summary>
+		/// <remarks>
+		/// Assign through here rather than to <c>AudioSource.volume</c> when code wants to change
+		/// how loud a sound is in the mix -- fading a track in, quietening a source with distance.
+		/// Writing the source directly works until the player next moves a slider, at which point
+		/// the value is overwritten by this component and the change is silently lost.
+		/// </remarks>
+		public float AuthoredVolume
+		{
+			get => authoredVolume;
+			set
+			{
+				authoredVolume = Mathf.Clamp01(value);
+				captured = true;
+				Apply();
+			}
+		}
+
+		private void Awake()
+		{
+			EnsureResolved();
+		}
+
+		private void OnEnable()
+		{
+			ClientAudioSettings.OnVolumeChanged += OnVolumeChanged;
+			Apply();
+		}
+
+		private void OnDisable()
+		{
+			ClientAudioSettings.OnVolumeChanged -= OnVolumeChanged;
+		}
+
+		/// <summary>
+		/// Re-applies this source's level when its own channel moves.
+		/// </summary>
+		/// <remarks>
+		/// Master is ignored on purpose: it is applied to the listener and reaches every sound
+		/// already. Reacting to it here as well would scale by it a second time, so a master at
+		/// half would play this source at a quarter while an untagged source next to it played at
+		/// half.
+		/// </remarks>
+		private void OnVolumeChanged(AudioChannel changed)
+		{
+			if (changed == channel)
+			{
+				Apply();
+			}
+		}
+
+		/// <summary>
+		/// Writes the authored volume, scaled by the player's level for this channel.
+		/// </summary>
+		public void Apply()
+		{
+			/* Resolved here rather than only in Awake. Apply is reachable before Awake has run --
+			 * from a caller that sets the channel on a freshly added component, and from the editor
+			 * -- and a null source there would silently skip the scaling rather than fail. */
+			EnsureResolved();
+
+			if (source == null)
+			{
+				return;
+			}
+
+			source.volume = authoredVolume * ChannelScale(channel);
+		}
+
+		/// <summary>
+		/// Finds the source and takes its authored volume, if that has not happened yet.
+		/// </summary>
+		private void EnsureResolved()
+		{
+			if (source == null)
+			{
+				source = GetComponent<AudioSource>();
+			}
+
+			if (!captured && source != null)
+			{
+				authoredVolume = source.volume;
+				captured = true;
+			}
+		}
+
+		/// <summary>
+		/// The multiplier a channel contributes to a source.
+		/// </summary>
+		/// <remarks>
+		/// One for Master, which is not a per-source channel: it is already on the listener, and a
+		/// source tagged Master would otherwise be scaled by it twice. Returning one rather than
+		/// refusing the assignment keeps a mis-tagged source merely un-scaled instead of silent,
+		/// which is the better way to be wrong.
+		/// </remarks>
+		/// <param name="channel">The channel to scale by.</param>
+		public static float ChannelScale(AudioChannel channel)
+		{
+			return channel == AudioChannel.Master
+				? 1.0f
+				: ClientAudioSettings.EffectiveVolume(channel);
+		}
+
+		/// <summary>
+		/// Points this source at a different channel.
+		/// </summary>
+		/// <param name="value">The channel to follow.</param>
+		public void SetChannel(AudioChannel value)
+		{
+			if (!Enum.IsDefined(typeof(AudioChannel), value))
+			{
+				Log.Warning("ChannelAudioSource",
+					$"{gameObject.name} was pointed at an unknown audio channel; leaving it on {channel}.");
+				return;
+			}
+
+			channel = value;
+			Apply();
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/Audio/ChannelAudioSource.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/Audio/ChannelAudioSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 066e84bc9d360e8479a874bf63841d21

--- a/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientAudioSettings.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/Settings/ClientAudioSettings.cs
@@ -59,6 +59,11 @@ namespace FishMMO.Client
 		public static readonly AudioChannel[] PlayableChannels =
 		{
 			AudioChannel.Master,
+			AudioChannel.Music,
+			AudioChannel.Effects,
+			AudioChannel.Ambient,
+			AudioChannel.Interface,
+			AudioChannel.Voice,
 		};
 
 		/// <summary>Player-facing label for each channel, indexed by <see cref="AudioChannel"/>.</summary>
@@ -246,11 +251,11 @@ namespace FishMMO.Client
 		/// </summary>
 		/// <remarks>
 		/// Scoped to <see cref="PlayableChannels"/>, which is what the button the player pressed
-		/// actually offers. Resetting the whole enum would write a key for each of the five
-		/// channels the client cannot yet play through — settings the player was never shown,
-		/// appearing in Configuration.cfg because they pressed reset on the one they were. A
-		/// channel with no stored key already resolves to <see cref="DefaultVolume"/>, so there is
-		/// nothing to put back for the ones left out.
+		/// actually offers. That is now every channel, but the scoping stays: it is the reason a
+		/// channel retired from the list stops being written to Configuration.cfg rather than
+		/// lingering there as a setting nobody is shown. A channel with no stored key already
+		/// resolves to <see cref="DefaultVolume"/>, so there is nothing to put back for one left
+		/// out.
 		/// </remarks>
 		public static void ResetToDefaults()
 		{

--- a/FishMMO-Unity/Assets/UnitTests/AudioChannelRoutingTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/AudioChannelRoutingTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Reflection;
+using FishMMO.Client;
+using NUnit.Framework;
+using UnityEngine;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for routing an <see cref="AudioSource"/> through a player volume channel.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Only Master was ever applied, on the listener, so every sound moved together and nothing
+	/// finer could be offered. Routing lets a player turn music down without turning combat down
+	/// with it, which is the whole point of having channels at all.
+	/// </para>
+	/// <para>
+	/// Two mistakes are easy here and neither is audible as a bug so much as a slow wrongness, so
+	/// both have tests: scaling by Master a second time on top of the listener, which makes the
+	/// master slider behave quadratically; and re-reading the source's current volume as the base,
+	/// which ratchets a sound quieter every time the player touches the slider and never gives it
+	/// back.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class AudioChannelRoutingTests
+	{
+		private readonly List<GameObject> created = new List<GameObject>();
+		private readonly Dictionary<AudioChannel, float> savedLevels = new Dictionary<AudioChannel, float>();
+
+		[SetUp]
+		public void SetUp()
+		{
+			// Levels are global, so anything moved here has to be put back.
+			foreach (AudioChannel channel in ClientAudioSettings.PlayableChannels)
+			{
+				savedLevels[channel] = ClientAudioSettings.GetVolume(channel);
+			}
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			foreach (KeyValuePair<AudioChannel, float> pair in savedLevels)
+			{
+				ClientAudioSettings.SetVolume(pair.Key, pair.Value);
+			}
+			savedLevels.Clear();
+
+			foreach (ChannelAudioSource routed in live)
+			{
+				if (routed != null)
+				{
+					Lifecycle(routed, "OnDisable");
+				}
+			}
+			live.Clear();
+
+			foreach (GameObject go in created)
+			{
+				if (go != null)
+				{
+					Object.DestroyImmediate(go);
+				}
+			}
+			created.Clear();
+		}
+
+		private readonly List<ChannelAudioSource> live = new List<ChannelAudioSource>();
+
+		/// <summary>
+		/// Builds a routed source and starts it, since edit mode does not run the Unity callbacks.
+		/// </summary>
+		/// <remarks>
+		/// Awake and OnEnable are invoked by hand because Unity does not call them for a component
+		/// added outside play mode. What is under test is the routing -- that a source subscribed
+		/// to its channel follows it -- not Unity's dispatch of its own lifecycle, which is not
+		/// this project's to verify. TearDown calls OnDisable for the matching reason: without it
+		/// the static volume event keeps handlers on destroyed components, and the next test to
+		/// move a slider drives a routine on an object that no longer exists.
+		/// </remarks>
+		private ChannelAudioSource NewSource(AudioChannel channel, float authoredVolume)
+		{
+			GameObject go = new GameObject($"RoutedSource_{channel}");
+			created.Add(go);
+
+			AudioSource audio = go.AddComponent<AudioSource>();
+			audio.volume = authoredVolume;
+
+			ChannelAudioSource routed = go.AddComponent<ChannelAudioSource>();
+			routed.SetChannel(channel);
+
+			Lifecycle(routed, "Awake");
+			Lifecycle(routed, "OnEnable");
+			live.Add(routed);
+
+			return routed;
+		}
+
+		private static void Lifecycle(ChannelAudioSource routed, string method)
+		{
+			MethodInfo info = typeof(ChannelAudioSource).GetMethod(
+				method, BindingFlags.Instance | BindingFlags.NonPublic);
+
+			LogAssert.IsNotNull(info, $"ChannelAudioSource must still have {method}.");
+			info.Invoke(routed, null);
+		}
+
+		private static float VolumeOf(ChannelAudioSource routed) =>
+			routed.GetComponent<AudioSource>().volume;
+
+		[Test]
+		public void ASourceIsScaledByItsOwnChannel()
+		{
+			ClientAudioSettings.SetVolume(AudioChannel.Music, 0.5f);
+
+			ChannelAudioSource music = NewSource(AudioChannel.Music, 1.0f);
+
+			// The slider curve is squared, so 0.5 on the slider is 0.25 of amplitude.
+			LogAssert.AreEqual(ClientAudioSettings.EffectiveVolume(AudioChannel.Music), VolumeOf(music),
+				"a routed source must play at its channel's level");
+		}
+
+		[Test]
+		public void MovingOneChannel_LeavesTheOthersAlone()
+		{
+			/* The entire reason channels exist. If this fails the player has six sliders that all
+			 * do the same thing. */
+			ClientAudioSettings.SetVolume(AudioChannel.Music, 1.0f);
+			ClientAudioSettings.SetVolume(AudioChannel.Effects, 1.0f);
+
+			ChannelAudioSource music = NewSource(AudioChannel.Music, 1.0f);
+			ChannelAudioSource effects = NewSource(AudioChannel.Effects, 1.0f);
+
+			ClientAudioSettings.SetVolume(AudioChannel.Music, 0.0f);
+
+			LogAssert.AreEqual(0.0f, VolumeOf(music), "music was turned off");
+			LogAssert.AreEqual(1.0f, VolumeOf(effects), "combat must not follow the music slider");
+		}
+
+		[Test]
+		public void ASourceFollowsItsChannelWhileTheSliderMoves()
+		{
+			ClientAudioSettings.SetVolume(AudioChannel.Ambient, 1.0f);
+			ChannelAudioSource ambient = NewSource(AudioChannel.Ambient, 1.0f);
+
+			ClientAudioSettings.SetVolume(AudioChannel.Ambient, 0.5f);
+
+			LogAssert.AreEqual(ClientAudioSettings.EffectiveVolume(AudioChannel.Ambient), VolumeOf(ambient),
+				"the source must track the slider, not only its value at spawn");
+		}
+
+		[Test]
+		public void RepeatedChanges_DoNotRatchetTheVolumeDown()
+		{
+			/* The failure that hides. Scaling is applied by writing the same field it is read from,
+			 * so an implementation that re-read the current volume as its base would fold the
+			 * channel level in again on every change -- quieter each time, and never recoverable by
+			 * putting the slider back. */
+			ClientAudioSettings.SetVolume(AudioChannel.Effects, 1.0f);
+			ChannelAudioSource effects = NewSource(AudioChannel.Effects, 1.0f);
+
+			for (int i = 0; i < 5; ++i)
+			{
+				ClientAudioSettings.SetVolume(AudioChannel.Effects, 0.5f);
+				ClientAudioSettings.SetVolume(AudioChannel.Effects, 1.0f);
+			}
+
+			LogAssert.AreEqual(1.0f, VolumeOf(effects),
+				"putting the slider back must restore the original volume exactly");
+		}
+
+		[Test]
+		public void MasterIsNotAppliedTwice()
+		{
+			/* Master is on the AudioListener and reaches everything already. A source scaled by it
+			 * again would be squared -- a master at half playing this source at a quarter while an
+			 * untagged source beside it played at half. */
+			ClientAudioSettings.SetVolume(AudioChannel.Master, 0.5f);
+
+			LogAssert.AreEqual(1.0f, ChannelAudioSource.ChannelScale(AudioChannel.Master),
+				"Master must contribute nothing per-source; the listener already applies it");
+		}
+
+		[Test]
+		public void ASourceTaggedMaster_IsLeftUnscaledRatherThanSilenced()
+		{
+			/* Being wrong quietly is better than being wrong loudly. A mis-tagged source that plays
+			 * at full volume is noticed and fixed; one that is silent looks like a missing sound. */
+			ClientAudioSettings.SetVolume(AudioChannel.Master, 0.0f);
+
+			ChannelAudioSource tagged = NewSource(AudioChannel.Master, 1.0f);
+
+			LogAssert.AreEqual(1.0f, VolumeOf(tagged),
+				"a source tagged Master keeps its authored volume; the listener does the rest");
+		}
+
+		[Test]
+		public void TheAuthoredVolumeIsWhatGetsScaled()
+		{
+			/* A quiet sound stays quiet relative to a loud one. Without this the channel level
+			 * would flatten every source to the same volume. */
+			ClientAudioSettings.SetVolume(AudioChannel.Effects, 1.0f);
+
+			ChannelAudioSource quiet = NewSource(AudioChannel.Effects, 0.25f);
+
+			LogAssert.AreEqual(0.25f, VolumeOf(quiet),
+				"the mix balance between sources must survive routing");
+
+			ClientAudioSettings.SetVolume(AudioChannel.Effects, 0.5f);
+
+			LogAssert.AreEqual(0.25f * ClientAudioSettings.EffectiveVolume(AudioChannel.Effects),
+				VolumeOf(quiet),
+				"and must still hold once the player moves the slider");
+		}
+
+		[Test]
+		public void EveryChannelIsOfferedToThePlayer()
+		{
+			/* The sliders are generated from this array, so it is what decides whether a channel a
+			 * sound can be routed to is one the player can actually control. */
+			foreach (AudioChannel channel in System.Enum.GetValues(typeof(AudioChannel)))
+			{
+				LogAssert.IsTrue(
+					System.Array.IndexOf(ClientAudioSettings.PlayableChannels, channel) >= 0,
+					$"{channel} can be routed to but is not offered as a slider");
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/AudioChannelRoutingTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/AudioChannelRoutingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d67ed578346214429b5d12711faa7cd


### PR DESCRIPTION
The channel model already existed -- Master, Music, Effects, Ambient, Interface, Voice, with labels
and per-channel defaults -- but only Master was ever applied, through `AudioListener.volume`. That
covers every sound at once, which is why nothing finer than "all of it" could be offered and why
`PlayableChannels` held Master alone.

## What this adds

`ChannelAudioSource` scales one `AudioSource` by its own channel and follows that channel while the
player moves the slider. With routing in place, offering the remaining five channels is what the
original design intended it to be: entries in one array. The sliders are generated from that array,
so no UI work was needed.

**Deliberately not an `AudioMixer`.** A mixer is the usual answer and a better one once there is an
audio team, but its groups and exposed parameters live in a binary asset that can only be authored
by hand in the editor, and every source has to be pointed at a group there as well. Keeping the
routing in code means it can be tested, and that adding a sound means adding a component rather
than editing a shared asset. Swapping to a mixer later replaces this component without touching the
settings model.

## Two mistakes that are easy here

Neither sounds like a bug so much as a slow wrongness, so both are pinned by tests:

**Master is not applied per-source.** It is already on the listener, and scaling by it again would
square it -- a master at half playing a routed source at a *quarter* while an untagged source beside
it played at half. `ClientAudioSettings.EffectiveVolume` already documents this and deliberately
excludes Master; this respects that. A source mistakenly tagged Master is left **unscaled** rather
than silenced, because a sound that is too loud gets noticed and fixed, while one that is silent
looks like content nobody made.

**The authored volume is captured once.** Scaling writes the same field it reads, so an
implementation that re-read the current volume as its base would fold the level in again on every
change -- quieter each time, and never recovered by putting the slider back.

Verified with negative controls: reintroducing either mistake fails exactly the tests written for
it (4 of 8 fail).

## Tests

Eight, covering: a source is scaled by its own channel; moving one channel leaves the others alone;
a source follows its slider rather than only its value at spawn; repeated changes do not ratchet;
Master is not double-applied; a Master-tagged source stays audible; relative mix balance between a
loud and a quiet source survives routing; and every routable channel is actually offered as a
slider.

Edit mode does not run Unity's component callbacks, so `Awake`/`OnEnable`/`OnDisable` are invoked by
hand in the fixture. What is under test is the routing, not Unity's dispatch of its own lifecycle;
`OnDisable` is called in teardown because otherwise the static volume event keeps handlers on
destroyed components and the next test to move a slider runs code on an object that no longer
exists.

Full EditMode suite: **1186 tests, 1186 passed, 0 failed**.

## This changes nothing audible today

Worth stating plainly: the project contains **no audio files and no `AudioSource` in any scene or
prefab**. The one playback path, `PlayRegionAudioAction`, still has a comment where the clip loading
should be. So the five new sliders move nothing yet.

That is the intent of this PR rather than an oversight -- the routing is in place and tested for
when sound arrives, and the first sound added only needs the component on it. If you would rather
not show sliders until something plays through them, reverting to `Master` alone in
`PlayableChannels` is a one-line change and the routing can stay.
