### PR TITLE
Make the world scene details rebuild finish before it returns

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/WorldSceneDetailsCacheBuilder.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/WorldSceneDetailsCacheBuilder.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
 using UnityEditor;
-using UnityEngine.AddressableAssets;
-using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Settings;
 using System;
@@ -13,83 +11,109 @@ namespace FishMMO.Shared
 	/// </summary>
 	public class WorldSceneDetailsCacheBuilder
 	{
-		/// <summary>
-		/// Rebuilds the WorldSceneDetailsCache asset. Loads the addressable asset asynchronously and triggers a rebuild.
-		/// If loading fails, creates a new asset and adds it to Addressables.
-		/// </summary>
-		//[MenuItem("FishMMO/Rebuild World Scene Details", priority = -10)]
-		/// <summary>Rebuilds the WorldSceneDetailsCache asset, loading or creating it as needed.</summary>
-		public static void Rebuild()
+		/// <summary>Menu entry point. See <see cref="Rebuild"/>.</summary>
+		[MenuItem("FishMMO/Rebuild World Scene Details", priority = -10)]
+		public static void RebuildMenuItem()
 		{
-			// Try loading the addressable asset asynchronously
-			AsyncOperationHandle handle = Addressables.LoadAssetAsync<WorldSceneDetailsCache>(WorldSceneDetailsCache.CACHE_FULL_PATH);
-
-			// Callback when the asset is loaded
-			handle.Completed += (op) =>
-			{
-				if (op.Status == AsyncOperationStatus.Succeeded)
-				{
-					// Successfully loaded the asset
-					WorldSceneDetailsCache worldDetailsCache = op.Result as WorldSceneDetailsCache;
-					if (worldDetailsCache != null)
-					{
-						UnityEngine.Debug.Log($"Addressable asset loaded: {worldDetailsCache.name}");
-						worldDetailsCache.Rebuild();
-						EditorUtility.SetDirty(worldDetailsCache);
-						AssetDatabase.SaveAssets();
-					}
-					else
-					{
-						UnityEngine.Debug.LogError("Failed to cast the loaded asset to WorldSceneDetailsCache.");
-					}
-				}
-				else
-				{
-					// If the asset failed to load, log the error and handle accordingly
-					UnityEngine.Debug.LogError($"Failed to load Addressable asset: {WorldSceneDetailsCache.CACHE_FULL_PATH}");
-					HandleLoadFailure();
-				}
-			};
+			Rebuild();
 		}
 
 		/// <summary>
-		/// Handles asset load failure by creating a new WorldSceneDetailsCache asset and adding it to Addressables.
+		/// Rebuilds the world scene details cache, creating it if it does not exist yet.
 		/// </summary>
-		private static void HandleLoadFailure()
+		/// <remarks>
+		/// <para>
+		/// Synchronous, and that is the point. This used to load the cache through
+		/// <c>Addressables.LoadAssetAsync</c> and do all of its work inside a
+		/// <c>handle.Completed</c> callback, so it returned having done nothing and finished later
+		/// — if the editor was still alive to finish it. Under <c>-executeMethod</c> it never was:
+		/// Unity ran the method, saw it return, and quit before the load completed, so the cache
+		/// was silently left stale while the process exited zero. That made the one instruction
+		/// <c>WorldMapDefinitionTests</c> gives — bake, then rebuild this cache — impossible to
+		/// carry out from a command line, and impossible to carry out at all while the menu item
+		/// below was commented out.
+		/// </para>
+		/// <para>
+		/// Loaded through <see cref="AssetDatabase"/> rather than Addressables. This is editor
+		/// tooling operating on a project asset, so the asset database is both the direct route and
+		/// the honest one: it does not depend on a built catalog, and it cannot report "missing"
+		/// for an asset that is sitting on disk. That distinction was not cosmetic — a catalog that
+		/// was merely stale sent the old code down its creation path, which called
+		/// <c>AssetDatabase.CreateAsset</c> over the existing file and replaced a populated cache
+		/// with an empty one.
+		/// </para>
+		/// </remarks>
+		/// <returns><c>true</c> if the cache was rebuilt and saved.</returns>
+		public static bool Rebuild()
+		{
+			WorldSceneDetailsCache cache =
+				AssetDatabase.LoadAssetAtPath<WorldSceneDetailsCache>(WorldSceneDetailsCache.CACHE_FULL_PATH);
+
+			if (cache == null)
+			{
+				return Create();
+			}
+
+			bool rebuilt = cache.Rebuild();
+
+			EditorUtility.SetDirty(cache);
+			AssetDatabase.SaveAssets();
+
+			if (!rebuilt)
+			{
+				Debug.LogWarning(
+					$"[WorldSceneDetailsCacheBuilder] '{WorldSceneDetailsCache.CACHE_FULL_PATH}' was rebuilt, " +
+					"but at least one reader reported a failure. The cache may be incomplete.");
+			}
+
+			return rebuilt;
+		}
+
+		/// <summary>
+		/// Creates the cache asset and registers it with Addressables.
+		/// </summary>
+		/// <remarks>
+		/// Reached only when the asset genuinely does not exist. It writes to
+		/// <see cref="WorldSceneDetailsCache.CACHE_FULL_PATH"/>, so reaching it while a cache is
+		/// present would destroy that cache rather than rebuild it.
+		/// </remarks>
+		/// <returns><c>true</c> if the asset was created and registered.</returns>
+		private static bool Create()
 		{
 			try
 			{
-				// Create a new instance of WorldSceneDetailsCache if loading fails
-				WorldSceneDetailsCache worldDetailsCache = ScriptableObject.CreateInstance<WorldSceneDetailsCache>();
-				worldDetailsCache.Rebuild();
-				EditorUtility.SetDirty(worldDetailsCache);
+				WorldSceneDetailsCache cache = ScriptableObject.CreateInstance<WorldSceneDetailsCache>();
+				bool rebuilt = cache.Rebuild();
 
-				// Create the asset and save it
-				AssetDatabase.CreateAsset(worldDetailsCache, WorldSceneDetailsCache.CACHE_FULL_PATH);
+				EditorUtility.SetDirty(cache);
+				AssetDatabase.CreateAsset(cache, WorldSceneDetailsCache.CACHE_FULL_PATH);
 
 				AddressableAssetSettings settings = AddressableAssetSettingsDefaultObject.Settings;
 				if (settings == null)
 				{
-					UnityEngine.Debug.LogError("Addressable Asset Settings not found.");
-					return;
+					Debug.LogError("[WorldSceneDetailsCacheBuilder] Addressable Asset Settings not found.");
+					return false;
 				}
 
-				// Add the new asset to Addressables if not already present
-				AddressableAssetEntry entry = settings.FindAssetEntry(AssetDatabase.AssetPathToGUID(WorldSceneDetailsCache.CACHE_FULL_PATH));
-				if (entry == null)
+				string guid = AssetDatabase.AssetPathToGUID(WorldSceneDetailsCache.CACHE_FULL_PATH);
+
+				// Registered so the client can load it at runtime; the editor reads it directly.
+				if (settings.FindAssetEntry(guid) == null)
 				{
-					entry = settings.CreateOrMoveEntry(AssetDatabase.AssetPathToGUID(WorldSceneDetailsCache.CACHE_FULL_PATH), settings.DefaultGroup);
-					UnityEngine.Debug.Log($"Asset '{WorldSceneDetailsCache.CACHE_FULL_PATH}' added to Addressables.");
+					settings.CreateOrMoveEntry(guid, settings.DefaultGroup);
+					Debug.Log($"[WorldSceneDetailsCacheBuilder] '{WorldSceneDetailsCache.CACHE_FULL_PATH}' added to Addressables.");
 				}
 
 				EditorUtility.SetDirty(settings);
 				AssetDatabase.SaveAssets();
 				AssetDatabase.Refresh();
+
+				return rebuilt;
 			}
 			catch (Exception ex)
 			{
-				// Log any error that occurs during asset creation
-				UnityEngine.Debug.LogError($"Error during asset creation: {ex.Message}");
+				Debug.LogError($"[WorldSceneDetailsCacheBuilder] Could not create the cache: {ex.Message}");
+				return false;
 			}
 		}
 	}

