### PR TITLE
Write array serializers for broadcasts that carry [UseGlobalCustomSerializer]

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/AbilityBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/AbilityBroadcasts.cs
@@ -1,4 +1,4 @@
-using FishNet.Broadcast;
+﻿using FishNet.Broadcast;
 using FishNet.Serializing;
 using FishNet.CodeGenerating;
 using FishMMO.Logging;
@@ -40,6 +40,48 @@ namespace FishMMO.Shared
 			{
 				TemplateID = reader.ReadInt32Unpacked(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="KnownAbilityAddBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for KnownAbilityAddBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteKnownAbilityAddBroadcastArray(this Writer writer, KnownAbilityAddBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteKnownAbilityAddBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="KnownAbilityAddBroadcast"/>.</summary>
+		public static KnownAbilityAddBroadcast[] ReadKnownAbilityAddBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			KnownAbilityAddBroadcast[] value = new KnownAbilityAddBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadKnownAbilityAddBroadcast();
+			}
+
+			return value;
 		}
 	}
 
@@ -86,6 +128,48 @@ namespace FishMMO.Shared
 			{
 				TemplateID = reader.ReadInt32Unpacked(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="KnownAbilityEventAddBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for KnownAbilityEventAddBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteKnownAbilityEventAddBroadcastArray(this Writer writer, KnownAbilityEventAddBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteKnownAbilityEventAddBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="KnownAbilityEventAddBroadcast"/>.</summary>
+		public static KnownAbilityEventAddBroadcast[] ReadKnownAbilityEventAddBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			KnownAbilityEventAddBroadcast[] value = new KnownAbilityEventAddBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadKnownAbilityEventAddBroadcast();
+			}
+
+			return value;
 		}
 	}
 
@@ -189,6 +273,48 @@ namespace FishMMO.Shared
 				TemplateID = templateID,
 				Events = events,
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="AbilityAddBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for AbilityAddBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteAbilityAddBroadcastArray(this Writer writer, AbilityAddBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteAbilityAddBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="AbilityAddBroadcast"/>.</summary>
+		public static AbilityAddBroadcast[] ReadAbilityAddBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			AbilityAddBroadcast[] value = new AbilityAddBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadAbilityAddBroadcast();
+			}
+
+			return value;
 		}
 	}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/AchievementBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/AchievementBroadcasts.cs
@@ -1,4 +1,4 @@
-using FishNet.Broadcast;
+﻿using FishNet.Broadcast;
 using FishNet.Serializing;
 using FishNet.CodeGenerating;
 
@@ -48,6 +48,48 @@ namespace FishMMO.Shared
 				Value = reader.ReadUInt32(),
 				Tier = reader.ReadUInt8Unpacked(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="AchievementUpdateBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for AchievementUpdateBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteAchievementUpdateBroadcastArray(this Writer writer, AchievementUpdateBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteAchievementUpdateBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="AchievementUpdateBroadcast"/>.</summary>
+		public static AchievementUpdateBroadcast[] ReadAchievementUpdateBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			AchievementUpdateBroadcast[] value = new AchievementUpdateBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadAchievementUpdateBroadcast();
+			}
+
+			return value;
 		}
 	}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/FactionBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/FactionBroadcasts.cs
@@ -1,4 +1,4 @@
-using FishNet.Broadcast;
+﻿using FishNet.Broadcast;
 using FishNet.Serializing;
 using FishNet.CodeGenerating;
 
@@ -45,6 +45,48 @@ namespace FishMMO.Shared
 				TemplateID = reader.ReadInt32Unpacked(),
 				NewValue = reader.ReadInt32(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="FactionUpdateBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for FactionUpdateBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteFactionUpdateBroadcastArray(this Writer writer, FactionUpdateBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteFactionUpdateBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="FactionUpdateBroadcast"/>.</summary>
+		public static FactionUpdateBroadcast[] ReadFactionUpdateBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			FactionUpdateBroadcast[] value = new FactionUpdateBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadFactionUpdateBroadcast();
+			}
+
+			return value;
 		}
 	}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/Inventory/BankBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/Inventory/BankBroadcasts.cs
