### PR TITLE
Shift-click to move an item to the other open container

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs
@@ -56,6 +56,21 @@ namespace FishMMO.Client
 		}
 
 		/// <inheritdoc/>
+		protected override ReferenceButtonType? QuickTransferTarget => ReferenceButtonType.Inventory;
+
+		/// <inheritdoc/>
+		protected override void SendQuickTransferRequest(int fromSlot, int toSlot)
+		{
+			// Into the inventory, so it is the inventory's request even though the bank sends it.
+			Client.Broadcast(new InventorySwapItemSlotsBroadcast()
+			{
+				From = fromSlot,
+				To = toSlot,
+				FromInventory = InventoryType.Bank,
+			}, Channel.Reliable);
+		}
+
+		/// <inheritdoc/>
 		protected override void SendSwapRequest(int fromSlot, int toSlot, InventoryType fromInventory)
 		{
 			Client.Broadcast(new BankSwapItemSlotsBroadcast()

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Inventory/UITKInventory.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Inventory/UITKInventory.cs
@@ -26,6 +26,22 @@ namespace FishMMO.Client
 		protected override InventoryType OwnInventoryType => InventoryType.Inventory;
 
 		/// <inheritdoc/>
+		protected override ReferenceButtonType? QuickTransferTarget => ReferenceButtonType.Bank;
+
+		/// <inheritdoc/>
+		protected override void SendQuickTransferRequest(int fromSlot, int toSlot)
+		{
+			/* Into the bank, so it is the bank's request. The server refuses it when no banker is
+			 * in range, which is what keeps a shift-click from banking from anywhere. */
+			Client.Broadcast(new BankSwapItemSlotsBroadcast()
+			{
+				From = fromSlot,
+				To = toSlot,
+				FromInventory = InventoryType.Inventory,
+			}, Channel.Reliable);
+		}
+
+		/// <inheritdoc/>
 		protected override void SendSwapRequest(int fromSlot, int toSlot, InventoryType fromInventory)
 		{
 			Client.Broadcast(new InventorySwapItemSlotsBroadcast()

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs
@@ -832,11 +832,154 @@ namespace FishMMO.Client
 
 			if (evt.button == 0)
 			{
-				HandleSlotLeftClick(slotIndex);
+				/* Shift is read from the event rather than from global input state: the modifier
+				 * that matters is the one held when this click happened, and a poll can answer for
+				 * a moment either side of it. */
+				if (evt.shiftKey)
+				{
+					TryQuickTransfer(slotIndex);
+				}
+				else
+				{
+					HandleSlotLeftClick(slotIndex);
+				}
 			}
 			else if (evt.button == 1)
 			{
 				HandleSlotRightClick(slotIndex);
+			}
+		}
+
+		/// <summary>
+		/// The container a shift-click sends an item to, or null when this panel has nowhere to
+		/// send one.
+		/// </summary>
+		protected virtual ReferenceButtonType? QuickTransferTarget => null;
+
+		/// <summary>
+		/// Sends the request that moves an item out of this panel and into
+		/// <see cref="QuickTransferTarget"/>.
+		/// </summary>
+		/// <remarks>
+		/// The broadcast belongs to the DESTINATION container, not this one — moving into the bank
+		/// is a bank swap whoever asked for it — so the panel losing the item is the one that has
+		/// to name the other panel's request.
+		/// </remarks>
+		/// <param name="fromSlot">Slot in this panel the item is leaving.</param>
+		/// <param name="toSlot">Slot in the target container it is going to.</param>
+		protected virtual void SendQuickTransferRequest(int fromSlot, int toSlot)
+		{
+		}
+
+		/// <summary>
+		/// Moves an item to the other open container without a drag.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Banking a bagful is the operation players repeat most, and doing it by drag means one
+		/// press, one aim and one release per item across two panels.
+		/// </para>
+		/// <para>
+		/// The destination is the first free slot this client can see, and the request is the same
+		/// swap a drag onto that slot would send. That is deliberate: it carries exactly the risk
+		/// the drag it replaces already carries, no more. A slot this client believes is empty and
+		/// the server does not would swap two items rather than move one — but the player aiming a
+		/// drag at that same slot gets the same outcome, so quick transfer is not introducing a
+		/// class of mistake, only saving the aiming.
+		/// </para>
+		/// </remarks>
+		/// <param name="slotIndex">Slot holding the item to send.</param>
+		protected void TryQuickTransfer(int slotIndex)
+		{
+			if (QuickTransferTarget == null)
+			{
+				return;
+			}
+
+			IItemContainer source = OwnContainer;
+			IItemContainer target = ResolveContainer(QuickTransferTarget.Value);
+
+			// No target container means the other panel is not something this character has.
+			if (source == null || target == null)
+			{
+				return;
+			}
+
+			if (IsSlotBlocked(slotIndex) ||
+				!source.TryGetItem(slotIndex, out Item item) ||
+				item == null)
+			{
+				return;
+			}
+
+			if (!source.CanManipulate() || !target.CanManipulate())
+			{
+				return;
+			}
+
+			int destination = FirstFreeSlot(target);
+			if (destination < 0)
+			{
+				/* Said out loud. A shift-click that silently does nothing is indistinguishable from
+				 * one the game did not register, and the player's next move is to try it again. */
+				Notify($"No room in your {QuickTransferTargetName}.", ToastSeverity.Warning);
+				return;
+			}
+
+			// Claim both ends, or neither: a slot marked as waiting for an unsent request never unlocks.
+			if (!ItemOperationTracker.TryBegin(DragType, slotIndex))
+			{
+				return;
+			}
+			if (!ItemOperationTracker.TryBegin(QuickTransferTarget.Value, destination))
+			{
+				ItemOperationTracker.Release(DragType, slotIndex);
+				return;
+			}
+
+			SendQuickTransferRequest(slotIndex, destination);
+		}
+
+		/// <summary>Player-facing name of the quick transfer destination, for a refusal.</summary>
+		private string QuickTransferTargetName
+		{
+			get
+			{
+				switch (QuickTransferTarget)
+				{
+					case ReferenceButtonType.Bank: return "bank";
+					case ReferenceButtonType.Inventory: return "inventory";
+					default: return "bags";
+				}
+			}
+		}
+
+		/// <summary>
+		/// The first slot of a container that can take an item, or -1 when none can.
+		/// </summary>
+		/// <remarks>
+		/// A locked slot is skipped rather than treated as free: it is waiting on a request of its
+		/// own, and aiming a second one at it would be refused.
+		/// </remarks>
+		private static int FirstFreeSlot(IItemContainer container)
+		{
+			for (int i = 0; i < container.Items.Count; ++i)
+			{
+				if (container.IsSlotEmpty(i) && !container.IsSlotLocked(i))
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		/// <summary>Shows a transient notice, if the toast panel is up.</summary>
+		private static void Notify(string text, ToastSeverity severity)
+		{
+			if (UIManager.TryGetTK("UIToast", out UITKToast toast))
+			{
+				toast.Show(text, severity);
 			}
 		}
 

--- a/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs
@@ -114,12 +114,12 @@ namespace FishMMO.UnitTests
 			 * names the other panel's broadcast. Getting this backwards would ask the server to move
 			 * the item to where it already is. */
 			LogAssert.IsTrue(
-				MethodBody(BankPath, "protected override void SendQuickTransferRequest", "/// <inheritdoc/>\n\t\tprotected override void SendSwapRequest")
+				MethodBody(BankPath, "protected override void SendQuickTransferRequest", "protected override void SendSwapRequest")
 					.Contains("InventorySwapItemSlotsBroadcast"),
 				"the bank must send an inventory swap to push an item out to the inventory");
 
 			LogAssert.IsTrue(
-				MethodBody(InventoryPath, "protected override void SendQuickTransferRequest", "/// <inheritdoc/>\n\t\tprotected override void SendSwapRequest")
+				MethodBody(InventoryPath, "protected override void SendQuickTransferRequest", "protected override void SendSwapRequest")
 					.Contains("BankSwapItemSlotsBroadcast"),
 				"the inventory must send a bank swap to push an item into the bank");
 		}

--- a/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs for shift-clicking an item across to the other open container (issue #197).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Banking a bagful is the operation players repeat most, and by drag it costs a press, an aim
+	/// and a release per item across two panels. Shift-click sends the item to the first free slot
+	/// of the other container instead.
+	/// </para>
+	/// <para>
+	/// The destination is chosen from what this client can see, and the request is the same swap a
+	/// drag onto that slot would have sent — deliberately, so it carries exactly the risk the drag
+	/// it replaces already carried. What it must not do is pick a slot that is occupied or waiting,
+	/// because a swap into an occupied slot moves two items when the player asked to move one.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class QuickTransferTests
+	{
+		private const string PanelPath =
+			"Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs";
+
+		private const string BankPath =
+			"Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs";
+
+		private const string InventoryPath =
+			"Assets/Scripts/Client/GUI/World/Inventory/UITKInventory.cs";
+
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path);
+		}
+
+		/// <summary>The body of a named method in a source file.</summary>
+		private static string MethodBody(string relativePath, string signature, string nextSymbol)
+		{
+			string source = ReadSource(relativePath);
+
+			int start = source.IndexOf(signature, StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, $"{relativePath} must still declare {signature}");
+
+			int end = source.IndexOf(nextSymbol, start, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > start, $"{relativePath}: the end of {signature} must be locatable");
+
+			return source.Substring(start, end - start);
+		}
+
+		[Test]
+		public void TheDestinationSlotIsFreeAndNotWaiting()
+		{
+			/* The one thing quick transfer must get right. A swap into an occupied slot exchanges
+			 * two items when the player asked to move one, and a slot that is locked is already
+			 * answering a different request. */
+			string body = MethodBody(PanelPath, "private static int FirstFreeSlot", "/// <summary>Shows a transient notice");
+
+			LogAssert.IsTrue(body.Contains("IsSlotEmpty"),
+				"the destination must be an empty slot");
+			LogAssert.IsTrue(body.Contains("IsSlotLocked"),
+				"a slot already waiting on a request must not be chosen");
+		}
+
+		[Test]
+		public void AFullDestinationIsRefusedOutLoud()
+		{
+			/* A shift-click that silently does nothing is indistinguishable from one the game did
+			 * not register, and the player's next move is to try it again. */
+			string body = MethodBody(PanelPath, "protected void TryQuickTransfer", "private string QuickTransferTargetName");
+
+			LogAssert.IsTrue(body.Contains("< 0"),
+				"a container with no free slot must be detected");
+			LogAssert.IsTrue(body.Contains("Notify("),
+				"and the refusal must be shown to the player");
+		}
+
+		[Test]
+		public void BothEndsAreClaimedOrNeither()
+		{
+			/* Same rule the drag path follows: a slot marked as waiting for a request that was
+			 * never sent stays locked until the panel is rebuilt. */
+			string body = MethodBody(PanelPath, "protected void TryQuickTransfer", "private string QuickTransferTargetName");
+
+			LogAssert.IsTrue(body.Contains("ItemOperationTracker.Release("),
+				"claiming the second end and failing must release the first");
+		}
+
+		[Test]
+		public void ShiftClickIsRoutedSeparatelyFromAPlainClick()
+		{
+			/* A plain click still starts a drag or completes one; only shift diverts it. Reading the
+			 * modifier from the event rather than polling input state keeps the two in step. */
+			string body = MethodBody(PanelPath, "private void OnSlotPointerDown", "protected virtual void HandleSlotRightClick");
+
+			LogAssert.IsTrue(body.Contains("evt.shiftKey"),
+				"shift must be read from the click that happened");
+			LogAssert.IsTrue(body.Contains("TryQuickTransfer"),
+				"a shift-click must route to the transfer");
+			LogAssert.IsTrue(body.Contains("HandleSlotLeftClick"),
+				"a plain click must still behave as before");
+		}
+
+		[Test]
+		public void EachPanelSendsTheOtherContainersRequest()
+		{
+			/* Moving INTO the bank is a bank swap whoever asked for it, so the panel losing the item
+			 * names the other panel's broadcast. Getting this backwards would ask the server to move
+			 * the item to where it already is. */
+			LogAssert.IsTrue(
+				MethodBody(BankPath, "protected override void SendQuickTransferRequest", "/// <inheritdoc/>\n\t\tprotected override void SendSwapRequest")
+					.Contains("InventorySwapItemSlotsBroadcast"),
+				"the bank must send an inventory swap to push an item out to the inventory");
+
+			LogAssert.IsTrue(
+				MethodBody(InventoryPath, "protected override void SendQuickTransferRequest", "/// <inheritdoc/>\n\t\tprotected override void SendSwapRequest")
+					.Contains("BankSwapItemSlotsBroadcast"),
+				"the inventory must send a bank swap to push an item into the bank");
+		}
+
+		[Test]
+		public void ThePanelsPointAtEachOther()
+		{
+			LogAssert.IsTrue(
+				ReadSource(BankPath).Contains("QuickTransferTarget => ReferenceButtonType.Inventory"),
+				"the bank sends to the inventory");
+
+			LogAssert.IsTrue(
+				ReadSource(InventoryPath).Contains("QuickTransferTarget => ReferenceButtonType.Bank"),
+				"the inventory sends to the bank");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/QuickTransferTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3bbf32f76fa86bc4cb74974f88b602a4


### PR DESCRIPTION
Closes #197.

Shift-clicking a slot sends the item to the first free slot of the other container — inventory to
bank, bank to inventory. Banking a bagful is the operation players repeat most, and by drag it
costs a press, an aim and a release per item across two panels.

## Written once

It lives in `UITKItemGridPanel`, so both panels have it and neither can drift from the other. Each
panel names two things: the container it pushes to, and the request that performs the move.

The request belongs to the **destination**, not the sender — moving into the bank is a bank swap
whoever asked for it — so the panel losing the item sends the other panel's broadcast. Getting that
backwards would ask the server to move the item to where it already is.

## The destination slot

The first slot this client sees as **empty and unlocked**, and the request is the same swap a drag
onto that slot would have sent.

That is deliberate. It carries exactly the risk the drag it replaces already carried, and no more:
if this client believes a slot is empty and the server disagrees, the swap exchanges two items —
but a player aiming a drag at that same slot gets the same outcome. Quick transfer is not
introducing a class of mistake, only saving the aiming.

A locked slot is skipped rather than treated as free, because it is already answering a request of
its own and a second one aimed at it would be refused.

Both ends are claimed or neither, the same rule the drag path follows: a slot marked as waiting for
a request that was never sent stays locked until the panel is rebuilt.

## Refusals are said out loud

A full destination shows a toast. A shift-click that silently does nothing is indistinguishable
from one the game did not register, and the player's next move is to try it again.

## Decisions from the issue

- **Where it lands** — first free slot. Merging into an existing stack of the same item is the
  better behaviour but wants stack splitting (#198) alongside it, so it is not attempted here.
- **No room** — refused whole, never partially moved, and said out loud.
- **Equipment** — untouched. Shift-clicking an equipped item does nothing, which is the safer
  starting point.

Nothing new is trusted to the client. The server revalidates, and it refuses a bank swap when no
banker is in range — which is what stops a shift-click banking from anywhere.

## Tests

`QuickTransferTests` pins the free-and-unlocked rule, the spoken refusal, the claim-both-or-neither
rule, that shift is read from the click event rather than polled, and that each panel sends the
*other* container's request.

Verified with a negative control: accepting locked slots as free, and silencing the refusal, each
fail the test written for them.

## Note on the suite

Six `ExploredReadoutTests` fail on this branch and are unrelated — they are the map handle bug fixed
in #206, which this branch does not include. With that merged the suite is 1303/1303.
