### PR TITLE
Grant every race Punch, and point the biome error at its field

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Naming/SceneObjectNameResolver.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Entity/Naming/SceneObjectNameResolver.cs
@@ -339,7 +339,10 @@ namespace FishMMO.Shared
 			if (settings.RequiresBiome && (biome == null || biome.Naming == null || !biome.Naming.IsUsable))
 			{
 				error = biome == null
-					? $"{settings.Mode} names need a biome: set one, or place the object where the scene's biome map covers"
+					/* Names the Biome field rather than saying "a biome", so the message points at the
+					 * thing to change. The two ways out are a field on this object and a property of
+					 * where it sits, and the reader has to be told which is which. */
+					? $"{settings.Mode} names need a biome. Set the Biome field, or place the object where the scene's biome map covers."
 					: $"biome '{biome.name}' has no naming data";
 				return false;
 			}

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Abyssal Dreamer.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Abyssal Dreamer.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Air Elemental.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Air Elemental.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Animated Armor.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Animated Armor.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Arachnid.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Arachnid.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Banshee.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Banshee.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Basilisk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Basilisk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Beastman.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Beastman.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Birdfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Birdfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Blindkin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Blindkin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Boar.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Boar.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Boggart.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Boggart.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Bone Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Bone Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Bugbear.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Bugbear.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cambion.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cambion.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Catfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Catfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cave Bear.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cave Bear.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Celestial.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Celestial.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Centaur.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Centaur.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Changeling.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Changeling.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Chimera.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Chimera.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Clay Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Clay Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cloud Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cloud Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cockatrice.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cockatrice.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cragborn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cragborn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Cyclops.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Cyclops.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dark Elf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dark Elf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dawnborn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dawnborn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Death Knight.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Death Knight.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Deep Gnome.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Deep Gnome.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Deepfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Deepfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Demon.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Demon.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Devil.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Devil.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dire Wolf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dire Wolf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Doppelganger.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Doppelganger.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dragon.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dragon.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Drake.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Drake.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Drakekin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Drakekin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dryad.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dryad.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Duergar.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Duergar.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Dwarf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Dwarf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Earth Elemental.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Earth Elemental.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Elementborn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Elementborn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Elephantfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Elephantfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ettin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ettin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Fae.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Fae.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Fire Elemental.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Fire Elemental.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Fire Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Fire Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Fishfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Fishfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Flesh Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Flesh Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Forgeborn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Forgeborn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Frogfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Frogfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Frost Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Frost Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gargoyle.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gargoyle.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gazer.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gazer.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ghast.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ghast.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ghost.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ghost.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ghoul.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ghoul.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Beetle.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Beetle.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Rat.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Rat.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Spider.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Spider.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Toad.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Giant Toad.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gnoll.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gnoll.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gnome.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gnome.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Goblin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Goblin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gorgon.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gorgon.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Gremlin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Gremlin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Griffin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Griffin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Hag.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Hag.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Half-Elf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Half-Elf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Halfling.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Halfling.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Harpy.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Harpy.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Hellborn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Hellborn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Hill Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Hill Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Hobgoblin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Hobgoblin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Hydra.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Hydra.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ice Wraith.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ice Wraith.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Imp.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Imp.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Iron Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Iron Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Jelly.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Jelly.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Kobold.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Kobold.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Kraken.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Kraken.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Lich.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Lich.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Lindworm.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Lindworm.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Living Statue.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Living Statue.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Lizardfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Lizardfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Mandrake.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Mandrake.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Manticore.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Manticore.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Mantisfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Mantisfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Merfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Merfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Mimic.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Mimic.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Mindreaver.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Mindreaver.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Minotaur.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Minotaur.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Mummy.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Mummy.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Naga.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Naga.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ogre.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ogre.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ooze.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ooze.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Phoenix.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Phoenix.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Pixie.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Pixie.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Poison Frogfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Poison Frogfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Rat King.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Rat King.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ratfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ratfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Ravenfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Ravenfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Revenant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Revenant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Salamander.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Salamander.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Sand Worm.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Sand Worm.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Satyr.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Satyr.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Scorpion.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Scorpion.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Sea Serpent.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Sea Serpent.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Serpentfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Serpentfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Shade.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Shade.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Sharkfolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Sharkfolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Siren.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Siren.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Skeleton.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Skeleton.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Slime.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Slime.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Specter.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Specter.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Spider Elf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Spider Elf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Spider Queen.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Spider Queen.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Spiderkin.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Spiderkin.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Spirit.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Spirit.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Sporeling.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Sporeling.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Stone Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Stone Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Stone Golem.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Stone Golem.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Storm Giant.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Storm Giant.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Succubus.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Succubus.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Sylph.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Sylph.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Talonbear.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Talonbear.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Thornbeast.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Thornbeast.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Treefolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Treefolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Troglodyte.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Troglodyte.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Troll.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Troll.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Turtlefolk.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Turtlefolk.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Undead.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Undead.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Undine.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Undine.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Unicorn.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Unicorn.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Vampire.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Vampire.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wasp Swarm.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wasp Swarm.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Water Elemental.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Water Elemental.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Werewolf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Werewolf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wight.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wight.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wildblood.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wildblood.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wisp.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wisp.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wood Elf.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wood Elf.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wraith.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wraith.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Wyvern.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Wyvern.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:

--- a/FishMMO-Unity/Assets/Templates/Entity/Races/Zombie.asset
+++ b/FishMMO-Unity/Assets/Templates/Entity/Races/Zombie.asset
@@ -31,7 +31,8 @@ MonoBehaviour:
     HeadScale: 1
   InitialAttributes: {fileID: 0}
   InitialFaction: {fileID: 0}
-  StartingAbilities: []
+  StartingAbilities:
+  - {fileID: 11400000, guid: 2e669850a4855b9438e174f70db28d9a, type: 2}
   StartingInventoryItems: []
   StartingEquipment: []
   Naming:


### PR DESCRIPTION
Two of the eight tests failing on `dev`. The third, `AIArchetypeAssetTests`, is #222; the name-generator pair is raised as #223.

## Starting abilities

`StartingAbilityTests.EveryRaceGrantsAtLeastOneAbility` reports one race with no starting ability. It is **146 of 149** — only Elf, Human and Orc grant anything, and all three grant Punch.

Every other race began with no way to attack at all. That is the same gap that left every NPC unable to fight (#216): the ability picker chooses from what the character knows, and an empty list means it returns nothing however the rest is configured.

Punch for all of them, matching the three already set. It is the unarmed baseline every creature should have, and a race that wants something better can add to it rather than start from nothing.

146 assets, one line each.

## Biome error message

`SceneObjectNamerTests.DungeonAndPOI_NeedABiome_AndWorkWithOne` asserts the error contains `"Biome"`. The message read:

> Dungeon names need a biome: set one, or place the object where the scene's biome map covers

Capitalising "biome" mid-sentence to satisfy the assertion would make the prose worse. Instead the message now names the **field** to set:

> Dungeon names need a biome. Set the Biome field, or place the object where the scene's biome map covers.

The two ways out are a field on the object and a property of where it sits, and the reader has to be told which is which — so naming the field is what the message was missing anyway.

`StartingAbilityTests` + `SceneObjectNamerTests`: **19/19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)