### PR TITLE
WIP: say so when a player-only build ships whatever bundles are already on disk

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Core/CustomBuildTool.cs
+++ b/FishMMO-Unity/Assets/Scripts/Shared/Implementation/Tools/Extensions/Unity/Editor/FishMMO Dashboard/CustomBuildTool/Core/CustomBuildTool.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 using UnityEditor;
 using UnityEditorInternal;
 using System.IO;
@@ -438,13 +438,25 @@ namespace FishMMO.Shared.CustomBuildTool.Core
 		// can be generated from CI.
 		// =====================================================================
 
-		/// <summary>CLI entry: build the Client player. OS target read from -fishmmoOSTarget arg.</summary>
+		/// <summary>CLI entry: build the Client player ONLY. OS target read from -fishmmoOSTarget arg.</summary>
+		/// <remarks>
+		/// Does NOT rebuild Addressables — the existing bundles are shipped untouched. Use
+		/// <see cref="BuildClientWithAddressablesCLI"/> unless you know the content on disk is
+		/// current, because a stale bundle produces a player that runs new code against old
+		/// assets and reports nothing unusual while doing it.
+		/// </remarks>
 		public static void BuildClientCLI()
 		{
 			RunCliBuild(BuildTypeEnvironment.Client, includeAddressables: false, addressablesOnly: false);
 		}
 
-		/// <summary>CLI entry: build the Server player. OS target read from -fishmmoOSTarget arg.</summary>
+		/// <summary>CLI entry: build the Server player ONLY. OS target read from -fishmmoOSTarget arg.</summary>
+		/// <remarks>
+		/// Does NOT rebuild Addressables — the existing bundles are shipped untouched. Use
+		/// <see cref="BuildServerWithAddressablesCLI"/> unless you know the content on disk is
+		/// current, because a stale bundle produces a player that runs new code against old
+		/// assets and reports nothing unusual while doing it.
+		/// </remarks>
 		public static void BuildServerCLI()
 		{
 			RunCliBuild(BuildTypeEnvironment.Server, includeAddressables: false, addressablesOnly: false);
@@ -495,6 +507,26 @@ namespace FishMMO.Shared.CustomBuildTool.Core
 					UnityEngine.Debug.LogError("[CustomBuildTool] WebGL Server builds are not supported. Aborting.");
 					if (Application.isBatchMode) EditorApplication.Exit(2);
 					return;
+				}
+
+				/* A player-only build ships whatever Addressables content is already on disk.
+				 *
+				 * That is the point of the entry point and sometimes what you want, but the two
+				 * CLI names differ by one word and the stale outcome is silent: the build reports
+				 * every step, exits zero, and the player then loads templates, prefabs and scenes
+				 * from bundles that may predate the code it was just built from. A content change
+				 * made in the editor simply does not appear, and nothing in the log says why.
+				 *
+				 * Cost a day of misdiagnosis: a server built this way kept granting a starting
+				 * ability that had been removed from the race templates hours earlier, because the
+				 * bundle holding those templates was never rebuilt. Say so, so the next person
+				 * reads it in the log rather than inferring it from behaviour. */
+				if (!includeAddressables && !addressablesOnly)
+				{
+					UnityEngine.Debug.LogWarning(
+						$"[CustomBuildTool] Building the {buildType} player WITHOUT Addressables. " +
+						"Existing bundles are shipped as-is, so any content changed since they were " +
+						$"last built will NOT appear. Use Build{buildType}WithAddressablesCLI to rebuild both.");
 				}
 
 				BuildEnvironmentOptions.SetBuildType(buildType);


### PR DESCRIPTION
**Draft — the diagnosis is solid but I am unsure this is the right shape for the fix. Would value your steer before polishing.**

## The trap

`BuildServerCLI` and `BuildServerWithAddressablesCLI` differ by one word, and only one rebuilds Addressables:

```csharp
public static void BuildServerCLI()
    => RunCliBuild(BuildTypeEnvironment.Server, includeAddressables: false, addressablesOnly: false);

public static void BuildServerWithAddressablesCLI()
    => RunCliBuild(BuildTypeEnvironment.Server, includeAddressables: true,  addressablesOnly: false);
```

The player-only variant is a legitimate entry point. The problem is that its stale outcome is **completely silent**: every step is reported, the exit code is zero, and the resulting player loads templates, prefabs and scenes from bundles that may predate the code it was just built from.

## How it bit

A starting ability was removed from the Elf/Human/Orc race templates on `dev`. A server built with `BuildServerCLI` kept granting it for hours afterwards, because `shared_static_permanent_assets_all` — the bundle holding those templates — was never rebuilt.

It surfaced as character creation failing with a duplicate starting ability, which sent the investigation into the creation path and the database write. Three rebuild-and-test cycles went into what turned out to be a build command doing exactly what it says on the tin. The build log gave no hint, because there was nothing wrong with the build.

## What this does

Logs a warning naming the risk and the alternative entry point, and says the same in the XML docs on both player-only CLI entries. **No behaviour change** — the build does exactly what it did before, and now says what it is doing.

## Why it is a draft

Three things I would rather you decided:

1. **A warning may be too weak.** An opt-in flag (`-fishmmoAllowStaleAddressables`) that errors otherwise would make the stale case deliberate rather than merely announced — at the cost of breaking any existing caller relying on current behaviour.
2. **It fires on every player-only build**, including ones where shipping existing bundles is precisely the intent. That could be noise for a CI pipeline that splits the two steps on purpose.
3. **A real staleness check would be better** — comparing bundle timestamps against the content they were built from would be quieter and more accurate. I do not know whether the Addressables API exposes that cheaply here, and did not want to guess at it in a first pass.

Happy to take any of those directions, or to drop this if you would rather solve it by renaming the entry points so the distinction is impossible to miss.

EditMode **2209/2209**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)