### PR TITLE
Make a duplicated starting ability legal, and check the ones a character actually gets

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/CharacterCreate/CharacterCreateSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/LoginServer/CharacterCreate/CharacterCreateSystem.cs
@@ -714,6 +714,34 @@ namespace FishMMO.Server.Implementation.LoginServer
 		/// <summary>
 		/// Builds CPU-only prepared ability entries from immutable templates.
 		/// </summary>
+		/// <summary>True when this ability has already been prepared for the character.</summary>
+		/// <remarks>
+		/// Starting abilities come from two places — the global list on this system, and the race
+		/// template — and nothing stops an ability appearing in both. Knowing an ability is a fact,
+		/// not a quantity, so the same ability twice is one ability, not two.
+		///
+		/// Without this the batch carries two rows with the same key. The service filters the
+		/// collision, the write reports 1/2 applied, and because these are newly created rows
+		/// nothing can legitimately supersede them — so the incomplete write is treated as failure
+		/// and the whole character creation rolls back. The player is told creation failed; the
+		/// server log names the ability count and not the duplicate.
+		///
+		/// Deliberately NOT applied to starting inventory: two of the same potion is a legitimate
+		/// request, and those rows are keyed by slot rather than by template.
+		/// </remarks>
+		private static bool AlreadyPrepared(List<PreparedAbilityEntry> abilities, int templateID)
+		{
+			for (int i = 0; i < abilities.Count; ++i)
+			{
+				if (abilities[i].TemplateID == templateID)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		private void BuildStartingAbilityEntries(List<AbilityTemplate> startingAbilities, List<PreparedAbilityEntry> abilities)
 		{
 			if (startingAbilities == null)
@@ -723,6 +751,11 @@ namespace FishMMO.Server.Implementation.LoginServer
 
 			foreach (AbilityTemplate startingAbility in startingAbilities)
 			{
+				if (startingAbility == null || AlreadyPrepared(abilities, startingAbility.ID))
+				{
+					continue;
+				}
+
 				abilities.Add(new PreparedAbilityEntry(startingAbility.ID, startingAbility.GetAllAbilityEventIDs()));
 			}
 		}
@@ -740,7 +773,7 @@ namespace FishMMO.Server.Implementation.LoginServer
 			foreach (int id in templateIDs)
 			{
 				AbilityTemplate startingAbility = AbilityTemplate.Get<AbilityTemplate>(id);
-				if (startingAbility != null)
+				if (startingAbility != null && !AlreadyPrepared(abilities, startingAbility.ID))
 				{
 					abilities.Add(new PreparedAbilityEntry(startingAbility.ID, startingAbility.GetAllAbilityEventIDs()));
 				}

--- a/FishMMO-Unity/Assets/UnitTests/Prediction/CombatAudit20260831Round3Tests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/Prediction/CombatAudit20260831Round3Tests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -547,7 +547,11 @@ namespace FishMMO.UnitTests
 		{
 			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
 			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
-			return File.ReadAllText(path);
+			/* Normalised, because one assertion below matches a pattern spanning a line break.
+			 * The working tree is CRLF on Windows, so a bare \n never matches there and the
+			 * assertion fails against code that is present and correct. Sibling fixtures in this
+			 * folder already normalise for the same reason. */
+			return File.ReadAllText(path).Replace("\r\n", "\n");
 		}
 
 		private T NewTemplate<T>(string name) where T : ScriptableObject

--- a/FishMMO-Unity/Assets/UnitTests/StartingAbilityTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/StartingAbilityTests.cs
@@ -1,3 +1,6 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using UnityEngine;
 using System.Collections.Generic;
 using FishMMO.Shared;
 using NUnit.Framework;
@@ -31,9 +34,92 @@ namespace FishMMO.UnitTests
 	/// </remarks>
 	public class StartingAbilityTests
 	{
-		/// <summary>Every ability granted by a race template, with the race that grants it.</summary>
-		private static IEnumerable<(string Race, AbilityTemplate Ability)> StartingAbilities()
+		/// <summary>Resolves an ability template by its ID, from assets rather than the cache.</summary>
+		/// <remarks>
+		/// <c>AbilityTemplate.Get</c> reads the runtime cache, which nothing populates in EditMode —
+		/// it returns null for every ID here, which is indistinguishable from the list being empty.
+		/// Scanning the assets is what makes the global list checkable outside play mode.
+		/// </remarks>
+		private static AbilityTemplate FindAbilityByID(int id)
 		{
+			foreach (string guid in AssetDatabase.FindAssets("t:AbilityTemplate"))
+			{
+				AbilityTemplate candidate = AssetDatabase.LoadAssetAtPath<AbilityTemplate>(
+					AssetDatabase.GUIDToAssetPath(guid));
+
+				if (candidate != null && candidate.ID == id)
+				{
+					return candidate;
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>The template's runtime cache ID, recomputed when the cache has not run.</summary>
+		private static int TemplateID(ScriptableObject template)
+		{
+			if (template is ICachedObject cached && cached.ID != 0)
+			{
+				return cached.ID;
+			}
+
+			return (template.GetType().Name + template.name).GetDeterministicHashCode();
+		}
+
+		/// <summary>The ability ids every new character is granted, from the login server config.</summary>
+		private static IEnumerable<int> GlobalStartingAbilityIds()
+		{
+			string text = System.IO.File.ReadAllText(
+				"Assets/Prefabs/Server/LoginServer/CharacterCreateSystem.asset");
+
+			Match m = Regex.Match(text, @"startingAbilityIDs: ([0-9a-fA-F]*)");
+			Assert.That(m.Success, Is.True,
+				"startingAbilityIDs must be present in the login server config.");
+
+			string hex = m.Groups[1].Value;
+			byte[] bytes = new byte[hex.Length / 2];
+			for (int i = 0; i < bytes.Length; ++i)
+			{
+				bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+			}
+
+			for (int i = 0; i + 4 <= bytes.Length; i += 4)
+			{
+				yield return BitConverter.ToInt32(bytes, i);
+			}
+		}
+
+		/// <summary>Every ability a new character is guaranteed, with where it comes from.</summary>
+		/// <remarks>
+		/// Two sources, because <c>CharacterCreateSystem</c> grants from two: the global
+		/// <c>startingAbilityIDs</c> on its own asset, and the race template. Reading only the race
+		/// templates made this test silently vacuous the moment the races were emptied — it kept
+		/// passing over an empty set until the guard below caught it, and would have missed an inert
+		/// ability granted globally to every character of every race.
+		/// </remarks>
+		private static IEnumerable<(string Source, AbilityTemplate Ability)> StartingAbilities()
+		{
+			/* Read from the asset text and matched by recomputed hash, mirroring
+			 * ItemAttributeRollTests. Two EditMode facts force this: CharacterCreateSystem is a
+			 * MonoBehaviour asset, which AssetDatabase's t: filter does not resolve; and ICachedObject.ID
+			 * is assigned by AddToCache at runtime, so every asset loaded here reports ID 0 and matching
+			 * on it silently finds nothing. */
+			foreach (int id in GlobalStartingAbilityIds())
+			{
+				foreach (string guid in AssetDatabase.FindAssets("t:AbilityTemplate"))
+				{
+					AbilityTemplate ability = AssetDatabase.LoadAssetAtPath<AbilityTemplate>(
+						AssetDatabase.GUIDToAssetPath(guid));
+
+					if (ability != null && TemplateID(ability) == id)
+					{
+						yield return ("every character", ability);
+						break;
+					}
+				}
+			}
+
 			foreach (string guid in AssetDatabase.FindAssets("t:RaceTemplate"))
 			{
 				RaceTemplate race = AssetDatabase.LoadAssetAtPath<RaceTemplate>(
@@ -68,7 +154,7 @@ namespace FishMMO.UnitTests
 		{
 			int checkedCount = 0;
 
-			foreach ((string race, AbilityTemplate ability) in StartingAbilities())
+			foreach ((string source, AbilityTemplate ability) in StartingAbilities())
 			{
 				++checkedCount;
 
@@ -76,7 +162,7 @@ namespace FishMMO.UnitTests
 				int tickEvents = ability.OnTickEvents?.Count ?? 0;
 
 				Assert.Greater(hitEvents + tickEvents, 0,
-					$"'{ability.name}', granted by race '{race}', has no hit or tick events. " +
+					$"'{ability.name}', granted to {source}, has no hit or tick events. " +
 					"It will spawn, detect its target and apply nothing.");
 			}
 


### PR DESCRIPTION
Character creation failed outright for every new account:

```
[CharacterCreateSystem] Starting abilities (character 20) was incomplete:
1/2 written (1 filtered, 0 superseded). These rows are newly created, so
nothing newer can exist to supersede them — the batch was rejected or filtered.
```

The character is assigned an ID and then never exists — `characters` has no row 19 or 20.

## Cause

Starting abilities come from two places, and both were granting Punch (`-127508958`):

```csharp
BuildStartingAbilityEntries(startingAbilityIDs, preparedAbilities);          // global, on the system asset
BuildStartingAbilityEntries(raceTemplate.StartingAbilities, preparedAbilities); // per race
```

Two rows, one key. The service filters the collision — `Filtered` explicitly covers *"two rows in the batch collided on the same key"* — the write reports 1/2, and `RequireCompleteAsync` treats an incomplete write of brand-new rows as failure. The whole creation rolls back.

The strictness is right: nothing can legitimately supersede a row that was just created, and silently producing a character missing a starting ability would be worse.

## Change

Emptying the races' `StartingAbilities` (done on `dev` already) removes today's collision but not the shape — two sources feeding one keyed set will overlap again the moment someone adds a race ability that is also global. Knowing an ability is a fact, not a quantity, so the same ability twice is one ability. Deduplicated where the entries are built, which covers both call sites.

**Not** applied to starting inventory: two of the same potion is a legitimate request, and those rows are keyed by slot rather than by template.

## The test went vacuous

`StartingAbilityTests` enumerated only race templates. Once the races were emptied it passed over an empty set until its own guard caught it — and it would have missed an inert ability granted **globally to every character of every race**, which is precisely what Punch is. It now reads the global list as well.

Two EditMode facts shaped how, both already solved in `ItemAttributeRollTests` and reused here:

- `CharacterCreateSystem` is a **MonoBehaviour** asset, so `AssetDatabase.FindAssets("t:CharacterCreateSystem")` resolves nothing — the ids are read from the asset text.
- `ICachedObject.ID` is assigned by `AddToCache` at runtime, so every asset loaded in EditMode reports `ID == 0` and matching on it silently finds nothing — the id is recomputed from the same deterministic hash.

Both failure modes are silent, which is how the original enumeration looked correct.

## Also: a test that never passed

`CombatAudit20260831Round3Tests` has failed since it was added in `43b328c6`. Its assertion matches a pattern spanning a line break using `\n`:

```csharp
networking.Contains("CatchUpSpawnedContainer(ability, spawned,\n\t\t\t\t\tentry.LifeElapsedBeforeStartTicks,")
```

The working tree is CRLF on Windows, so it can never match, and it reported correct code as missing — the production behaviour is present at `AbilityController.Networking.cs:190`. Sibling fixtures in that folder already normalise; this one's `ReadSource` did not. One line.

## Verification

EditMode **2209/2209**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)