@@ -1,4 +1,4 @@
-using FishNet.Broadcast;
+﻿using FishNet.Broadcast;
 using FishNet.Serializing;
 using FishNet.CodeGenerating;
 
@@ -57,6 +57,48 @@ namespace FishMMO.Shared
 				Seed = reader.ReadInt32Unpacked(),
 				StackSize = reader.ReadUInt32(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="BankSetItemBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for BankSetItemBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteBankSetItemBroadcastArray(this Writer writer, BankSetItemBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteBankSetItemBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="BankSetItemBroadcast"/>.</summary>
+		public static BankSetItemBroadcast[] ReadBankSetItemBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			BankSetItemBroadcast[] value = new BankSetItemBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadBankSetItemBroadcast();
+			}
+
+			return value;
 		}
 	}
 

--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/Inventory/InventoryBroadcasts.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Network/Character/Inventory/InventoryBroadcasts.cs
@@ -1,4 +1,4 @@
-using FishNet.Broadcast;
+﻿using FishNet.Broadcast;
 using FishNet.Serializing;
 using FishNet.CodeGenerating;
 
@@ -56,6 +56,48 @@ namespace FishMMO.Shared
 				Seed = reader.ReadInt32Unpacked(),
 				StackSize = reader.ReadUInt32(),
 			};
+		}
+
+		/// <summary>Writes an array of <see cref="InventorySetItemBroadcast"/>.</summary>
+		/// <remarks>
+		/// Explicit because the element carries <c>[UseGlobalCustomSerializer]</c>. That attribute
+		/// tells FishNet the element has a hand-written serializer, and codegen then declines to
+		/// synthesise one for the ARRAY as well — it emits nothing and says nothing at build time.
+		/// The gap only appears when a broadcast carrying the array is actually sent, as
+		/// "Write method not found for InventorySetItemBroadcast[]", by which point the send has already failed.
+		/// A null array is written as length -1 so it round-trips as null rather than as empty.
+		/// </remarks>
+		public static void WriteInventorySetItemBroadcastArray(this Writer writer, InventorySetItemBroadcast[] value)
+		{
+			if (value == null)
+			{
+				writer.WriteInt32(-1);
+				return;
+			}
+
+			writer.WriteInt32(value.Length);
+			for (int i = 0; i < value.Length; i++)
+			{
+				writer.WriteInventorySetItemBroadcast(value[i]);
+			}
+		}
+
+		/// <summary>Reads an array of <see cref="InventorySetItemBroadcast"/>.</summary>
+		public static InventorySetItemBroadcast[] ReadInventorySetItemBroadcastArray(this Reader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length < 0)
+			{
+				return null;
+			}
+
+			InventorySetItemBroadcast[] value = new InventorySetItemBroadcast[length];
+			for (int i = 0; i < length; i++)
+			{
+				value[i] = reader.ReadInventorySetItemBroadcast();
+			}
+
+			return value;
 		}
 	}
 

