### PR TITLE
Label the guild roster column Race, because that is what it shows

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UIGuild.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UIGuild.uss
@@ -2,9 +2,9 @@
     UIGuild.uss
     Layout for the guild panel. Colours come from FishMMO-Theme.uss.
 
-    Four roster columns — member, rank, class, location. Rank sits beside the
+    Four roster columns — member, rank, race, location. Rank sits beside the
     name because it is the field a player scans for, and pairing it with the
-    name it belongs to is the whole point of a table; class and location follow
+    name it belongs to is the whole point of a table; race and location follow
     because they answer "who is this" and "can I reach them", in that order.
 
     The panel is taller and wider than the roster alone needed. It now carries a
@@ -178,7 +178,7 @@
    down the column, so a width that tracks content would make it unscannable. */
 .guild-column--level    { width: 44px; }
 .guild-column--rank     { width: 70px; }
-.guild-column--class    { width: 90px; }
+.guild-column--race    { width: 90px; }
 .guild-column--location { width: 110px; }
 
 /* ── Body ───────────────────────────────────────────────── */
@@ -226,7 +226,7 @@
     flex-shrink: 0;
 }
 
-.guild-member__class {
+.guild-member__race {
     width: 90px;
     flex-shrink: 0;
     overflow: hidden;
@@ -482,7 +482,7 @@
     margin-right: 3px;
 }
 
-/* Shared caption sizing; the --name/--rank/--class/--location modifiers set the widths. */
+/* Shared caption sizing; the --name/--rank/--race/--location modifiers set the widths. */
 .guild-column {
     flex-shrink: 0;
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UIGuild.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UIGuild.uxml
@@ -46,7 +46,7 @@
                 <ui:Label text="MEMBER" class="fish-col-head guild-column guild-column--name" />
                 <ui:Label text="LVL" class="fish-col-head guild-column guild-column--level" />
                 <ui:Label text="RANK" class="fish-col-head guild-column guild-column--rank" />
-                <ui:Label text="CLASS" class="fish-col-head guild-column guild-column--class" />
+                <ui:Label text="RACE" class="fish-col-head guild-column guild-column--race" />
                 <ui:Label text="LOCATION" class="fish-col-head guild-column guild-column--location" />
             </ui:VisualElement>
 
@@ -108,7 +108,7 @@
         <ui:VisualElement name="guild-hover-card" class="guild-hover-card">
             <ui:Label name="guild-hover-name" text="" class="guild-hover-card__name" />
             <ui:Label name="guild-hover-rank" text="" class="guild-hover-card__line" />
-            <ui:Label name="guild-hover-class" text="" class="guild-hover-card__line" />
+            <ui:Label name="guild-hover-race" text="" class="guild-hover-card__line" />
             <ui:Label name="guild-hover-location" text="" class="guild-hover-card__line" />
             <ui:Label name="guild-hover-seen" text="" class="guild-hover-card__line" />
             <!--

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
@@ -64,7 +64,7 @@ namespace FishMMO.Client
 		private const string ROW_RANK_CLASS = "guild-member__rank";
 
 		/// <summary>USS class applied to a member row's class label.</summary>
-		private const string ROW_CLASS_CLASS = "guild-member__class";
+		private const string ROW_RACE_CLASS = "guild-member__race";
 
 		/// <summary>USS class applied to a member row's location label.</summary>
 		private const string ROW_LOCATION_CLASS = "guild-member__location";
@@ -178,7 +178,7 @@ namespace FishMMO.Client
 		/// <summary>Name of the hover card's rank label.</summary>
 		private const string HOVER_RANK_NAME = "guild-hover-rank";
 		/// <summary>Name of the hover card's class label.</summary>
-		private const string HOVER_CLASS_NAME = "guild-hover-class";
+		private const string HOVER_RACE_NAME = "guild-hover-race";
 		/// <summary>Name of the hover card's location label.</summary>
 		private const string HOVER_LOCATION_NAME = "guild-hover-location";
 		/// <summary>Name of the hover card's last-seen label.</summary>
@@ -310,7 +310,7 @@ namespace FishMMO.Client
 			/// <summary>Member rank label.</summary>
 			public Label Rank;
 			/// <summary>Member class label.</summary>
-			public Label Class;
+			public Label Race;
 			/// <summary>Member location label.</summary>
 			public Label Location;
 		}
@@ -478,7 +478,7 @@ namespace FishMMO.Client
 		/// <summary>Hover card rank label.</summary>
 		private Label hoverRank;
 		/// <summary>Hover card class label.</summary>
-		private Label hoverClass;
+		private Label hoverRace;
 		/// <summary>Hover card location label.</summary>
 		private Label hoverLocation;
 		/// <summary>Hover card last-seen label.</summary>
@@ -552,7 +552,7 @@ namespace FishMMO.Client
 			hoverCard = root.Q(HOVER_CARD_NAME);
 			hoverName = root.Q<Label>(HOVER_NAME_NAME);
 			hoverRank = root.Q<Label>(HOVER_RANK_NAME);
-			hoverClass = root.Q<Label>(HOVER_CLASS_NAME);
+			hoverRace = root.Q<Label>(HOVER_RACE_NAME);
 			hoverLocation = root.Q<Label>(HOVER_LOCATION_NAME);
 			hoverSeen = root.Q<Label>(HOVER_SEEN_NAME);
 			hoverNote = root.Q<Label>(HOVER_NOTE_NAME);
@@ -1941,10 +1941,10 @@ namespace FishMMO.Client
 			rank.enableRichText = false;
 			rowRoot.Add(rank);
 
-			Label memberClass = new Label();
-			memberClass.AddToClassList("fish-row__meta");
-			memberClass.AddToClassList(ROW_CLASS_CLASS);
-			rowRoot.Add(memberClass);
+			Label memberRace = new Label();
+			memberRace.AddToClassList("fish-row__meta");
+			memberRace.AddToClassList(ROW_RACE_CLASS);
+			rowRoot.Add(memberRace);
 
 			Label location = new Label();
 			location.AddToClassList("fish-row__meta");
@@ -1959,7 +1959,7 @@ namespace FishMMO.Client
 				Name = name,
 				Level = level,
 				Rank = rank,
-				Class = memberClass,
+				Race = memberRace,
 				Location = location,
 			};
 
