### PR TITLE
Give hostile NPCs an ability to attack with

### DIFF
--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc mage.prefab
@@ -373,7 +373,8 @@ MonoBehaviour:
   LootTable: {fileID: 0}
   onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 0f2ff92179a6d1b4c9dde7ad6a4afdb0, type: 2}
-  Abilities: []
+  Abilities:
+  - {fileID: 11400000, guid: 9a571cab03b3f684da8436e4391abdbb, type: 2}
   objectSpawner: {fileID: 0}
   spawnableSettings:
     rid: -2

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc warrior.prefab
@@ -375,7 +375,8 @@ MonoBehaviour:
   LootTable: {fileID: 0}
   onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 0f2ff92179a6d1b4c9dde7ad6a4afdb0, type: 2}
-  Abilities: []
+  Abilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   objectSpawner: {fileID: 0}
   spawnableSettings:
     rid: -2

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Monsters/Orcs/an orc.prefab
@@ -374,7 +374,8 @@ MonoBehaviour:
   LootTable: {fileID: 0}
   onInteractTriggers: []
   AttributeBonuses: {fileID: 11400000, guid: 7c33d6280baf6d94b8eee0548a749deb, type: 2}
-  Abilities: []
+  Abilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   objectSpawner: {fileID: 0}
   spawnableSettings:
     rid: -2

--- a/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
+++ b/FishMMO-Unity/Assets/Prefabs/Shared/Entity/NPCs/Pets/a lesser fire elemental.prefab
@@ -5213,7 +5213,8 @@ MonoBehaviour:
   LootTable: {fileID: 0}
   onInteractTriggers: []
   AttributeBonuses: {fileID: 0}
-  Abilities: []
+  Abilities:
+  - {fileID: 11400000, guid: 7c14874e3c902684a8d562913ed73c24, type: 2}
   objectSpawner: {fileID: 0}
   spawnableSettings:
     rid: -2

