### PR TITLE
Release chat focus from the element that actually holds it

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChat.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Chat/UITKChat.cs
@@ -596,6 +596,38 @@ namespace FishMMO.Client
 		/// <summary>
 		/// True when the chat input field currently holds keyboard focus.
 		/// </summary>
+		/// <summary>Releases keyboard focus from the input, whichever element actually holds it.</summary>
+		/// <remarks>
+		/// A TextField delegates focus to an inner text element, so the focused element is a CHILD
+		/// of the field and calling Blur() on the field itself can be a no-op -- the field was never
+		/// the focused element. Focus then survives the "release", <see cref="IsInputFocused"/> stays
+		/// true forever, and two things follow from it: EnableChatInput returns early on every later
+		/// press so chat cannot be reopened, and the panel keeps asking for the cursor so mouse mode
+		/// never auto-dismisses. Reported as sending one line and then being unable to send another
+		/// until the cursor was toggled by hand, which is what cleared the stale focus.
+		///
+		/// Blurs the element the focus controller actually names, then the field, so it releases
+		/// whichever of the two is holding on.
+		/// </remarks>
+		private void ReleaseInputFocus()
+		{
+			if (inputField == null)
+			{
+				return;
+			}
+
+			VisualElement focused = inputField.panel?.focusController?.focusedElement as VisualElement;
+			if (focused != null && IsSelfOrDescendant(focused, inputField))
+			{
+				focused.Blur();
+			}
+
+			inputField.Blur();
+		}
+
+		/// <summary>
+		/// True when the chat input field currently holds keyboard focus.
+		/// </summary>
 		private bool IsInputFocused =>
 			inputField != null &&
 			inputField.panel != null &&
@@ -667,7 +699,7 @@ namespace FishMMO.Client
 					 * hit Escape or click the world. Escape was given this treatment and Enter was
 					 * not, which is why sending one chat line silently disabled the game. */
 					inputReleasedOnFrame = Time.frameCount;
-					inputField.Blur();
+					ReleaseInputFocus();
 					evt.StopPropagation();
 					break;
 
@@ -678,7 +710,7 @@ namespace FishMMO.Client
 					 * means "stop typing", which is what every other game means by it. */
 					inputField.value = "";
 					ResetInputHistoryCursor();
-					inputField.Blur();
+					ReleaseInputFocus();
 					evt.StopPropagation();
 					break;
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/NPC/NPC.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/NPC/NPC.cs
@@ -966,6 +966,12 @@ namespace FishMMO.Shared
 				// NPCs don't craft abilities so there's no DB-assigned ID.
 				Ability ability = new Ability((long)template.ID, template);
 				abilityController.LearnAbility(ability);
+
+				/* What an NPC actually walks away knowing. The AI's ability picker chooses from
+				 * exactly this set, so an NPC that learns nothing here cannot attack whatever its
+				 * archetype or rotation says -- and that failure is otherwise invisible: the mob
+				 * still aggroes, still chases and still repositions, it simply never swings. */
+				Log.Debug("NPC", $"'{name}' learned ability '{template.name}' (ID {template.ID}).");
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/KCC/KCCPlayer.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Prediction/KCC/KCCPlayer.cs
@@ -432,6 +432,20 @@ namespace FishMMO.Shared
 			}
 			Motor.SetPlatformVelocity(platformVelocity);
 
+			/* The two numbers that decide whether a rider is actually carried. The motor adds the
+			 * platform velocity only when the platform is moving UP into the character (dot > 0.5)
+			 * or the character is stably grounded on it -- and a platform travelling horizontally
+			 * has a dot near zero, so a rider who is not stably grounded is not carried at all and
+			 * stands still while the deck slides away. Zero velocity produces the same symptom for
+			 * a different reason, so both are named. */
+			if (currentPlatform != null)
+			{
+				Log.Debug("KCCPlayer",
+					$"Riding '{currentPlatform.name}': platformVelocity={platformVelocity} " +
+					$"(magnitude {platformVelocity.magnitude:0.###}), " +
+					$"stableOnGround={Motor.GroundingStatus.IsStableOnGround}.");
+			}
+
 			// Stamina consumed by sprint/jump inside the motor update (KCCController.UpdateVelocity)
 			// must still re-simulate during reconcile replay to keep the predicted stamina value
 			// correct, but the OnAttributeUpdated notifications it raises must NOT fire during

