### PR TITLE
Count what the bank holds, not what it drew

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs
@@ -83,7 +83,12 @@ namespace FishMMO.Client
 		/// <summary>Label shown in place of the grid when nothing is stored.</summary>
 		private Label emptyLabel;
 
-		/// <summary>Cached item sprite per slot, used to drive the capacity readout.</summary>
+		/// <summary>Cached item sprite per slot.</summary>
+		/// <remarks>
+		/// No longer the source of the capacity readout — see <see cref="RefreshCapacity"/>. A
+		/// sprite says whether an item has an icon, which is not the same question as whether a
+		/// slot holds one.
+		/// </remarks>
 		private readonly List<Sprite> slotSprites = new List<Sprite>();
 
 		/// <summary>The slot grid container element.</summary>
@@ -627,19 +632,27 @@ namespace FishMMO.Client
 		/// Recomputes the header subtitle, footer counts and capacity bar.
 		/// </summary>
 		/// <remarks>
-		/// Occupancy is read from <c>slotSprites</c> rather than from the controller: this runs
-		/// on every slot write, and the sprite array is already the view's own record of which
-		/// slots are filled. Asking the controller would re-derive a fact the view just set.
+		/// Occupancy comes from the controller, which is the only thing that knows it. It used to
+		/// be counted from <c>slotSprites</c> on the reasoning that the sprite array is the view's
+		/// own record of which slots are filled — but a sprite records whether an item has an
+		/// ICON, not whether a slot holds an item. Every item whose template has no icon assigned,
+		/// or whose icon has not finished loading, left a null in that array and was counted as an
+		/// empty slot, so the totals read low and drifted as icons resolved.
+		///
+		/// The inventory panel had the same defect and was fixed the same way; the bank was missed.
 		/// </remarks>
 		private void RefreshCapacity()
 		{
-			int total = slotSprites.Count;
+			int total = slotViews.Count;
 			int used = 0;
-			for (int i = 0; i < total; ++i)
+			if (Character != null && Character.TryGet(out IBankController bankController))
 			{
-				if (slotSprites[i] != null)
+				for (int i = 0; i < total; ++i)
 				{
-					++used;
+					if (!bankController.IsSlotEmpty(i))
+					{
+						++used;
+					}
 				}
 			}
 			int free = total - used;

--- a/FishMMO-Unity/Assets/UnitTests/BankCapacityReadoutTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/BankCapacityReadoutTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that the bank's slot counters count items, not icons.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The readout counted non-null entries in the view's cached sprite array. A sprite records
+	/// whether an item has an ICON, which is a different question from whether a slot holds an
+	/// item, and the two come apart in two ordinary situations: a template with no icon assigned,
+	/// and a template whose icon has not finished loading, since
+	/// <c>BaseItemTemplate.Icon</c> is an addressable resolved at runtime. Both left a null in the
+	/// array, so the bank reported those slots empty while the grid drew the placeholder that the
+	/// slot code deliberately provides for exactly that case.
+	/// </para>
+	/// <para>
+	/// Every shipped test item has an empty icon reference, so on the current content the bank
+	/// reported zero used no matter how much was in it.
+	/// </para>
+	/// <para>
+	/// The inventory panel had the identical defect and was already fixed by counting from the
+	/// controller. The bank was missed, so this pins both panels against the same regression rather
+	/// than only the one that was reported.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class BankCapacityReadoutTests
+	{
+		private const string BankPath =
+			"Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs";
+
+		private const string InventoryPath =
+			"Assets/Scripts/Client/GUI/World/Inventory/UITKInventory.cs";
+
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path);
+		}
+
+		/// <summary>The body of a panel's RefreshCapacity, where the occupancy decision lives.</summary>
+		private static string CapacityBody(string relativePath)
+		{
+			string source = ReadSource(relativePath);
+
+			int start = source.IndexOf("private void RefreshCapacity()", StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, $"{relativePath} must still have RefreshCapacity.");
+
+			int end = source.IndexOf("int free = total - used;", start, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > start, $"{relativePath}: the counting section must be locatable.");
+
+			return source.Substring(start, end - start);
+		}
+
+		[Test]
+		public void TheBankCountsItemsRatherThanIcons()
+		{
+			/* The defect. Counting sprites means an un-iconed item is invisible to the readout,
+			 * which on the current content is every item there is. */
+			string body = CapacityBody(BankPath);
+
+			/* The indexed read is the occupancy decision; a mention of the list is not. The
+			 * inventory still sizes its total from that list, correctly, so forbidding the name
+			 * outright would fail a panel that is already right. */
+			LogAssert.IsFalse(body.Contains("slotSprites[i]"),
+				"the bank must not decide occupancy from the cached sprites");
+
+			LogAssert.IsTrue(body.Contains("IsSlotEmpty"),
+				"the bank must ask the controller, which knows what the slot holds");
+		}
+
+		[Test]
+		public void TheInventoryCountsItemsRatherThanIcons()
+		{
+			/* Already fixed; pinned so the two panels cannot drift apart again. The bank's bug was
+			 * this same code before someone fixed one copy of it. */
+			string body = CapacityBody(InventoryPath);
+
+			LogAssert.IsFalse(body.Contains("slotSprites[i]"),
+				"the inventory must not decide occupancy from the cached sprites");
+
+			LogAssert.IsTrue(body.Contains("IsSlotEmpty"),
+				"the inventory must ask the controller");
+		}
+
+		[Test]
+		public void TheBankSizesTheReadoutFromItsSlots()
+		{
+			/* The total comes from the slots that exist rather than from the sprite cache. Both
+			 * lists hold one entry per slot so the two agree today, but once the cache is no longer
+			 * the occupancy record it should not be the capacity record either -- and a wrong total
+			 * is harder to notice than a wrong used-count, because it looks like a bank of the
+			 * wrong size rather than like a miscount.
+			 *
+			 * Asserted for the bank only. The inventory still takes its total from the sprite cache;
+			 * that is correct today and is left alone rather than changed in passing. */
+			string body = CapacityBody(BankPath);
+
+			LogAssert.IsTrue(body.Contains("int total = slotViews.Count;"),
+				"the bank's total must come from the slots the panel built");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/BankCapacityReadoutTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/BankCapacityReadoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58dac057b62512547b219b41fa31818f


### PR DESCRIPTION
Fixes #199.

## What was wrong

The bank's slot counters were derived from the view's cached sprite array — a slot counted as
filled when its sprite was non-null:

```csharp
Sprite sprite = item.Template != null ? item.Template.Icon : null;
slotSprites[slotIndex] = sprite;
```

A sprite records whether an item has an **icon**, not whether a slot holds an **item**. Those come
apart in two ordinary cases:

- **A template with no icon assigned** leaves a null, so the item counts as an empty slot. Every
  shipped test item has an empty icon reference (`icon: m_AssetGUID:` is blank), so on the current
  content the bank reported **zero used** however much was in it.
- **A template whose icon has not loaded yet** leaves a null too, since `BaseItemTemplate.Icon` is
  an addressable resolved at runtime. That one drifts — the count climbs as icons arrive.

The slot visuals already handled a missing icon by drawing a placeholder, with a comment saying "an
occupied slot must look occupied". So the drawing side had this right, and only the counting side
believed an un-iconed item was nothing.

## The fix

Occupancy comes from the controller, which is the only thing that knows it. The total comes from
the slots the panel actually built.

## The inventory panel already had this fixed

Worth flagging, because it is the strongest evidence the diagnosis is right and it shapes the
tests. `UITKInventory.RefreshCapacity` carries this remark:

> Occupancy comes from the controller, which is the only thing that knows it. It used to be counted
> from `slotSprites` on the reasoning that the sprite array is the view's own record of which slots
> are filled — but a sprite records whether an item has an ICON, not whether a slot holds an item.

Someone found this exact bug, fixed the inventory, and the bank was missed. So the tests here pin
**both** panels against the same regression rather than only the one that was reported.

## Tests

Three: the bank decides occupancy from the controller rather than the sprite cache; the inventory
still does (so the pair cannot drift apart again); and the bank sizes its total from its slots.

The assertions target the indexed read `slotSprites[i]` rather than any mention of the list — the
inventory legitimately still uses it for the total, and forbidding the name outright failed a panel
that is already correct. I only found that because the first run failed on it.

Verified with a negative control: restoring the sprite-derived count fails both bank tests and
leaves the inventory ones passing.

Full EditMode suite: **1259 tests, 1259 passed, 0 failed**.

## Left alone deliberately

The inventory still takes its `total` from `slotSprites.Count`. Both lists hold one entry per slot
so it is correct today; it is a latent coupling rather than a bug, and not something to change in
passing while fixing a different panel.