--- a/FishMMO-Unity/Assets/UnitTests/HostileNpcAbilityTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/HostileNpcAbilityTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that an NPC meant to fight knows at least one ability.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Reported as "I received no damage from any of the 3 mobs". Every combat trigger in the server
+	/// log had the player as its initiator and not one had a mob, and the reason was simply that no
+	/// NPC in the project knew any ability at all — all seven shipped with an empty list.
+	/// </para>
+	/// <para>
+	/// The first suspect was the AI archetypes, every one of which has a null
+	/// <c>AbilityRotation</c>. That is a red herring: a rotation is an OVERRIDE, and
+	/// <c>AIController.PickBestAbility</c> falls through to its own scoring-based picker when there
+	/// is none. The picker chooses from the NPC's known abilities, so with an empty list it returns
+	/// null however the archetype is configured, and an NPC stands there.
+	/// </para>
+	/// <para>
+	/// A vendor is exempt: a banker with no attack is correct. The test keys on whether the NPC has
+	/// an AI archetype that makes it hostile, so a new merchant does not have to be added to a list
+	/// here, while a new monster is covered the day it is created.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class HostileNpcAbilityTests
+	{
+		private static string NpcRoot =>
+			Path.Combine(Directory.GetCurrentDirectory(), "Assets/Prefabs/Shared/Entity/NPCs");
+
+		/// <summary>Names of AI archetypes whose NPCs are expected to fight.</summary>
+		/// <remarks>
+		/// Enemy and Pet both attack; only the vendor archetypes do not. Matched on the archetype
+		/// asset's own name so this does not need a per-prefab exclusion list.
+		/// </remarks>
+		private static readonly string[] FightingArchetypePrefixes = { "Enemy - ", "Pet - " };
+
+		[Test]
+		public void EveryFightingNpcKnowsAnAbility()
+		{
+			LogAssert.IsTrue(Directory.Exists(NpcRoot), $"NPC prefabs must live at {NpcRoot}");
+
+			Dictionary<string, string> archetypeNames = ArchetypeNamesByGuid();
+			LogAssert.IsTrue(archetypeNames.Count > 0, "there must be AI archetypes to resolve");
+
+			string[] prefabs = Directory.GetFiles(NpcRoot, "*.prefab", SearchOption.AllDirectories);
+			LogAssert.IsTrue(prefabs.Length > 0, "there must be NPC prefabs to check");
+
+			List<string> offenders = new List<string>();
+			int checkedCount = 0;
+
+			foreach (string prefab in prefabs)
+			{
+				string source = File.ReadAllText(prefab);
+
+				Match archetype = Regex.Match(source, "Archetype: \\{fileID: \\d+, guid: ([0-9a-f]{32})");
+				if (!archetype.Success ||
+					!archetypeNames.TryGetValue(archetype.Groups[1].Value, out string archetypeName) ||
+					!Fights(archetypeName))
+				{
+					continue;
+				}
+
+				checkedCount++;
+
+				/* An empty list serialises as "Abilities: []" and a populated one as "Abilities:"
+				 * followed by entries, so the bracket is the whole test. */
+				if (Regex.IsMatch(source, "\\n  Abilities: \\[\\]"))
+				{
+					offenders.Add($"{Path.GetFileNameWithoutExtension(prefab)} ({archetypeName})");
+				}
+			}
+
+			LogAssert.IsTrue(checkedCount > 0,
+				"no NPC resolved to a fighting archetype — the archetype lookup has stopped working");
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"an NPC with a fighting archetype and no abilities cannot attack anything, whatever " +
+				"its AI is set to: " + string.Join(", ", offenders));
+		}
+
+		/// <summary>Maps each AI archetype asset's guid to its file name.</summary>
+		private static Dictionary<string, string> ArchetypeNamesByGuid()
+		{
+			Dictionary<string, string> names = new Dictionary<string, string>();
+
+			string templates = Path.Combine(Directory.GetCurrentDirectory(), "Assets/Templates");
+			if (!Directory.Exists(templates))
+			{
+				return names;
+			}
+
+			foreach (string meta in Directory.GetFiles(templates, "*.asset.meta", SearchOption.AllDirectories))
+			{
+				string name = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(meta));
+				if (!Fights(name))
+				{
+					continue;
+				}
+
+				Match guid = Regex.Match(File.ReadAllText(meta), "guid: ([0-9a-f]{32})");
+				if (guid.Success)
+				{
+					names[guid.Groups[1].Value] = name;
+				}
+			}
+
+			return names;
+		}
+
+		private static bool Fights(string archetypeName)
+		{
+			foreach (string prefix in FightingArchetypePrefixes)
+			{
+				if (archetypeName.StartsWith(prefix, StringComparison.Ordinal))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/HostileNpcAbilityTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/HostileNpcAbilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88eb9745b735f41468dc5b7805dedac3


### PR DESCRIPTION
Stacked on #215. Fixes "I received no damage from any of the 3 mobs."

## What was wrong

Every combat trigger in the server log had the player as its initiator, and not one had a mob. The reason turned out to be blunt: **no NPC in the project knew any ability.** All seven shipped with `Abilities: []`, so there was nothing for any of them to attack with.

## The red herring, recorded because it is convincing

All sixteen AI archetypes have a null `AbilityRotation` — every `Enemy - *` and every `Pet - *`. That looks exactly like the cause and is not one.

A rotation is an **override**. `AIController.PickBestAbility` evaluates it only `if (AbilityRotation != null)` and otherwise falls straight through to its own scoring-based picker. That picker chooses from the NPC's *known abilities*, so with an empty list it returns null no matter how the archetype is configured. Authoring sixteen rotations would have changed nothing.

## Assignment

From the five ability templates that actually exist (the other 34 are `Mock/`), matched to each NPC's archetype:

| NPC | Archetype | Ability |
|---|---|---|
| an orc | Enemy - Brute | Punch |
| an orc warrior | Enemy - Melee | Punch |
| an orc mage | Enemy - Caster | Lesser Fireball |
| a lesser fire elemental | Pet - * | Lesser Flame |

The three vendors keep none, which is correct for a banker.

## Test

`HostileNpcAbilityTests` keys on whether an NPC's archetype is an `Enemy - ` or `Pet - ` rather than on a list of prefab names — so a new merchant needs no exemption, and a new monster is covered the day it is created. It also asserts that it found some fighting NPCs at all, so the archetype lookup silently breaking cannot turn it into a no-op.

Verified against the pre-fix prefabs rather than by trusting a green run: it reports all four, and passes after.

Suite **1421/1421**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)