### PR TITLE
Put the look sensitivity doc comment back on its own method

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UITKOptions.cs
@@ -1298,15 +1298,6 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
-		/// Binds the look sensitivity slider.
-		/// </summary>
-		/// <remarks>
-		/// The stored value is clamped on the way in, for the same reason brightness is: it is a
-		/// float in a file the player can edit, and it multiplies raw mouse delta. A large one makes
-		/// the view unusable at exactly the moment they would need to reach this menu to undo it,
-		/// and zero makes the camera immovable.
-		/// </remarks>
-		/// <summary>
 		/// Fills the antialiasing dropdown and applies the player's choice as they make it.
 		/// </summary>
 		/// <remarks>
@@ -1362,6 +1353,15 @@ namespace FishMMO.Client
 			"TAA (Temporal)",
 		};
 
+		/// <summary>
+		/// Binds the look sensitivity slider.
+		/// </summary>
+		/// <remarks>
+		/// The stored value is clamped on the way in, for the same reason brightness is: it is a
+		/// float in a file the player can edit, and it multiplies raw mouse delta. A large one makes
+		/// the view unusable at exactly the moment they would need to reach this menu to undo it,
+		/// and zero makes the camera immovable.
+		/// </remarks>
 		private void InitializeLookSensitivity()
 		{
 			if (lookSensitivitySlider == null)


### PR DESCRIPTION
Same fault as the one corrected in `a41aac0d` for the texture filtering option, in the
antialiasing option (#191). Mine, and the same cause both times.

The new method was inserted directly above `InitializeLookSensitivity`'s **signature** -- which sits
below its XML doc comment. So the comment stayed where it was and ended up attached to the new
method instead:

- `InitializeLookSensitivity` lost its documentation entirely
- `InitializeAntialiasing` gained a `<remarks>` block explaining how mouse delta is clamped and why
  a large sensitivity makes the view unusable

Nothing behavioural, but the docs now actively mislead: the paragraph on the antialiasing method
describes the sensitivity slider.

This moves the block back. No code changes.

## Verification

Full EditMode suite: **1247 tests, 1246 passed**. The single failure,
`WorldMapDefinitionTests.EveryWorldSceneHasAMapDefinition`, is present on clean `dev` before this
change and is unrelated -- it reports that seven world scenes have no `WorldMapDefinition` and asks
for `FishMMO/World Map/Bake Maps` to be run.