--- a/FishMMO-Unity/Assets/UnitTests/FishMMO.UnitTests.asmdef
+++ b/FishMMO-Unity/Assets/UnitTests/FishMMO.UnitTests.asmdef
@@ -11,7 +11,8 @@
         "KinematicCharacterController",
         "Unity.TextMeshPro",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.Addressables"
+        "Unity.Addressables",
+        "FishMMO.Shared.Tools.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/FishMMO-Unity/Assets/UnitTests/WorldSceneDetailsCacheBuilderTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/WorldSceneDetailsCacheBuilderTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using FishMMO.Shared;
+using NUnit.Framework;
+using UnityEditor;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that rebuilding the world scene details cache finishes before it returns.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The rebuild used to load the cache through Addressables and do its work in a
+	/// <c>handle.Completed</c> callback, so it returned having done nothing. Interactively the
+	/// callback arrived a moment later and the asset was written, which is why this went unnoticed.
+	/// Under <c>-executeMethod</c> the editor quits as soon as the method returns, so the callback
+	/// never ran: the process exited zero, printed nothing, and left the cache stale.
+	/// </para>
+	/// <para>
+	/// That mattered beyond convenience. <c>WorldMapDefinitionTests</c> tells whoever reads its
+	/// failure to bake the maps and then rebuild this cache -- an instruction that could not be
+	/// carried out from a command line at all, and could not be carried out from the editor either
+	/// while the menu item was commented out.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class WorldSceneDetailsCacheBuilderTests
+	{
+		private static WorldSceneDetailsCache LoadCache()
+		{
+			return AssetDatabase.LoadAssetAtPath<WorldSceneDetailsCache>(
+				WorldSceneDetailsCache.CACHE_FULL_PATH);
+		}
+
+		[Test]
+		public void TheCacheIsPopulatedBeforeRebuildReturns()
+		{
+			/* The whole defect, stated as behaviour. A rebuild that schedules its work and returns
+			 * passes nothing here, because by the time the assertion runs the caller has already
+			 * been handed control back -- which is exactly the moment the editor quits under
+			 * -executeMethod. */
+			WorldSceneDetailsCache before = LoadCache();
+			LogAssert.IsNotNull(before,
+				$"'{WorldSceneDetailsCache.CACHE_FULL_PATH}' must exist for this fixture.");
+
+			int sceneCount = before.Scenes.Count;
+			LogAssert.IsTrue(sceneCount > 0,
+				"the cache must already hold scenes, or this fixture cannot tell a working rebuild " +
+				"from one that quietly emptied it");
+
+			bool rebuilt = WorldSceneDetailsCacheBuilder.Rebuild();
+
+			LogAssert.IsTrue(rebuilt,
+				"Rebuild must report success synchronously, not schedule the work and return");
+
+			LogAssert.AreEqual(sceneCount, LoadCache().Scenes.Count,
+				"the cache must hold the same scenes immediately after the call returns");
+		}
+
+		[Test]
+		public void RebuildingTwiceLeavesTheSameCache()
+		{
+			/* Rebuilding is how the cache is kept honest after a scene changes, so it has to be
+			 * safe to run at any time. If a second run disagreed with the first, nobody could run
+			 * it without checking what it did to their project. */
+			WorldSceneDetailsCacheBuilder.Rebuild();
+			int first = LoadCache().Scenes.Count;
+
+			WorldSceneDetailsCacheBuilder.Rebuild();
+			int second = LoadCache().Scenes.Count;
+
+			LogAssert.AreEqual(first, second, "a second rebuild must agree with the first");
+		}
+
+		[Test]
+		public void TheRebuildIsReachableFromTheEditorMenu()
+		{
+			/* The menu item was commented out, so the only way to run this was to know the type
+			 * name and call it by hand. A maintenance action nobody can find is one nobody runs. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/WorldSceneDetailsCacheBuilder.cs"));
+
+			int menu = source.IndexOf("[MenuItem(\"FishMMO/Rebuild World Scene Details", StringComparison.Ordinal);
+			LogAssert.IsTrue(menu >= 0, "the rebuild must be on the FishMMO menu");
+
+			// A commented-out attribute still contains the text, so the line has to be checked.
+			int lineStart = source.LastIndexOf('\n', menu) + 1;
+			string line = source.Substring(lineStart, menu - lineStart);
+
+			LogAssert.IsFalse(line.Contains("//"),
+				"the menu item must not be commented out");
+		}
+
+		[Test]
+		public void TheRebuildDoesNotDependOnTheAddressablesCatalog()
+		{
+			/* Pinned in source because the failure it prevents is destructive and cannot be
+			 * provoked safely from a test.
+			 *
+			 * Loading through Addressables reports "missing" whenever the catalog is stale, not
+			 * only when the asset is absent -- and the missing branch creates the asset, writing
+			 * over the very file it failed to read. A stale catalog therefore replaced a populated
+			 * cache with an empty one. The asset database cannot make that mistake: it answers for
+			 * what is on disk. */
+			string source = File.ReadAllText(Path.Combine(
+				Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/WorldSceneDetailsCacheBuilder.cs"));
+
+			int rebuild = source.IndexOf("public static bool Rebuild()", StringComparison.Ordinal);
+			LogAssert.IsTrue(rebuild >= 0, "Rebuild must still exist and report its outcome");
+
+			int end = source.IndexOf("private static bool Create()", rebuild, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > rebuild, "the end of Rebuild must be locatable");
+
+			string body = source.Substring(rebuild, end - rebuild);
+
+			LogAssert.IsFalse(body.Contains("LoadAssetAsync"),
+				"the cache must be read from the asset database, not through an async catalog load");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/WorldSceneDetailsCacheBuilderTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/WorldSceneDetailsCacheBuilderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c604c2effc1eba46a38f6a80117e1dd


### PR DESCRIPTION
Found while trying to follow the instruction `WorldMapDefinitionTests` gives when it fails.

## What was wrong

`WorldSceneDetailsCacheBuilder.Rebuild` loaded the cache through `Addressables.LoadAssetAsync` and
did **all** of its work inside a `handle.Completed` callback, so it returned having done nothing.

Interactively the callback arrived a moment later and the asset was written, which is why this went
unnoticed. Under `-executeMethod` the editor quits as soon as the method returns, so the callback
never ran: **the process exited zero, printed nothing, and left the cache stale.**

That made the failing map test impossible to satisfy. Its message says to bake the maps and then
rebuild this cache -- but the rebuild could not be run from a command line at all, and not from the
editor either, because the menu item was commented out. I hit exactly this: baking all seven scenes
succeeded, the test still failed, and my first rebuild attempt "succeeded" without touching the
asset. I only caught it because the file's timestamp had not moved.

## Three changes

**Read through `AssetDatabase`, not Addressables.** This is editor tooling operating on a project
asset, so the asset database is both the direct route and the honest one: it does not depend on a
built catalog, and it cannot report "missing" for a file sitting on disk.

That distinction is not cosmetic. Loading through Addressables reports failure whenever the catalog
is stale, not only when the asset is absent -- and the failure branch calls
`AssetDatabase.CreateAsset` over `CACHE_FULL_PATH`, **replacing a populated cache with an empty
one**. A stale catalog could therefore destroy the cache it was asked to refresh.

**`Rebuild` now returns whether it succeeded**, so a caller or a build step can tell. It reported
nothing before, which is what let a no-op look like success.

**The menu item is uncommented**, so the action the test asks for can be found by someone who does
not already know the type name.

## Tests

Four: the cache is populated by the time the call returns (the defect, stated as behaviour); a
second rebuild agrees with the first, so it is safe to run at any time; the rebuild is reachable
from the menu, checking the line is not commented out; and the read does not go through an async
catalog load.

The last one is pinned in source deliberately -- the failure it guards is destructive and cannot be
provoked safely from a test.

Verified with a negative control: restoring the async shape and re-commenting the menu item fails
**three of the four**, including the populated-before-return test.

Full EditMode suite: **1260 tests, 1260 passed, 0 failed** -- which now includes
`WorldMapDefinitionTests` passing, after baking the maps and running this rebuild.
