### PR TITLE
Give Civilian - Townsfolk a return-home state

### DIFF
--- a/FishMMO-Unity/Assets/Templates/Entity/NPCs/AI/Archetypes/Civilian - Townsfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/NPCs/AI/Archetypes/Civilian - Townsfolk.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   IdleState: {fileID: 11400000, guid: 51f855b3de8e6644eb22eee716657935, type: 2}
   WanderState: {fileID: 11400000, guid: b4bee0c12e3b92c48b285850bd5d47c1, type: 2}
   PatrolState: {fileID: 0}
-  ReturnHomeState: {fileID: 0}
+  ReturnHomeState: {fileID: 11400000, guid: b84f263b6aaadc40b9179f69c75abdf0, type: 2}
   RetreatState: {fileID: 0}
   DeadState: {fileID: 0}
   Personality: {fileID: 0}


### PR DESCRIPTION
Fixes `AIArchetypeAssetTests.EveryArchetype_IsInternallyConsistent`, one of eight tests currently failing on `dev`.

> Civilian - Townsfolk: InitialState has leashing enabled but no ReturnHomeState is assigned — CheckLeash bails out and the NPC never leashes.

## Why on the archetype rather than the state

The other way to satisfy it is to turn leashing off on the initial state — but that state is `Basic Wander State`, and **`an orc` uses it too**. Clearing the flag there would change the orc's behaviour as a side effect of fixing a civilian.

Every `Enemy - *` archetype already points at `Shared ReturnHome State`; this makes Townsfolk the same. A townsfolk walking home is what leashing should mean for a civilian, so the archetype was simply missing the state rather than wanting the behaviour disabled.

One line, one asset.

`AIArchetypeAssetTests` **19/19**.

## The other seven failures — deliberately not touched

They are all in newly-added work and each needs a call that is yours, not mine:

| Test | What it wants | Why I stopped |
|---|---|---|
| `StartingAbilityTests.EveryRaceGrantsAtLeastOneAbility` | Race 'Abyssal Dreamer' grants no starting abilities | **146 of 149 races grant none** — only Elf, Human and Orc do, each granting Punch. Whether monster races are meant to be playable (and so covered by this test) is a design decision across 146 assets. |
| `NameGeneratorWindowTests.Generate_CountIsClampedToOneHundred` | count clamps to 100, got 5000 | The clamp exists (`Mathf.Clamp(e.newValue, 1, 100)`) but runs in a `ValueChangedCallback`, which needs a panel to dispatch. This may be the harness rather than the code. |
| `NameGeneratorWindowTests.SelectCategory_ShowsRaceOrBiomeAsAppropriate` | Cities must hide the biome row | Intent of the Cities category is yours. |
| `TitleGenerationTests` ×2 | capitalisation of composed objects; which honorifics take a place | Both are content/grammar rules for your generator. |
| `SceneObjectNamerTests.DungeonAndPOI_NeedABiome_AndWorkWithOne` | error text containing `"Biome"` | The message reads "…names need a biome" — capitalising mid-sentence would make the prose worse, so the test may be what wants relaxing. |
| `CombatAudit20260831RecommendedFixTests.TargetSelection_IsReportedVerifiedAndBounded` | owner's trace tick must report frame changes | Needs the intent behind the audit item. |

Happy to take any of these if you say which way you want them to go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)