### PR TITLE
Give antialiasing its own row in the options panel

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml
@@ -59,6 +59,8 @@
                 <ui:VisualElement class="options-row">
                     <ui:Label text="Texture Filtering" class="fish-label options-row-label" />
                     <ui:DropdownField name="anisotropic-dropdown" class="fish-dropdown options-row-field" />
+                </ui:VisualElement>
+                <ui:VisualElement class="options-row">
                     <ui:Label text="Antialiasing" class="fish-label options-row-label" />
                     <ui:DropdownField name="antialiasing-dropdown" class="fish-dropdown options-row-field" />
                 </ui:VisualElement>

--- a/FishMMO-Unity/Assets/UnitTests/OptionsRowLayoutTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/OptionsRowLayoutTests.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that each options row carries one setting.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// A row lays its children out across the panel's width, so two settings sharing one row do not
+	/// wrap — they squeeze, and the second control runs off the right edge of the panel. That is
+	/// what happened when the antialiasing and texture filtering settings were merged: both were
+	/// added by separate changes in the same place, the rows collapsed into one, and the resulting
+	/// panel showed a truncated dropdown and grew a horizontal scrollbar.
+	/// </para>
+	/// <para>
+	/// It is a merge hazard rather than a typo — the two additions were individually correct — so it
+	/// is worth a test rather than care. Nothing about the markup makes an overloaded row look wrong
+	/// on the page.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class OptionsRowLayoutTests
+	{
+		private const string OptionsUxml =
+			"Assets/Scripts/Client/GUI/World/Options/UIOptions.uxml";
+
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path);
+		}
+
+		/// <summary>The inner markup of every options row.</summary>
+		private static MatchCollection Rows()
+		{
+			return Regex.Matches(
+				ReadSource(OptionsUxml),
+				"<ui:VisualElement class=\"options-row\">(.*?)</ui:VisualElement>",
+				RegexOptions.Singleline);
+		}
+
+		[Test]
+		public void ThePanelStillHasRows()
+		{
+			/* Guards the two tests below from passing on an empty match set, which is what they
+			 * would do if the class name or the markup shape ever changed. */
+			LogAssert.IsTrue(Rows().Count > 10,
+				"the options panel must still be built from options-row elements");
+		}
+
+		[Test]
+		public void NoRowCarriesTwoControls()
+		{
+			/* The failure: a row does not wrap, so the second control is pushed off the panel. */
+			foreach (Match row in Rows())
+			{
+				int controls = Regex.Matches(
+					row.Groups[1].Value,
+					"<ui:(DropdownField|Slider|Toggle|TextField)\\b").Count;
+
+				LogAssert.IsTrue(controls <= 1,
+					$"an options row carries {controls} controls; each row holds one setting: {Caption(row)}");
+			}
+		}
+
+		[Test]
+		public void NoRowCarriesTwoCaptions()
+		{
+			/* Two captions is the same fault seen from the other side, and catches the case where
+			 * the second setting's control has not been added yet. */
+			foreach (Match row in Rows())
+			{
+				int captions = Regex.Matches(
+					row.Groups[1].Value,
+					"<ui:Label[^>]*class=\"fish-label").Count;
+
+				LogAssert.IsTrue(captions <= 1,
+					$"an options row carries {captions} captions: {Caption(row)}");
+			}
+		}
+
+		/// <summary>First caption in a row, to name it in a failure.</summary>
+		private static string Caption(Match row)
+		{
+			Match text = Regex.Match(row.Groups[1].Value, "text=\"([^\"]+)\"");
+			return text.Success ? text.Groups[1].Value : "(unnamed row)";
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/OptionsRowLayoutTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/OptionsRowLayoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f83a0a006ccb4494d904bfd293cba4a9


### PR DESCRIPTION
Reported from the running client: the antialiasing dropdown is cut off at the right edge of the
options panel, its label is clipped, and the panel has grown a horizontal scrollbar.

## Cause

Texture filtering and antialiasing share one `options-row`:

```xml
<ui:VisualElement class="options-row">
    <ui:Label text="Texture Filtering" ... />
    <ui:DropdownField name="anisotropic-dropdown" ... />
    <ui:Label text="Antialiasing" ... />
    <ui:DropdownField name="antialiasing-dropdown" ... />
</ui:VisualElement>
```

A row lays its children across the panel's width and does not wrap, so two settings in one row do
not stack — they squeeze, and the second control runs off the edge. The scrollbar is the panel
offering to scroll to a control that should never have been out there.

This is a merge artefact, not a mistake in either change: the two settings were added by separate
work in the same place, and the rows collapsed into one when they came together. Each was correct
on its own.

## Fix

One row each. Order is unchanged — Quality, Texture Filtering, Antialiasing, Brightness — so
nothing moves except the wrap.

## Tests

An overloaded row does not look wrong in the markup, and nothing fails until someone opens the
panel, so this is pinned rather than left to care. `OptionsRowLayoutTests` walks every options row
and refuses more than one control or caption in any of them. All 23 rows pass, so this was the only
one.

There is also a guard test asserting the panel still has rows at all — without it the other two
would pass vacuously if the class name or markup shape ever changed.

Verified with a negative control: re-collapsing the row fails both assertions.

## Note on the suite

Six tests fail on my machine, all in `ExploredReadoutTests`, and they are unrelated to this change
— they fail identically on a clean `dev`. `ClientMapSystem.BeginLoadMapImage` subscribes to
`Definition.MapImage.LoadAssetAsync<Texture2D>()` without checking `handle.IsValid()`, and in edit
mode that handle is invalid, so it throws.

They only appear once the world maps have been baked, which is why they pass in a repo that has not
run `FishMMO/World Map/Bake Maps` — and `WorldMapDefinitionTests` asks you to bake. I am happy to
send the `IsValid()` guard as its own PR if you want it.
