### PR TITLE
Guard client-only views out of the server build

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Arena/ArenaFlagVisuals.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Arena/ArenaFlagVisuals.cs
@@ -40,6 +40,11 @@ namespace FishMMO.Client
 		/// <summary>Brings the drawn flags into line with a match state.</summary>
 		public static void Apply(ArenaMatchStateBroadcast state, ArenaTemplate template)
 		{
+#if UNITY_SERVER
+			/* Arena flag markers are a client view. BaseCharacter.ClientCharacters does not exist
+			 * in a server build, and a server draws no markers. */
+			return;
+#else
 			if (state.Objectives == null || state.Phase == ArenaMatchPhase.Ended || state.Phase == ArenaMatchPhase.Cancelled)
 			{
 				Clear();
@@ -104,6 +109,7 @@ namespace FishMMO.Client
 			{
 				Remove(id);
 			}
+		#endif
 		}
 
 		/// <summary>Destroys every marker.</summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/World/ClientNameplateDisplay.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/World/ClientNameplateDisplay.cs
@@ -261,6 +261,11 @@ namespace FishMMO.Client
 		/// </summary>
 		private void Sweep()
 		{
+#if UNITY_SERVER
+			/* Nameplates are a client view. BaseCharacter.ClientCharacters does not exist in a server
+			 * build, and there is nothing to draw for anyway. */
+			return;
+#else
 			Transform currentTarget = targetController != null ? targetController.Current.Target : null;
 			/* The pinned character counts as targeted for as long as the pin holds: its card is
 			 * up and its nameplate belongs with it, whatever the pointer is doing. */
@@ -319,6 +324,7 @@ namespace FishMMO.Client
 					guildLabel.gameObject.SetActive(visible);
 				}
 			}
+		#endif
 		}
 
 		/// <summary>Squared distance from the local player to a character, in metres squared.</summary>


### PR DESCRIPTION
The server build does not compile:

```
ArenaFlagVisuals.cs(68,25):        error CS0117
ClientNameplateDisplay.cs(269,51): error CS0117
'BaseCharacter' does not contain a definition for 'ClientCharacters'
```

`BaseCharacter.ClientCharacters` is declared inside `#if !UNITY_SERVER`, and both of these read it unguarded — so a server build reaches those lines with the symbol gone. The **client** build is unaffected, which is why it goes unnoticed until someone builds a server.

## The fix

Both are client views — arena flag markers and nameplates — and a server draws neither, so each returns early on the server rather than being compiled out entirely.

A whole-class guard would have been wrong: `ClientNameplateDisplay` is referenced from `Client.cs`, `UITKOptions`, `UITKTarget` and `ClientWorldLabelSettings`, none of which are guarded, so removing the type from server builds would just move the error.

This matches the pattern already used in `ClientAudioFocusWatcher` and `ClientSettingsPump`.

Twelve lines, two files.

## Based on 1c93c37f, not dev's tip

Deliberately. `ebf11ca6` cannot compile `FishMMO.Shared.dll` at all — the FishNet weaver fails with `IsReadOnlyAttribute ... is declared in another module`, raised as #229. This branch sits on the last commit that builds, so it can be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)