### PR TITLE
Check the map image handle before subscribing to it

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Map/ClientMapSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Map/ClientMapSystem.cs
@@ -603,6 +603,25 @@ namespace FishMMO.Client
 			string requestedScene = SceneName;
 
 			mapImageHandle = Definition.MapImage.LoadAssetAsync<Texture2D>();
+
+			/* A handle can come back invalid, and subscribing to one throws rather than reporting
+			 * failure through the callback below. Addressables answers this way when it has no
+			 * initialised runtime to load through -- which is every edit-mode test that reaches here,
+			 * so the exception surfaces as a fixture failure rather than as a map that did not draw.
+			 * ReleaseMapImage already tests the same handle before releasing it; this is the matching
+			 * test on the way in.
+			 *
+			 * Treated as a failed load rather than swallowed: the map draws over a plain background
+			 * either way, and the reason is worth saying once. */
+			if (!mapImageHandle.IsValid())
+			{
+				mapImageHandle = default;
+				Log.Warning("ClientMapSystem",
+					$"Addressables returned no load for the baked map image of scene '{requestedScene}'. " +
+					"The world map will draw markers over a plain background.");
+				return;
+			}
+
 			mapImageLoading = true;
 			mapImageHandle.Completed += handle =>
 			{


### PR DESCRIPTION
## The failure

Six tests in `ExploredReadoutTests` fail with:

```
System.Exception : Attempting to use an invalid operation handle
  at FishMMO.Client.ClientMapSystem.BeginLoadMapImage () ClientMapSystem.cs:607
```

`BeginLoadMapImage` subscribes to the handle returned by `AssetReference.LoadAssetAsync` without
asking whether it is valid. **Subscribing to an invalid handle throws** — it does not report failure
through the completion callback, so the careful `handle.Status != Succeeded` handling just below it
never gets the chance to run.

Addressables returns an invalid handle when it has no initialised runtime to load through, which is
every edit-mode test that reaches this line.

## Why it is not visible in a fresh clone

It only fails **once the world maps have been baked**. A definition with no image assigned returns
early and never reaches this line, so:

- a repository that has not run `FishMMO/World Map/Bake Maps` → these six pass
- `WorldMapDefinitionTests` fails there instead, and tells you to bake
- bake → that one passes and **these six start failing**

The two suites could not both be green. I hit it from the other direction: I baked the maps to
satisfy `WorldMapDefinitionTests`, and these appeared.

## The fix

Check `IsValid()` before subscribing, and treat an invalid handle as a failed load rather than
swallowing it — the map draws markers over a plain background either way, and the reason is worth
saying once.

`ReleaseMapImage` already tests the same handle before releasing it. This is the matching test on
the way in, so the two ends now agree that a handle may be invalid.

## Verification

**Full EditMode suite: 1303 tests, 1303 passed.** It was 1297 of 1303 immediately before this
change, with the six named above failing — so this is verified against real failing tests rather
than a synthetic control.