--- a/FishMMO-Unity/Assets/UnitTests/BroadcastArraySerializerTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/BroadcastArraySerializerTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that every broadcast sent as an array can actually be written.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// A struct marked <c>[UseGlobalCustomSerializer]</c> tells FishNet its wire format is hand
+	/// written. Codegen then declines to synthesise a serializer for an ARRAY of that struct as
+	/// well, and says nothing at build time — the build is clean and the weaver logs no warning.
+	/// </para>
+	/// <para>
+	/// The gap surfaces only when a broadcast carrying the array is sent, as "Write method not
+	/// found for X[]", by which point the send has already failed. Reported as being unable to buy
+	/// from a merchant: the server took payment and granted the item, then could not tell the
+	/// client, so the purchase was refunded and the player saw a refusal. The same gap covered the
+	/// bank, learning an ability, and achievement updates.
+	/// </para>
+	/// <para>
+	/// Structs WITHOUT the attribute are fine — codegen covers element and array both — so this
+	/// checks the pairing rather than every array in the codebase.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class BroadcastArraySerializerTests
+	{
+		private static string NetworkRoot =>
+			Path.Combine(Directory.GetCurrentDirectory(),
+				"Assets/Scripts/Shared/Implementation/Network");
+
+		private static string ScriptsRoot =>
+			Path.Combine(Directory.GetCurrentDirectory(), "Assets/Scripts");
+
+		/// <summary>Source of every script under Assets/Scripts, line endings normalised.</summary>
+		private static string AllScriptSource()
+		{
+			StringBuilder builder = new StringBuilder();
+
+			foreach (string file in Directory.GetFiles(ScriptsRoot, "*.cs", SearchOption.AllDirectories))
+			{
+				builder.AppendLine(File.ReadAllText(file));
+			}
+
+			return builder.ToString();
+		}
+
+		/// <summary>Every broadcast type that appears as an array field in the network layer.</summary>
+		/// <remarks>
+		/// Read off the declaration rather than a type list, so a new array field is covered the
+		/// moment it is written.
+		/// </remarks>
+		private static List<string> ArrayElementTypes()
+		{
+			SortedSet<string> types = new SortedSet<string>(StringComparer.Ordinal);
+			const string marker = "Broadcast[] ";
+
+			foreach (string file in Directory.GetFiles(NetworkRoot, "*.cs", SearchOption.AllDirectories))
+			{
+				foreach (string line in File.ReadAllLines(file))
+				{
+					string trimmed = line.Trim();
+					if (!trimmed.StartsWith("public ", StringComparison.Ordinal))
+					{
+						continue;
+					}
+
+					int at = trimmed.IndexOf(marker, StringComparison.Ordinal);
+					if (at < 0)
+					{
+						continue;
+					}
+
+					string name = trimmed.Substring("public ".Length,
+						at + "Broadcast".Length - "public ".Length);
+					types.Add(name);
+				}
+			}
+
+			return new List<string>(types);
+		}
+
+		[Test]
+		public void EveryCustomSerializedBroadcastSentAsAnArrayHasAnArraySerializer()
+		{
+			string source = AllScriptSource();
+			List<string> elementTypes = ArrayElementTypes();
+
+			LogAssert.IsTrue(elementTypes.Count > 0, "there must be broadcast arrays to check");
+
+			List<string> missing = new List<string>();
+
+			foreach (string type in elementTypes)
+			{
+				/* Only the hand-written ones. Without the attribute codegen covers the array too, and
+				 * demanding a serializer for those would be asking for code nobody needs. */
+				if (!DeclaresCustomSerializer(source, type))
+				{
+					continue;
+				}
+
+				if (!source.Contains("this Writer writer, " + type + "[]") ||
+					!source.Contains(type + "[] Read" + type + "Array(this Reader reader)"))
+				{
+					missing.Add(type);
+				}
+			}
+
+			LogAssert.IsTrue(missing.Count == 0,
+				"these broadcasts are sent as arrays and carry [UseGlobalCustomSerializer], so codegen " +
+				"will not write the array serializer and the send fails at runtime: " +
+				string.Join(", ", missing));
+		}
+
+		/// <summary>True when the struct is declared with the global custom serializer attribute.</summary>
+		private static bool DeclaresCustomSerializer(string source, string type)
+		{
+			int at = source.IndexOf("struct " + type, StringComparison.Ordinal);
+			while (at >= 0)
+			{
+				/* The attribute sits immediately above the declaration, with only a doc comment or
+				 * blank lines between. A short window keeps another struct's attribute out of it. */
+				int from = Math.Max(0, at - 400);
+				if (source.Substring(from, at - from).Contains("[UseGlobalCustomSerializer]"))
+				{
+					return true;
+				}
+
+				at = source.IndexOf("struct " + type, at + 1, StringComparison.Ordinal);
+			}
+
+			return false;
+		}
+
+		[Test]
+		public void AnArraySerializerRoundTripsNullAsNull()
+		{
+			/* Length -1 for null, so an absent array does not come back as an empty one. A caller
+			 * that distinguishes "no update" from "update with nothing in it" needs that. */
+			string source = AllScriptSource();
+			const string signature = "public static void Write";
+			int at = source.IndexOf(signature, StringComparison.Ordinal);
+			int checked_ = 0;
+
+			while (at >= 0)
+			{
+				int open = source.IndexOf('{', at);
+				int head = open > at ? open - at : 0;
+
+				if (head > 0 && source.Substring(at, head).Contains("Array(this Writer writer"))
+				{
+					string body = source.Substring(open, Math.Min(600, source.Length - open));
+					LogAssert.IsTrue(body.Contains("WriteInt32(-1)"),
+						"an array serializer must write -1 for a null array: " + source.Substring(at, head).Trim());
+					checked_++;
+				}
+
+				at = source.IndexOf(signature, at + 1, StringComparison.Ordinal);
+			}
+
+			LogAssert.IsTrue(checked_ > 0, "there must be array serializers to check");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/BroadcastArraySerializerTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/BroadcastArraySerializerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80786183f73d4074b50a53d5a11232a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Buying from a merchant takes the player's currency, grants the item, then fails to tell the client:

```
Write method not found for FishMMO.Shared.InventorySetItemBroadcast[].
Use a supported type or create a custom serializer.
```

`SendNewItemBroadcast` returns false on that failure, so the purchase is refunded and the player sees a refusal. Reported as "still can't buy Test Sword from the general goods vendor" — the price was a red herring; this fires for every item at any price.

## Cause

A struct marked `[UseGlobalCustomSerializer]` tells FishNet its wire format is hand written. Codegen then declines to synthesise a serializer for an **array** of that struct as well — and emits no diagnostic while doing so. The build is clean, the weaver logs nothing, and the gap appears only when a broadcast carrying the array is actually sent.

`InventorySetMultipleItemsBroadcast` carries `InventorySetItemBroadcast[]`, so the login sync and every inventory update depend on an array serializer that was never generated.

## Scope

Seven types. Five were failing in a single play session; two more were latent:

| Type | Status before |
|---|---|
| `InventorySetItemBroadcast` | failing |
| `BankSetItemBroadcast` | failing |
| `KnownAbilityAddBroadcast` | failing |
| `KnownAbilityEventAddBroadcast` | failing |
| `AchievementUpdateBroadcast` | failing |
| `AbilityAddBroadcast` | latent |
| `FactionUpdateBroadcast` | latent |

So this is item acquisition generally rather than a merchant bug: any inventory or bank update, learning an ability, and achievement and faction updates.

Structs **without** the attribute are unaffected — codegen covers element and array both — which is why the fix is per-type rather than a blanket change, and why `FriendAddBroadcast`, `HotkeySetBroadcast` and `QuestUpdateBroadcast` are untouched despite also being sent as arrays.

## Change

An explicit `Write<T>Array` / `Read<T>Array` pair per affected type, in that type's existing serializer class, following the convention already used for the element serializers. A null array is written as length `-1` so it round-trips as null rather than as empty — a caller that distinguishes "no update" from "an update containing nothing" needs that.

No change to any wire format that currently works, and no change to which broadcasts are sent.

## Test

`BroadcastArraySerializerTests` reads array fields off their declarations rather than from a fixed list, so a new broadcast array that carries the attribute and lacks an array serializer fails at build time instead of in a play session. That is the part worth keeping: the failure mode here is silent at build time, and the next one would be found the same expensive way.

## Verification

- `Write method not found` went from failing **every** purchase to **zero** across all three game servers, on a live server with a client built from this change.
- EditMode suite **2208/2209**. The single failure is `CombatAudit20260831Round3Tests`, which fails on `dev` independently of this change.

Note both sides need rebuilding together — the server writes the array and the client reads it, and a client built before this change cannot read what a fixed server sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)