### PR TITLE
Disambiguate SceneType and SceneStatus in GroupFinder

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.GroupFinder.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.GroupFinder.cs
@@ -13,6 +13,12 @@ using System.Linq;
 using System;
 using System.Threading.Tasks;
 using UnityEngine;
+// The DB-side SceneType and SceneStatus enums (FishMMO.Database.Data.Enums)
+// collide with the game-side ones (FishMMO.Shared) that this file also uses.
+// The unqualified name resolves to the shared enum here; the DB enum is used
+// explicitly by its full name at the DB boundary.
+using SceneType = FishMMO.Shared.SceneType;
+using SceneStatus = FishMMO.Shared.SceneStatus;
 
 namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 {


### PR DESCRIPTION
The new `InteractableSystem.GroupFinder.cs` does not compile: it `using`s both `FishMMO.Shared` and `FishMMO.Database.Data.Enums`, and each defines its own `SceneType` and `SceneStatus`. Unqualified references to `SceneType.Group` and `SceneStatus.Ready` fail with:

```
error CS0104: 'SceneType' is an ambiguous reference between
              'FishMMO.Database.Data.Enums.SceneType' and 'FishMMO.Shared.SceneType'
```

Five sites at lines 367, 885, 908, 976 (some carry two).

Two `using` aliases at the top point the unqualified names at the shared enum. The DB-side enum keeps working through its fully-qualified name, which the file already uses at the boundary casts:

```csharp
(FishMMO.Database.Data.Enums.SceneType)(int)SceneType.Group
```

That pattern is the reason the shared enum is what the RHS wants: the whole point of the cast is to promote a shared value across the DB boundary.

No behavioural change — both enums are `: int` with matching values, so the numeric conversions come out the same. Just gets the file back to compiling.

Verified on a Unity EditMode run: full suite **1409/1409**, including `GroupFinderRulesTests` 17/17. On a clean `dev` checkout it was 0 tests run, because the assembly failed to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)