@@ -1991,7 +1991,7 @@ namespace FishMMO.Client
 			row.Name.text = model.Name;
 			row.Level.text = model.Level > 0 ? model.Level.ToString() : "—";
 			row.Rank.text = ResolveRankName(model.RankOrder);
-			row.Class.text = ResolveRaceName(model.RaceID);
+			row.Race.text = ResolveRaceName(model.RaceID);
 			row.Location.text = online ? model.Location : DescribeLastSeen(model.LastOnlineUtcTicks);
 
 			if (row.Dot != null)
@@ -2094,9 +2094,9 @@ namespace FishMMO.Client
 			{
 				hoverRank.text = $"Rank: {ResolveRankName(model.RankOrder)}";
 			}
-			if (hoverClass != null)
+			if (hoverRace != null)
 			{
-				hoverClass.text = $"Class: {ResolveRaceName(model.RaceID)}";
+				hoverRace.text = $"Race: {ResolveRaceName(model.RaceID)}";
 			}
 			if (hoverLocation != null)
 			{


### PR DESCRIPTION
The guild roster column header read **CLASS**, and the hover card printed **"Class: Human"** --
while both were filled from `ResolveRaceName(model.RaceID)`.

FishMMO is classless, so the label named something the game does not have *and* described the value
it was showing wrongly, at the same time.

## Renamed through, not just at the surface

- the column header (`CLASS` → `RACE`)
- the hover card line (`Class: Human` → `Race: Human`)
- `MemberRow.Class` → `MemberRow.Race`
- the hover element name and its constant (`guild-hover-class` → `guild-hover-race`)
- the USS classes for the column and the row cell (`guild-column--class`, `guild-member__class`)
- the three USS comments that described the roster as having a class column

A field called `Class` holding a race is how the wrong label comes back: the next person to read it
has every reason to believe the column is a placeholder waiting for a class system, and to "fix"
the header back.

Full EditMode suite: **1256 tests, 1256 passed, 0 failed**.