--- a/FishMMO-Unity/Assets/UnitTests/ChatScrollBehaviourTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/ChatScrollBehaviourTests.cs
@@ -115,6 +115,25 @@ namespace FishMMO.UnitTests
 		}
 
 		[Test]
+		public void ReleasingTheInputBlursWhatActuallyHasFocus()
+		{
+			/* A TextField delegates focus to an inner text element, so the focused element is a
+			 * CHILD of the field and Blur() on the field itself can be a no-op. Focus then survives
+			 * the release: EnableChatInput returns early on every later press so chat cannot be
+			 * reopened, and the panel keeps asking for the cursor so mouse mode never dismisses.
+			 * Reported as sending one line and then being unable to send another. */
+			string source = ReadSource(ChatPath);
+
+			string release = MethodBody(source, "private void ReleaseInputFocus", "private bool IsInputFocused");
+			LogAssert.IsTrue(release.Contains("focusedElement"),
+				"the release must blur the element the focus controller actually names");
+
+			string keys = MethodBody(source, "private void OnInputKeyDown", "private void OnInputFocusOut");
+			LogAssert.IsFalse(keys.Contains("inputField.Blur()"),
+				"the key handler must release through ReleaseInputFocus, not the field alone");
+		}
+
+		[Test]
 		public void SenderlessRowsDoNotCarryAnEmptyLabel()
 		{
 			/* The row wraps, and a hidden child still counts as a flex item — it opened an empty


### PR DESCRIPTION
Fixes: "I sent one message and then I could not send a second, but then I hid the cursor and then I could."

## Cause

A `TextField` delegates focus to an inner text element, so the focused element is a **child** of the field — and `inputField.Blur()` can be a no-op, because the field itself was never what had focus.

Focus therefore survived the release, and both reported symptoms follow from that one fact:

- `IsInputFocused` stayed true, so `EnableChatInput` returned early on every later press and chat could not be reopened.
- The panel kept reporting that it needed the cursor, so `HandleAutoDismiss` never turned mouse mode off.

Toggling the cursor by hand cleared the stale focus — which is exactly the workaround that was found, and the thing that made this look strange rather than broken.

`ReleaseInputFocus` blurs the element the focus controller actually names, then the field, so it releases whichever of the two is holding on. Both the send path and the Escape path go through it.

## Two diagnostics for defects still open

Neither is a fix; both are the decisive missing number.

**Platform carry.** The motor adds platform velocity only when the platform moves *up* into the character (`dot > 0.5`) or the rider is `IsStableOnGround`. A horizontally travelling deck has a dot near zero, so an ungrounded rider is not carried at all. The server log already shows the rider picked up and dropped one second later — which is what an uncarried rider does: they slide out of the volume and are never picked up again. `KCCPlayer` now logs the velocity and the grounding flag, which separates "zero velocity" from "not stable ground".

**NPC abilities.** #216 assigned them and the learning code is correct, but no mob has attacked yet. `PickBestAbility` chooses from exactly the learned set, and an NPC that learns nothing cannot attack however its AI is configured — while still aggroing, chasing and repositioning, which is what makes it look like an AI problem. `NPC` now logs what each one walks away knowing.

## Verified this round

The orc warrior fix from #212 is confirmed at the mechanism level — the server log now reads `Swept hit: collider 'an orc warrior(Clone)' … character an orc warrior(Clone)`, where before every swing resolved to the caster.

Suite **1422/1422**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)