### PR TITLE
Consolidate duplicated request and slot handling, and fix what the duplication hid

### DIFF
--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/FishMMO-Theme.uss
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/FishMMO-Theme.uss
@@ -1219,8 +1219,23 @@ TextField.fish-input > #unity-text-input {
     hand; the mail compose fields take the other route and refuse to pin a height at all. Any panel
     that gives a .fish-input an exact height has to put this class on it, or its box renders empty.
 */
+/*
+    The type-qualified selectors are load bearing, not belt and braces.
+
+    Unity's default stylesheet sets that 10px padding through a TYPE-qualified rule, so a bare
+    class selector loses the specificity fight and the padding survives. TextField was spelled out
+    for that reason; the numeric fields were not, and every one of them therefore kept the default
+    padding and rendered an empty box however it was styled. The merchant quantity field is an
+    IntegerField, which is why issues #263 and #277 came back after the TextField fix appeared to
+    settle them: the field accepted input and reported the right value the whole time, and simply
+    drew nothing. Any new field type given .fish-input--compact has to be named here too.
+*/
 .fish-input--compact > #unity-text-input,
-TextField.fish-input--compact > #unity-text-input {
+TextField.fish-input--compact > #unity-text-input,
+IntegerField.fish-input--compact > #unity-text-input,
+FloatField.fish-input--compact > #unity-text-input,
+LongField.fish-input--compact > #unity-text-input,
+DoubleField.fish-input--compact > #unity-text-input {
     padding-top: 0;
     padding-bottom: 0;
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/UITKControl.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using FishMMO.Logging;
 using FishMMO.Shared;
+using FishMMO.Shared.Core;
 
 namespace FishMMO.Client
 {
@@ -1038,6 +1039,190 @@ namespace FishMMO.Client
 				inventory.Show();
 			}
 		}
+
+		#region Name prompts
+
+		/// <summary>
+		/// Name the chat panel is registered under with <see cref="UIManager"/>.
+		/// </summary>
+		public const string ChatPanelName = "UIChat";
+
+		/// <summary>
+		/// Name the shared single-line text prompt is registered under with <see cref="UIManager"/>.
+		/// </summary>
+		public const string InputDialogPanelName = "UIDialogInputBox";
+
+		/// <summary>
+		/// The line shown when a name the player typed resolves to nobody.
+		/// </summary>
+		/// <remarks>
+		/// One constant rather than a literal per panel. The failure it reports is not
+		/// panel-specific — a name did not resolve, which has nothing to do with guilds, parties or
+		/// friend lists — so the three panels that resolved a typed name all spelled it identically
+		/// and would have drifted apart the first time one of them was reworded. The wording that IS
+		/// panel-specific, namely who you may not invite and to what, stays with the caller.
+		/// </remarks>
+		public const string UnknownCharacterMessage = "A person with that name could not be found.";
+
+		/// <summary>
+		/// Writes one line into the chat panel's system channel.
+		/// </summary>
+		/// <param name="message">The line to show.</param>
+		/// <remarks>
+		/// Chat is how this UI tells the player an action went nowhere, and every caller had written
+		/// the same lookup-then-instantiate pair to say so. A missing chat panel is silence rather
+		/// than an error: it is a panel like any other and may not be registered yet, and every
+		/// hand-rolled copy of this already behaved that way by writing the call inside the
+		/// <c>TryGetTK</c> test.
+		/// </remarks>
+		protected static void ShowSystemMessage(string message)
+		{
+			if (UIManager.TryGetTK(ChatPanelName, out UITKChat chat))
+			{
+				chat.InstantiateChatMessage(ChatChannel.System, "", message);
+			}
+		}
+
+		/// <summary>
+		/// Opens the shared single-line prompt and runs <paramref name="onAccept"/> with what the
+		/// player typed.
+		/// </summary>
+		/// <param name="prompt">The question shown in the dialog.</param>
+		/// <param name="onAccept">Receives the accepted text. Not called on cancel.</param>
+		/// <returns>True when the prompt was shown.</returns>
+		/// <remarks>
+		/// The dialog is a SHARED panel — there is one of it, registered with
+		/// <see cref="UIManager"/> — so every prompt in the client is a lookup by name that can
+		/// fail, and each panel that wanted to ask the player something wrote that lookup itself.
+		/// Failing to find it returns false rather than throwing: a panel asking a question when the
+		/// dialog does not exist has nothing useful to do, and the one thing it must not do is carry
+		/// on as though the player had answered.
+		/// </remarks>
+		protected static bool TryPromptForText(string prompt, Action<string> onAccept)
+		{
+			if (!UIManager.TryGetTK(InputDialogPanelName, out UITKDialogInputBox input))
+			{
+				return false;
+			}
+
+			input.Open(prompt, onAccept, null);
+			return true;
+		}
+
+		/// <summary>
+		/// Resolves the player character an action should act on without asking: the hovered one,
+		/// else the pinned one.
+		/// </summary>
+		/// <param name="source">The character whose targeting is read — normally the local player.</param>
+		/// <param name="targetCharacter">The resolved player character, or null.</param>
+		/// <returns>True when a player character was resolved.</returns>
+		/// <remarks>
+		/// The hovered character first, then the pinned one. The pointer is on the button when it
+		/// fires, so the hover target is usually empty — and the pinned card is exactly the player's
+		/// way of saying "this one" ahead of time.
+		/// <para>
+		/// What comes back is a character, never a name, so this path never touches the naming
+		/// system: the caller already holds the ID it needs. That is the whole difference between it
+		/// and <see cref="PromptForCharacterID"/>, and the reason a panel tries this first and only
+		/// asks when it fails.
+		/// </para>
+		/// <para>
+		/// Returning false covers three separate misses — no character, no target controller, and a
+		/// target that is not a player character — because a caller treats all three the same way:
+		/// fall back to asking for a name.
+		/// </para>
+		/// </remarks>
+		protected static bool TryResolveTargetCharacter(IPlayerCharacter source, out IPlayerCharacter targetCharacter)
+		{
+			targetCharacter = null;
+
+			if (source == null ||
+				!source.TryGet(out ITargetController targetController))
+			{
+				return false;
+			}
+
+			Transform target = targetController.Current.Target != null
+				? targetController.Current.Target
+				: targetController.PinnedTarget;
+
+			targetCharacter = target != null ? target.GetComponent<IPlayerCharacter>() : null;
+			return targetCharacter != null;
+		}
+
+		/// <summary>
+		/// Prompts for a character name, resolves it to a character ID, and hands that ID to the
+		/// caller once it is known to be somebody other than the player themselves.
+		/// </summary>
+		/// <param name="prompt">The question shown in the dialog.</param>
+		/// <param name="self">
+		/// Reads the local character AT RESOLUTION TIME — see the remarks for why this is a delegate.
+		/// </param>
+		/// <param name="selfMessage">Shown when the name resolves to the player themselves.</param>
+		/// <param name="onResolved">Receives a character ID that resolved and is not the player's.</param>
+		/// <returns>True when the prompt was shown. Resolution happens later, off a server reply.</returns>
+		/// <remarks>
+		/// <para>
+		/// Three panels — guild invite, party invite, add friend — each held an independent copy of
+		/// this entire flow, differing only in the broadcast they sent and two strings. That is a bad
+		/// shape for it, because every step has a way of being wrong that is SILENT: skip the name
+		/// validation and an unvalidatable string goes to the server to be rejected; skip the
+		/// <c>id == 0</c> test and a failed lookup sends an invite to character zero; skip the self
+		/// test and the player invites themselves and waits for a dialog that never arrives. None of
+		/// those fail at the call site, so nothing reveals the omission — which is precisely the sort
+		/// of thing that belongs in one place with a test guarding it.
+		/// </para>
+		/// <para>
+		/// <paramref name="self"/> is a delegate rather than an <see cref="IPlayerCharacter"/>
+		/// because the ID arrives from the SERVER, asynchronously: a player can leave the world
+		/// between typing a name and the reply landing. The copies this replaces read their
+		/// <c>Character</c> field INSIDE the callback, so they tested the character as it was when
+		/// the answer came back and treated "no character any more" as a reason not to send. Taking
+		/// the character by value here would have quietly turned that into a send against a stale
+		/// reference.
+		/// </para>
+		/// <para>
+		/// An invalid name is silent, as all three copies were. The dialog has closed by then, and
+		/// the name rules — length, letters, single spaces — are the ones the player already met on
+		/// the character creation screen.
+		/// </para>
+		/// </remarks>
+		protected static bool PromptForCharacterID(string prompt, Func<IPlayerCharacter> self, string selfMessage, Action<long> onResolved)
+		{
+			return TryPromptForText(prompt, (s) =>
+			{
+				if (!Authentication.IsAllowedCharacterName(s))
+				{
+					return;
+				}
+
+				ClientNamingSystem.GetCharacterID(s, (id) =>
+				{
+					if (id == 0)
+					{
+						ShowSystemMessage(UnknownCharacterMessage);
+						return;
+					}
+
+					IPlayerCharacter character = self != null ? self() : null;
+					if (character == null || character.ID == id)
+					{
+						/* A null character takes the same branch as "that is you", which is what the
+						 * copies did by testing Character != null before comparing IDs. It reads
+						 * oddly — the player is told they cannot invite themselves when in truth
+						 * there is no player — but the alternative is broadcasting from a panel
+						 * whose character is gone, and the branch is unreachable while a character
+						 * is in the world. */
+						ShowSystemMessage(selfMessage);
+						return;
+					}
+
+					onResolved?.Invoke(id);
+				});
+			});
+		}
+
+		#endregion
 
 		/// <summary>
 		/// Shows the panel by enabling the <see cref="UIDocument"/>.

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Container/UITKContainer.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Container/UITKContainer.cs
@@ -99,15 +99,24 @@ namespace FishMMO.Client
 		/// <summary>Rendered rows, one per non-empty container slot.</summary>
 		private readonly List<RowView> rowViews = new List<RowView>();
 
+		/*  This was a hand-rolled Dictionary<int, float> of send times with its own expiry sweep,
+		 *  the third such sweep in the client and the second one in a world item panel. The clock
+		 *  here was already the right one (unscaledTime), which is precisely why the duplication was
+		 *  dangerous: the corpse loot panel next door had written the same watchdog against
+		 *  Time.time, so the two panels disagreed about whether a paused game pauses a network
+		 *  deadline, and only one of them was right. Sharing one implementation is what makes that
+		 *  disagreement impossible rather than merely currently-absent — see
+		 *  PendingSlotWatchdogTests. */
+
 		/// <summary>
-		/// Container slots with a take in flight, mapped to the time the request was sent.
+		/// Container slots with a take in flight.
 		/// </summary>
 		/// <remarks>
 		/// Keyed by slot rather than by row index because rows are rebuilt whenever the server
 		/// re-sends the contents, and a row's position moves as slots above it empty. The slot
 		/// index is the only identifier that survives a rebuild.
 		/// </remarks>
-		private readonly Dictionary<int, float> pendingSlots = new Dictionary<int, float>();
+		private readonly ItemSlotPendingSet pendingSlots = new ItemSlotPendingSet();
 
 		private VisualElement listRoot;
 		private Label subtitleLabel;
@@ -256,7 +265,7 @@ namespace FishMMO.Client
 				return;
 			}
 
-			pendingSlots.Remove(msg.Slot);
+			pendingSlots.Release(msg.Slot);
 			ApplyPendingOverlays();
 
 			SetStatus(msg.Success ? string.Empty : DescribeFailure(msg.Reason));
@@ -433,7 +442,7 @@ namespace FishMMO.Client
 			for (int i = 0; i < rowViews.Count; ++i)
 			{
 				RowView view = rowViews[i];
-				bool waiting = pendingSlots.ContainsKey(view.Slot);
+				bool waiting = pendingSlots.IsPending(view.Slot);
 				view.Pending?.EnableInClassList(CSS_HIDDEN, !waiting);
 			}
 		}
@@ -450,12 +459,16 @@ namespace FishMMO.Client
 				return;
 			}
 
-			if (pendingSlots.ContainsKey(slot))
+			/* The double-submit guard. TryBegin refuses a slot that already has a request in flight
+			 * rather than re-arming its watchdog, so clicking a stuck row repeatedly cannot keep
+			 * pushing its deadline out — the timeout below still fires on schedule. The 5s is passed
+			 * explicitly because the shared default is 8s, and adopting it here would have quietly
+			 * lengthened how long a row stays locked. */
+			if (!pendingSlots.TryBegin(slot, PENDING_TIMEOUT_SECONDS))
 			{
 				return;
 			}
 
-			pendingSlots[slot] = UnityEngine.Time.unscaledTime;
 			ApplyPendingOverlays();
 			SetStatus(string.Empty);
 
@@ -499,34 +512,22 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Clears rows whose reply never arrived.
 		/// </summary>
+		/// <remarks>
+		/// <c>CollectExpired</c> reports each slot exactly once per wait, so this is safe to drive
+		/// straight from the tick. Releasing only re-enables the row — a reply that arrives after
+		/// the release is still handled normally.
+		/// </remarks>
 		private void ReleaseTimedOutRequests()
 		{
-			if (pendingSlots.Count < 1)
+			if (!pendingSlots.HasAnyPending)
 			{
 				return;
 			}
 
-			float now = UnityEngine.Time.unscaledTime;
-			List<int> expired = null;
-
-			foreach (KeyValuePair<int, float> pair in pendingSlots)
+			if (pendingSlots.CollectExpired().Count > 0)
 			{
-				if (now - pair.Value >= PENDING_TIMEOUT_SECONDS)
-				{
-					(expired ??= new List<int>()).Add(pair.Key);
-				}
+				ApplyPendingOverlays();
 			}
-
-			if (expired == null)
-			{
-				return;
-			}
-
-			for (int i = 0; i < expired.Count; ++i)
-			{
-				pendingSlots.Remove(expired[i]);
-			}
-			ApplyPendingOverlays();
 		}
 
 		// ── Helpers ───────────────────────────────────────────────────────────
@@ -548,7 +549,7 @@ namespace FishMMO.Client
 		/// </summary>
 		private void ClearPending()
 		{
-			pendingSlots.Clear();
+			pendingSlots.ReleaseAll();
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Equipment/UITKEquipment.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Equipment/UITKEquipment.cs
@@ -13,12 +13,43 @@ namespace FishMMO.Client
 	/// equipped items alongside the attributes they contribute to.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// This panel renders the server's answer and never its own guess. Every request it sends
 	/// leaves the slot looking exactly as it did, marked as waiting, until the equipment container
 	/// is replicated back — see <see cref="HandleSlotRightClick"/> for what that replaced and why.
+	/// </para>
+	/// <para>
+	/// Everything a SLOT does — joining the operation tracker, deciding whether a slot is
+	/// available, painting the icon and the stack badge and the lock overlay, keeping the tooltip
+	/// honest, starting a drag, abandoning what is in flight — comes from
+	/// <see cref="UITKSlotPanelBase"/>, which this panel shares with the bag and the bank. It used
+	/// to be a second copy of all of it, eighteen identically named members, and it had drifted
+	/// from the grid version in three ways; that class records which, and
+	/// <see cref="OnSlotPointerDown"/> below carries the one that was a player-visible bug.
+	/// </para>
+	/// <para>
+	/// What is genuinely this panel's own is the half a socket does differently: its slots are
+	/// AUTHORED in <c>UIEquipment.uxml</c> rather than built from a container's slot count, a drop
+	/// onto one is an equip rather than a swap, and beside the sockets it draws the attributes and
+	/// the live character preview that no item grid has.
+	/// </para>
 	/// </remarks>
-	public class UITKEquipment : UITKCharacterControl
+	public class UITKEquipment : UITKSlotPanelBase
 	{
+		// ── What this panel says about itself ─────────────────────────────────
+
+		/// <inheritdoc/>
+		/// <remarks>
+		/// "eq", which is already the prefix every class in <c>UIEquipment.uss</c> carries:
+		/// <c>eq-hidden</c> and <c>eq-slot__lock--pending</c> are exactly the two names the shared
+		/// painters derive from it. The two <c>const</c> strings that used to spell them out here
+		/// were the same convention written a second time.
+		/// </remarks>
+		protected override string Prefix => "eq";
+
+		/// <inheritdoc/>
+		protected override ReferenceButtonType DragType => ReferenceButtonType.Equipment;
+
 		// ── UXML element names ────────────────────────────────────────────────
 
 		/// <summary>Name of the attribute list ScrollView element in the UXML.</summary>
@@ -34,14 +65,9 @@ namespace FishMMO.Client
 		/// <summary>Name of the stamina stat label element in the UXML.</summary>
 		private const string STAT_STAM_NAME     = "stat-stam";
 
-		// ── Shared UI overlay names (panels resolved by GameObject name via UIManager) ──
-
-		/// <summary>Name of the shared drag object overlay.</summary>
-		private const string DRAG_OBJECT_NAME = "UIDragObject";
-		/// <summary>Name of the shared tooltip overlay.</summary>
-		private const string TOOLTIP_NAME = "UITooltip";
-		/// <summary>Name of the shared transient-notice overlay.</summary>
-		private const string TOAST_NAME = "UIToast";
+		/* DRAG_OBJECT_NAME, TOOLTIP_NAME and TOAST_NAME are on UITKSlotPanelBase — three string
+		 * constants that were identical in this file and in the item grid, naming overlays neither
+		 * panel owns. */
 
 		/// <summary>
 		/// UXML element name for every <see cref="ItemSlot"/>, indexed by its enum value.
@@ -79,10 +105,10 @@ namespace FishMMO.Client
 
 		// ── USS class names ───────────────────────────────────────────────────
 
-		/// <summary>USS class for hiding equipment elements.</summary>
-		private const string CSS_HIDDEN         = "eq-hidden";
-		/// <summary>USS class marking a slot as waiting on the server.</summary>
-		private const string CSS_LOCK_PENDING   = "eq-slot__lock--pending";
+		/* eq-hidden and eq-slot__lock--pending are derived from Prefix by UITKSlotPanelBase, which
+		 * owns the painters that apply them. The attribute-row classes below are this panel's
+		 * alone: no item grid has an attribute list. */
+
 		/// <summary>USS class for an attribute category header.</summary>
 		private const string CSS_ATTR_CATEGORY  = "fish-attr-category";
 		/// <summary>USS class for an attribute row.</summary>
@@ -96,25 +122,13 @@ namespace FishMMO.Client
 		/// <summary>USS class for a percentage attribute value label.</summary>
 		private const string CSS_ATTR_PERCENT   = "fish-attr-row__value--percent";
 
-		// ── Per-slot view data ────────────────────────────────────────────────
-
-		/// <summary>Runtime view data for a single equipment slot element.</summary>
-		private struct SlotView
-		{
-			/// <summary>Root VisualElement of the slot (e.g. "slot-head").</summary>
-			public VisualElement Root;
-			/// <summary>Icon element (fish-slot__icon).</summary>
-			public VisualElement Icon;
-			/// <summary>Amount label (fish-slot__amount).</summary>
-			public Label Amount;
-			/// <summary>Lock overlay element (fish-slot__lock).</summary>
-			public VisualElement Lock;
-		}
-
 		// ── Private state ─────────────────────────────────────────────────────
 
-		/// <summary>Indexed by (int)ItemSlot; null until <see cref="OnStarting"/> has run.</summary>
-		private SlotView[] slotViews;
+		/* The SlotView struct and the slotViews collection are on UITKSlotPanelBase. This panel
+		 * used to hold them as an ARRAY that was null until OnStarting had seen a populated tree,
+		 * which meant eight null tests, one of which read .Length before testing and was an NRE on
+		 * the first equip of any session the player had not opened this window in. The shared list
+		 * starts empty instead, so every bounds check answers the same way with no special case. */
 
 		/// <summary>Live attribute value labels keyed by attribute template ID.</summary>
 		private readonly Dictionary<int, Label> attributeValueLabels = new Dictionary<int, Label>();
@@ -172,9 +186,6 @@ namespace FishMMO.Client
 		/// </remarks>
 		private RenderTexture previewTexture;
 
-		/// <summary>True while this panel holds a subscription on the shared operation tracker.</summary>
-		private bool trackerSubscribed;
-
 		// ── UITKControl lifecycle ─────────────────────────────────────────────
 
 		/// <summary>
@@ -207,27 +218,57 @@ namespace FishMMO.Client
 				closeBtn.clicked += Hide;
 			}
 
-			/* Equipment slots. The callbacks below are registered on elements that belong to the
-			 * tree being resolved right now — a rebuilt tree brings new elements and the old
-			 * handlers go with the old ones, so there is nothing to unregister and no per-rebuild
-			 * accumulation. The rebuilt views are captured wholesale into a fresh array for the
-			 * same reason: a stale SlotView points into a tree nobody can see. */
+			BuildSlotViewsFromMarkup(root);
+		}
+
+		/// <summary>
+		/// Fills the shared slot list from the sockets authored in the UXML.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// THIS IS THE PART A SHARED BASE MUST NOT OWN, and the reason
+		/// <see cref="UITKSlotPanelBase"/> holds the list but never populates it. The item grids
+		/// CREATE one element per container slot, so their slot count follows the container. These
+		/// ten sockets are authored in <c>UIEquipment.uxml</c> and found by name, so their count
+		/// follows the <see cref="ItemSlot"/> enum and the markup has to agree with it.
+		/// </para>
+		/// <para>
+		/// A socket whose element is missing is still ADDED, as a default
+		/// <c>SlotView</c> with a null root. Skipping it would shorten the list and every socket
+		/// after it would then draw the wrong item — the index into this list is the container slot
+		/// index, and that is the contract <see cref="SlotElementNames"/> exists to keep. The
+		/// shared painters already treat a null root as nothing to draw.
+		/// </para>
+		/// <para>
+		/// The callbacks are registered on elements that belong to the tree being resolved right
+		/// now — a rebuilt tree brings new elements and the old handlers go with the old ones, so
+		/// there is nothing to unregister and no per-rebuild accumulation. The list is cleared
+		/// first for the same reason: a stale SlotView points into a tree nobody can see.
+		/// </para>
+		/// </remarks>
+		private void BuildSlotViewsFromMarkup(VisualElement root)
+		{
+			slotViews.Clear();
+
 			int slotCount = SlotElementNames.Length;
-			slotViews = new SlotView[slotCount];
 			for (int i = 0; i < slotCount; ++i)
 			{
 				VisualElement slotRoot = root.Q(SlotElementNames[i]);
+
+				SlotView view = default;
+				if (slotRoot != null)
+				{
+					view.Root   = slotRoot;
+					view.Icon   = slotRoot.Q(className: "fish-slot__icon");
+					view.Amount = slotRoot.Q<Label>(className: "fish-slot__amount");
+					view.Lock   = slotRoot.Q(className: "fish-slot__lock");
+				}
+				slotViews.Add(view);
+
 				if (slotRoot == null)
 				{
 					continue;
 				}
-
-				SlotView view;
-				view.Root   = slotRoot;
-				view.Icon   = slotRoot.Q(className: "fish-slot__icon");
-				view.Amount = slotRoot.Q<Label>(className: "fish-slot__amount");
-				view.Lock   = slotRoot.Q(className: "fish-slot__lock");
-				slotViews[i] = view;
 
 				int slotIndex = i;
 				slotRoot.RegisterCallback<PointerDownEvent>(evt => OnSlotPointerDown(evt, slotIndex));
@@ -237,69 +278,24 @@ namespace FishMMO.Client
 			}
 		}
 
+		/* OnAfterStarting, OnAfterShow, OnClientSet, OnClientUnset and Hide are on
+		 * UITKSlotPanelBase. All five were the same overrides the item grid had written, THE
+		 * CONTRACT about the first open included — the same paragraph of explanation appeared in
+		 * both files. */
+
 		/// <summary>
-		/// Re-applies per-open content after the visual tree has been rebuilt.
+		/// Refreshes the character preview while the panel is on screen.
 		/// </summary>
 		/// <remarks>
-		/// The base implementation re-runs the character pre/post pair, which repopulates the
-		/// slots and attribute rows. What it does not carry across is the pending marks, which
-		/// live in the shared tracker rather than in the tree, so they have to be repainted onto
-		/// the new elements here.
-		/// </remarks>
-		protected override void OnAfterStarting()
-		{
-			base.OnAfterStarting();
-			ApplyPerOpenContent();
-		}
-
-		/// <summary>
-		/// Re-applies per-open content on every show, including the very first one.
-		/// </summary>
-		/// <remarks>
-		/// <c>OnAfterStarting</c> alone is not enough, and this is the trap THE CONTRACT warns
-		/// about: on the first ever open <c>hasStarted</c> is still false, so
-		/// <c>ReinitializeIfTreeReplaced</c> returns before re-running it. Doing the work from
-		/// both hooks is what makes the first open behave like every later one. Both paths are
-		/// idempotent — this re-reads state and repaints, it does not accumulate anything.
-		/// </remarks>
-		protected override void OnAfterShow()
-		{
-			ApplyPerOpenContent();
-		}
-
-		/// <summary>
-		/// Registers with the shared item-operation tracker.
-		/// </summary>
-		public override void OnClientSet()
-		{
-			SubscribeTracker();
-		}
-
-		/// <summary>
-		/// Detaches from the shared item-operation tracker.
-		/// </summary>
-		public override void OnClientUnset()
-		{
-			UnsubscribeTracker();
-		}
-
-		/// <summary>
-		/// Times out item operations whose reply never arrived, and refreshes the character
-		/// preview while the panel is on screen.
-		/// </summary>
-		/// <remarks>
-		/// <para>The tracker is shared and self-clearing, so it does not matter that all three item
-		/// panels drive it; whichever ticks first in a frame does the work and the others find
-		/// nothing outstanding.</para>
-		/// <para>The preview is refreshed here rather than on the equipment events because a
-		/// preview shows an animating character: the idle pose moves every frame, and a texture
-		/// rendered once when the panel opened would freeze it mid-stride. A frame is also when
-		/// the viewport's layout first becomes measurable, so this is the hook that gets the
-		/// preview its size on the opening frame.</para>
+		/// The preview is refreshed here rather than on the equipment events because a preview
+		/// shows an animating character: the idle pose moves every frame, and a texture rendered
+		/// once when the panel opened would freeze it mid-stride. A frame is also when the
+		/// viewport's layout first becomes measurable, so this is the hook that gets the preview
+		/// its size on the opening frame. The base ticks the operation tracker.
 		/// </remarks>
 		protected override void OnTick()
 		{
-			ItemOperationTracker.Tick();
+			base.OnTick();
 
 			if (Visible)
 			{
@@ -308,14 +304,15 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
-		/// Releases the preview camera and texture, runtime-created attribute elements and every
-		/// subscription this panel holds.
+		/// Releases the preview camera and texture, the runtime-created attribute elements, and the
+		/// equipment subscriptions.
 		/// </summary>
-		public override void OnDestroying()
+		/// <remarks>
+		/// The tracker subscription and the drag are released by the base before this runs, which
+		/// is the order this panel already used.
+		/// </remarks>
+		protected override void OnPanelDestroying()
 		{
-			UnsubscribeTracker();
-			ReleaseAndClearDrag();
-
 			if (Character != null && Character.TryGet(out IEquipmentController equipmentController))
 			{
 				equipmentController.OnSlotUpdated     -= OnEquipmentSlotUpdated;
@@ -331,40 +328,27 @@ namespace FishMMO.Client
 			previewFramed = false;
 
 			DestroyAttributeElements();
-			base.OnDestroying();
 		}
 
 		// ── Visibility overrides (preview sync) ──────────────────────────────
 
 		/// <summary>
-		/// Hides the equipment panel, releases the preview camera and abandons anything this panel
-		/// had in flight.
+		/// Hands the preview camera back once the panel has actually gone off screen.
 		/// </summary>
 		/// <remarks>
-		/// <para><c>Hide(bool)</c> and not <c>Hide()</c>: <c>Hide()</c> delegates here, but Escape
-		/// (<c>UIManager.CloseNext</c>) and quit-to-login (<c>Hide(false)</c>) both arrive at this
-		/// overload directly. A pending mark or a half-finished drag that outlives the panel is
-		/// invisible to the player and refuses their next click for no stated reason.</para>
-		/// <para>The camera is handed back here rather than simply left enabled, because the
-		/// preview's cost is paid every frame whether or not anyone is looking at it.</para>
+		/// The camera is handed back rather than simply left enabled, because the preview's cost is
+		/// paid every frame whether or not anyone is looking at it. The base decides WHEN this is —
+		/// including the Escape and quit-to-login paths, which reach <c>Hide(bool)</c> directly
+		/// rather than through <c>Hide()</c> — and abandons the pending marks and any half-finished
+		/// drag afterwards. Both used to be spelled out here and in the item grid.
 		/// </remarks>
-		/// <param name="overrideIsAlwaysOpen">When true, the call is a no-op.</param>
-		public override void Hide(bool overrideIsAlwaysOpen)
+		protected override void OnPanelHidden()
 		{
-			base.Hide(overrideIsAlwaysOpen);
-
-			if (Visible)
-			{
-				return;
-			}
-
 			/* The element stops drawing the texture before the renderer destroys it, so no frame
 			 * can find a destroyed texture still on the element's style. */
 			ApplyPreviewTexture(null);
 			previewRenderer.Configure(null);
 			previewFramed = false;
-
-			ReleaseAndClearDrag();
 		}
 
 		// ── Character control ─────────────────────────────────────────────────
@@ -471,11 +455,12 @@ namespace FishMMO.Client
 		/// </summary>
 		public void OnEquipmentSlotLockChanged(IItemContainer container, int slot, bool isLocked)
 		{
-			/* slotViews is null until OnStarting has seen a populated tree, and a panel that
-			 * starts hidden is handed a character — and therefore these events — long before
-			 * that. Reading .Length first was an NRE on the first equip of every session in which
-			 * the player had not opened this window. */
-			if (slotViews == null || slot < 0 || slot >= slotViews.Length)
+			/* The slot list is EMPTY until OnStarting has seen a populated tree, and a panel that
+			 * starts hidden is handed a character — and therefore these events — long before that.
+			 * An empty list fails the bounds check below; the array this used to be was null, and
+			 * reading its .Length first was an NRE on the first equip of every session in which the
+			 * player had not opened this window. */
+			if (slot < 0 || slot >= slotViews.Count)
 			{
 				return;
 			}
@@ -497,36 +482,26 @@ namespace FishMMO.Client
 		/// </remarks>
 		public void OnEquipmentSlotUpdated(IItemContainer container, Item item, int equipmentSlot)
 		{
-			if (container == null || slotViews == null ||
-				equipmentSlot < 0 || equipmentSlot >= slotViews.Length)
-			{
-				return;
-			}
+			ApplySlotUpdate(container, item, equipmentSlot);
+		}
 
-			ItemOperationTracker.Release(ReferenceButtonType.Equipment, equipmentSlot);
-
-			/* Equipment changes the silhouette: a two-handed weapon reaches further than a dagger,
-			 * and a frame sized before it existed crops it. Re-framing on the next frame rather
-			 * than this one is deliberate — the mesh is attached by the visual controller in the
-			 * same call chain, and measuring before it lands would measure the old silhouette
-			 * again. */
+		/// <summary>
+		/// Invalidates the preview framing when a socket has changed.
+		/// </summary>
+		/// <remarks>
+		/// Equipment changes the silhouette: a two-handed weapon reaches further than a dagger, and
+		/// a frame sized before it existed crops it. Re-framing on the next frame rather than this
+		/// one is deliberate — the mesh is attached by the visual controller in the same call chain,
+		/// and measuring before it lands would measure the old silhouette again.
+		/// <para>
+		/// A hook rather than part of the shared update, because it is the one thing a socket update
+		/// does that a bag-slot update has no equivalent of. It runs only for an update the shared
+		/// path accepted, which is where it sat before.
+		/// </para>
+		/// </remarks>
+		protected override void OnSlotUpdateReceived(int slotIndex)
+		{
 			previewFramed = false;
-
-			bool empty = container.IsSlotEmpty(equipmentSlot);
-			if (!empty)
-			{
-				SetSlotItem(equipmentSlot, item);
-			}
-			else
-			{
-				ClearSlot(equipmentSlot);
-			}
-
-			// A drag started from this slot no longer refers to what it was started from.
-			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject))
-			{
-				dragObject.NotifySlotChanged(ReferenceButtonType.Equipment, equipmentSlot, empty ? null : item);
-			}
 		}
 
 		// ── Attribute update callbacks ────────────────────────────────────────
@@ -672,89 +647,19 @@ namespace FishMMO.Client
 			return true;
 		}
 
-		// ── Shared operation tracker ──────────────────────────────────────────
-
-		/// <summary>
-		/// Joins the shared item-operation tracker, once.
-		/// </summary>
-		private void SubscribeTracker()
-		{
-			if (trackerSubscribed)
-			{
-				return;
-			}
-			trackerSubscribed = true;
-
-			/* -= before += on a static event. OnClientSet can run more than once in a session
-			 * (quit to login does SetClient(null) then SetClient(client)), and a static event
-			 * outlives this component, so a missed unsubscribe is a handler running forever on a
-			 * destroyed panel. */
-			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
-			ItemOperationTracker.SlotPendingChanged += OnTrackerSlotPendingChanged;
-			ItemOperationTracker.ResyncRequested    -= OnTrackerResyncRequested;
-			ItemOperationTracker.ResyncRequested    += OnTrackerResyncRequested;
-			ItemOperationTracker.Attach();
-		}
-
-		/// <summary>
-		/// Leaves the shared item-operation tracker, once.
-		/// </summary>
-		private void UnsubscribeTracker()
-		{
-			if (!trackerSubscribed)
-			{
-				return;
-			}
-			trackerSubscribed = false;
-
-			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
-			ItemOperationTracker.ResyncRequested    -= OnTrackerResyncRequested;
-			ItemOperationTracker.Detach();
-		}
-
-		/// <summary>
-		/// Repaints a slot when it starts or stops waiting on the server.
-		/// </summary>
-		private void OnTrackerSlotPendingChanged(ReferenceButtonType type, int slot, bool pending)
-		{
-			if (type != ReferenceButtonType.Equipment || slotViews == null ||
-				slot < 0 || slot >= slotViews.Length)
-			{
-				return;
-			}
-
-			ApplySlotLockVisual(slot, IsSlotBlocked(slot));
-		}
-
-		/// <summary>
-		/// Re-renders every slot from the replicated container.
-		/// </summary>
-		/// <remarks>
-		/// Raised when the server said the outcome of an operation is unknown, which is not the
-		/// same as saying it failed — see <c>ItemOperationFailureReason.ServerBusy</c>. Nothing is
-		/// reverted; the container is simply read again.
-		/// </remarks>
-		private void OnTrackerResyncRequested(ReferenceButtonType type)
-		{
-			if (type != ReferenceButtonType.Equipment)
-			{
-				return;
-			}
-
-			if (Character != null && Character.TryGet(out IEquipmentController equipmentController))
-			{
-				RefreshAllSlots(equipmentController);
-			}
-		}
+		/* SubscribeTracker, UnsubscribeTracker, OnTrackerSlotPendingChanged and
+		 * OnTrackerResyncRequested are on UITKSlotPanelBase. Four methods, some sixty lines,
+		 * character for character the same as the item grid's — including the -= before += on a
+		 * static event, and the reason for it, written out twice. */
 
 		// ── Private helpers ───────────────────────────────────────────────────
 
 		/// <summary>
 		/// Re-reads everything this panel shows from the character, without rebuilding the tree.
 		/// </summary>
-		private void ApplyPerOpenContent()
+		protected override void ApplyPerOpenContent()
 		{
-			if (slotViews == null || Character == null)
+			if (slotViews.Count == 0 || Character == null)
 			{
 				return;
 			}
@@ -776,185 +681,13 @@ namespace FishMMO.Client
 			RefreshPreview();
 		}
 
-		/// <summary>
-		/// Repaints every slot's item and lock state from the container.
-		/// </summary>
-		private void RefreshAllSlots(IEquipmentController container)
-		{
-			if (slotViews == null || container == null)
-			{
-				return;
-			}
+		/* RefreshAllSlots, IsSlotBlocked, RefreshSlot, SetSlotItem, ClearSlot, RefreshSlotTooltip
+		 * and ApplySlotLockVisual are on UITKSlotPanelBase — around two hundred lines that were a
+		 * second copy of the item grid's, down to the comment about a missing icon and the one
+		 * about issue #280. Two of them had drifted; read the base's remarks on IsSlotBlocked and
+		 * ApplySlotUpdate for what was different and which way it was settled. RefreshSlot is gone
+		 * entirely: it was a two-branch helper the shared refresh loop inlines. */
 
-			for (int i = 0; i < slotViews.Length; ++i)
-			{
-				if (slotViews[i].Root == null)
-				{
-					continue;
-				}
-				RefreshSlot(container, i);
-				ApplySlotLockVisual(i, IsSlotBlocked(i));
-			}
-		}
-
-		/// <summary>
-		/// Reports whether a slot is unavailable for a new request, for any reason.
-		/// </summary>
-		private bool IsSlotBlocked(int slotIndex)
-		{
-			if (ItemOperationTracker.IsPending(ReferenceButtonType.Equipment, slotIndex))
-			{
-				return true;
-			}
-
-			return Character != null &&
-				   Character.TryGet(out IEquipmentController equipmentController) &&
-				   equipmentController.IsSlotLocked(slotIndex);
-		}
-
-		/// <summary>
-		/// Refreshes a slot's icon and amount display from the equipment container.
-		/// </summary>
-		private void RefreshSlot(IEquipmentController container, int slotIndex)
-		{
-			if (container.TryGetItem(slotIndex, out Item item))
-			{
-				SetSlotItem(slotIndex, item);
-			}
-			else
-			{
-				ClearSlot(slotIndex);
-			}
-		}
-
-		/// <summary>
-		/// Populates a slot's icon and stack-count badge.
-		/// </summary>
-		private void SetSlotItem(int slotIndex, Item item)
-		{
-			if (item == null || slotViews == null || slotIndex < 0 || slotIndex >= slotViews.Length)
-			{
-				return;
-			}
-
-			ref SlotView view = ref slotViews[slotIndex];
-			if (view.Root == null)
-			{
-				return;
-			}
-
-			// Placeholder when the template has no icon: an occupied slot must look occupied.
-			UITKItemIcon.Apply(view.Icon, item.Template != null ? item.Template.Icon : null);
-
-			if (view.Amount != null)
-			{
-				if (item.IsStackable && item.Stackable != null)
-				{
-					view.Amount.text = item.Stackable.Amount.ToString();
-					view.Amount.RemoveFromClassList(CSS_HIDDEN);
-				}
-				else
-				{
-					view.Amount.text = "";
-					view.Amount.AddToClassList(CSS_HIDDEN);
-				}
-			}
-
-			RefreshSlotTooltip(slotIndex, item);
-		}
-
-		/// <summary>
-		/// Clears a slot's icon and hides the stack-count badge.
-		/// </summary>
-		private void ClearSlot(int slotIndex)
-		{
-			if (slotViews == null || slotIndex < 0 || slotIndex >= slotViews.Length)
-			{
-				return;
-			}
-
-			ref SlotView view = ref slotViews[slotIndex];
-			if (view.Root == null)
-			{
-				return;
-			}
-
-			UITKItemIcon.Clear(view.Icon);
-			if (view.Amount != null)
-			{
-				view.Amount.text = "";
-				view.Amount.AddToClassList(CSS_HIDDEN);
-			}
-
-			RefreshSlotTooltip(slotIndex, null);
-		}
-
-		/// <summary>
-		/// Keeps the tooltip for a slot in step with what the slot now shows.
-		/// </summary>
-		/// <remarks>
-		/// The same defect the item grids had (issue #280), and the same place to fix it: an
-		/// equipment slot that changes under a stationary cursor — a swap, an unequip, or the
-		/// replicate that acknowledges either — never gets a pointer leave or enter, so the tooltip
-		/// went on describing the item that was there when the pointer arrived.
-		/// <para>
-		/// <see cref="UITKTooltip.RefreshFor"/> ignores a slot the pointer is not over, which is what
-		/// makes it safe to call from the refresh loop that repaints all ten.
-		/// </para>
-		/// </remarks>
-		/// <param name="slotIndex">The slot that was just painted.</param>
-		/// <param name="item">What it now holds, or null when it now holds nothing.</param>
-		private void RefreshSlotTooltip(int slotIndex, Item item)
-		{
-			if (slotViews == null || slotIndex < 0 || slotIndex >= slotViews.Length)
-			{
-				return;
-			}
-
-			VisualElement owner = slotViews[slotIndex].Root;
-			if (owner == null)
-			{
-				return;
-			}
-
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				tooltip.RefreshFor(owner, item);
-			}
-		}
-
-		/// <summary>
-		/// Shows or hides the lock overlay on a slot.
-		/// </summary>
-		/// <remarks>
-		/// The same overlay carries two meanings — the container's own slot lock and a request
-		/// this panel is waiting on — because to the player they are the same statement: this slot
-		/// is busy, do not click it. The <c>--pending</c> modifier distinguishes them visually
-		/// without needing a second element in every slot.
-		/// </remarks>
-		private void ApplySlotLockVisual(int slotIndex, bool isLocked)
-		{
-			if (slotViews == null || slotIndex < 0 || slotIndex >= slotViews.Length)
-			{
-				return;
-			}
-
-			VisualElement lockEl = slotViews[slotIndex].Lock;
-			if (lockEl == null)
-			{
-				return;
-			}
-
-			lockEl.EnableInClassList(CSS_HIDDEN, !isLocked);
-			lockEl.EnableInClassList(CSS_LOCK_PENDING,
-				isLocked && ItemOperationTracker.IsPending(ReferenceButtonType.Equipment, slotIndex));
-		}
-
-		/// <summary>
-		/// Handles pointer-down events on an equipment slot element.
-		/// Left button: drag-and-drop equip or start drag.
-		/// Right button: unequip.
-		/// </summary>
 		/// <summary>
 		/// Completes a press-and-drag when the pointer is released over an equipment slot.
 		/// </summary>
@@ -989,6 +722,36 @@ namespace FishMMO.Client
 			}
 		}
 
+		/// <summary>
+		/// Handles pointer-down events on an equipment slot element.
+		/// Left button: drag-and-drop equip, or start a drag.
+		/// Shift + left button: send the item straight to the bag.
+		/// Right button: unequip.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// /* DELIBERATE BEHAVIOUR CHANGE. */ THE SHIFT BRANCH IS NEW AND IT IS A BUG FIX, not a
+		/// feature. Shift-click means "send this item to the other container" everywhere else in
+		/// the game — issue #197 put it in the bag and in the bank, and
+		/// <c>UITKItemGridPanel.OnSlotPointerDown</c> is where that lives — and a socket's other
+		/// container is the bag. Here it did nothing at all. The reason it did nothing is the reason
+		/// this whole file now has a shared base: the routing method existed twice under the same
+		/// name, the fix was made to one copy, and nothing connected the two. A player who learns
+		/// shift-click emptying their bags into the bank finds it dead the moment they try it on
+		/// what they are wearing, and reads that as the game not registering the click.
+		/// </para>
+		/// <para>
+		/// It routes to the same unequip a right-click performs, which is what makes it safe: no
+		/// new request, no new server path, no new refusal to explain. The only difference from a
+		/// right-click is that a shift-click is not also a way to cancel a drag, so it does not
+		/// clear one.
+		/// </para>
+		/// <para>
+		/// Shift is read from the event rather than from global input state: the modifier that
+		/// matters is the one held when this click happened, and a poll can answer for a moment
+		/// either side of it.
+		/// </para>
+		/// </remarks>
 		private void OnSlotPointerDown(PointerDownEvent evt, int slotIndex)
 		{
 			if (Character == null || Client == null)
@@ -998,7 +761,14 @@ namespace FishMMO.Client
 
 			if (evt.button == 0) // left
 			{
-				HandleSlotLeftClick(slotIndex);
+				if (evt.shiftKey)
+				{
+					TryQuickUnequip(slotIndex);
+				}
+				else
+				{
+					HandleSlotLeftClick(slotIndex);
+				}
 			}
 			else if (evt.button == 1) // right
 			{
@@ -1006,36 +776,9 @@ namespace FishMMO.Client
 			}
 		}
 
-		/// <summary>
-		/// Shows the item tooltip when the pointer enters an equipment slot that contains an item.
-		/// </summary>
-		private void OnSlotPointerEnter(int slotIndex, VisualElement owner)
-		{
-			if (Character == null ||
-				!Character.TryGet(out IEquipmentController equipmentController) ||
-				!equipmentController.TryGetItem(slotIndex, out Item item))
-			{
-				return;
-			}
-
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				// With an owner, so the tooltip closes itself if this slot is rebuilt under it.
-				tooltip.Open(item, owner);
-			}
-		}
-
-		/// <summary>
-		/// Hides the item tooltip when the pointer leaves an equipment slot.
-		/// </summary>
-		private void OnSlotPointerLeave(VisualElement owner)
-		{
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				// HideFor, so a stale leave cannot close a tooltip a different slot has since opened.
-				tooltip.HideFor(owner);
-			}
-		}
+		/* OnSlotPointerEnter and OnSlotPointerLeave are on UITKSlotPanelBase. Opening a tooltip for
+		 * whatever a slot holds, and closing it with HideFor so a stale leave cannot shut a tooltip
+		 * another slot has since opened, is the same act in a socket and in a bag slot. */
 
 		/// <summary>
 		/// Left-click: if a drag object is active, equip the dragged item into this slot;
@@ -1193,31 +936,8 @@ namespace FishMMO.Client
 			}
 		}
 
-		/// <summary>
-		/// Starts a drag from an occupied equipment slot.
-		/// </summary>
-		private void BeginDragFromSlot(UITKDragObject dragObject, IEquipmentController equipmentController, int slotIndex)
-		{
-			bool blocked = IsSlotBlocked(slotIndex);
-			bool gotItem = equipmentController.TryGetItem(slotIndex, out Item item);
-
-			// Report the refusal, not just the success — see UITKInventory.BeginDragFromSlot.
-			if (blocked || !gotItem || item == null)
-			{
-				FishMMO.Logging.Log.Debug("UITKEquipment",
-					$"BeginDrag REFUSED slot {slotIndex}: blocked={blocked} " +
-					$"(pending={ItemOperationTracker.IsPending(ReferenceButtonType.Equipment, slotIndex)}) " +
-					$"gotItem={gotItem} itemNull={item == null}.");
-				return;
-			}
-
-			// Same as the inventory: a missing icon must not prevent the item being unequipped.
-			Sprite icon = item.Template != null ? item.Template.Icon : null;
-
-			/* The item, not just the slot index. A slot index alone is only true for as long as
-			 * nothing writes to that slot, and the server can write to it at any moment. */
-			dragObject.SetItemReference(icon, slotIndex, ReferenceButtonType.Equipment, item);
-		}
+		/* BeginDragFromSlot is on UITKSlotPanelBase, refusal log and all — this copy and the item
+		 * grid's differed only in that the grid's had lost the log line. */
 
 		/// <summary>
 		/// Right-click: unequip the item to the inventory.
@@ -1237,6 +957,25 @@ namespace FishMMO.Client
 				dragObject.Clear();
 			}
 
+			TryQuickUnequip(slotIndex);
+		}
+
+		/// <summary>
+		/// Sends the item in <paramref name="slotIndex"/> back to the bag.
+		/// </summary>
+		/// <remarks>
+		/// Split out of <see cref="HandleSlotRightClick"/> so that shift-click can reach the same
+		/// request — see <see cref="OnSlotPointerDown"/> for why a socket needed a shift-click at
+		/// all. The one thing right-click does that shift-click does not is cancel a drag in
+		/// progress, which is why that stayed behind rather than moving in here.
+		/// <para>
+		/// Nothing is written on this client. The slot keeps rendering the item and is marked as
+		/// waiting; the equipment container being replicated back is what empties it.
+		/// </para>
+		/// </remarks>
+		/// <param name="slotIndex">The socket to empty.</param>
+		private void TryQuickUnequip(int slotIndex)
+		{
 			if (!Character.TryGet(out IEquipmentController equipmentController))
 			{
 				return;
@@ -1263,51 +1002,24 @@ namespace FishMMO.Client
 			}
 		}
 
-		/// <summary>
-		/// Resolves the character's container for a drag source type.
-		/// </summary>
-		private IItemContainer ResolveContainer(ReferenceButtonType type)
-		{
-			if (Character == null)
-			{
-				return null;
-			}
-
-			switch (type)
-			{
-				case ReferenceButtonType.Inventory:
-					return Character.TryGet(out IInventoryController inventoryController) ? inventoryController : null;
-				case ReferenceButtonType.Bank:
-					return Character.TryGet(out IBankController bankController) ? bankController : null;
-				case ReferenceButtonType.Equipment:
-					return Character.TryGet(out IEquipmentController equipmentController) ? equipmentController : null;
-				default:
-					return null;
-			}
-		}
-
-		/// <summary>
-		/// Abandons this panel's in-flight operations and any drag that started here.
-		/// </summary>
-		private void ReleaseAndClearDrag()
-		{
-			ItemOperationTracker.ReleaseAll(ReferenceButtonType.Equipment);
-
-			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject) &&
-				dragObject.IsDragging &&
-				dragObject.Type == ReferenceButtonType.Equipment)
-			{
-				dragObject.Clear();
-			}
-		}
+		/* ResolveContainer and ReleaseAndClearDrag are on UITKSlotPanelBase. ResolveContainer was
+		 * character for character identical to the item grid's, switch arms and all — the clearest
+		 * single sign that these two panels wanted one base: a method about the CHARACTER's
+		 * containers, with no reference to the panel it was written in, existing twice. */
 
 		/// <summary>
 		/// Shows a transient notice, if the toast panel is up.
 		/// </summary>
 		/// <remarks>
-		/// The same helper the item grids use. A drop this panel refuses is a gesture the player
-		/// made and expects an answer to — see <see cref="CompleteDropOntoSlot"/> — and the
-		/// equipment sockets are the one place a refusal has nowhere else to surface.
+		/// The same helper the item grids use, and the one piece of duplication deliberately left
+		/// standing: <c>QuickTransferTests</c> scans <c>UITKItemGridPanel</c> by locating this
+		/// method's summary line, so hoisting it would break a fixture outside this change's scope
+		/// for the sake of five lines. Said plainly rather than left to be rediscovered.
+		/// <para>
+		/// A drop this panel refuses is a gesture the player made and expects an answer to — see
+		/// <see cref="CompleteDropOntoSlot"/> — and the equipment sockets are the one place a
+		/// refusal has nowhere else to surface.
+		/// </para>
 		/// </remarks>
 		private static void Notify(string text, ToastSeverity severity)
 		{

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/FriendList/UITKFriendList.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/FriendList/UITKFriendList.cs
@@ -340,38 +340,33 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Prompts for a name and broadcasts an add-friend request.
 		/// </summary>
+		/// <remarks>
+		/// The name-to-ID half is <see cref="UITKControl.PromptForCharacterID"/>, shared with the
+		/// guild and party invite buttons, which held the same flow verbatim. Only the broadcast and
+		/// the "that is you" wording are this panel's.
+		/// <para>
+		/// There is deliberately NO target-first path here, unlike those two: a friend is added by
+		/// name on purpose. Adding whoever happens to be under the pointer is a different and much
+		/// easier-to-misfire action, and the roster row is where an already-known character is acted
+		/// on.
+		/// </para>
+		/// <para>
+		/// There is also no connection guard around this, again unlike the invite buttons — they
+		/// require a guild or a party to exist, which cannot be true offline, whereas this button has
+		/// no such precondition to lean on. The broadcast itself is the guard: it goes nowhere when
+		/// the client is not started.
+		/// </para>
+		/// </remarks>
 		public void OnButtonAddFriend()
 		{
-			if (UIManager.TryGetTK("UIDialogInputBox", out UITKDialogInputBox tooltip))
-			{
-				tooltip.Open("Please type the name of the person you wish to add.", (s) =>
+			PromptForCharacterID(
+				"Please type the name of the person you wish to add.",
+				() => Character,
+				"You can't add yourself as a friend.",
+				(id) => Client.Broadcast(new FriendAddNewBroadcast()
 				{
-					if (Authentication.IsAllowedCharacterName(s))
-					{
-						ClientNamingSystem.GetCharacterID(s, (id) =>
-						{
-							if (id != 0)
-							{
-								if (Character != null && Character.ID != id)
-								{
-									Client.Broadcast(new FriendAddNewBroadcast()
-									{
-										CharacterID = id
-									}, Channel.Reliable);
-								}
-								else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-								{
-									chat.InstantiateChatMessage(ChatChannel.System, "", "You can't add yourself as a friend.");
-								}
-							}
-							else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-							{
-								chat.InstantiateChatMessage(ChatChannel.System, "", "A person with that name could not be found.");
-							}
-						});
-					}
-				}, null);
-			}
+					CharacterID = id
+				}, Channel.Reliable));
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs
@@ -1174,6 +1174,14 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Invites the hovered or pinned target, or prompts for a name, to the guild.
 		/// </summary>
+		/// <remarks>
+		/// Target first, name second. Both halves live on <see cref="UITKControl"/> now — see
+		/// <see cref="UITKControl.TryResolveTargetCharacter"/> and
+		/// <see cref="UITKControl.PromptForCharacterID"/> — because the party panel and the friend
+		/// list had their own copy of each, identical down to the wording of the failure messages.
+		/// What stays here is what is genuinely guild-specific: the guard (a guild must exist to
+		/// invite into), the broadcast, and the one sentence that names the guild.
+		/// </remarks>
 		public void OnButtonInviteToGuild()
 		{
 			if (Character != null &&
@@ -1181,56 +1189,24 @@ namespace FishMMO.Client
 				guildController.ID > 0 &&
 				Client.NetworkManager.IsClientStarted)
 			{
-				if (Character.TryGet(out ITargetController targetController))
+				if (TryResolveTargetCharacter(Character, out IPlayerCharacter targetCharacter))
 				{
-					/* The hovered character first, then the pinned one. The pointer is on this
-					 * button when it fires, so the hover target is usually empty — and the
-					 * pinned card is exactly the player's way of saying "this one" ahead of time. */
-					Transform target = targetController.Current.Target != null
-						? targetController.Current.Target
-						: targetController.PinnedTarget;
-					IPlayerCharacter targetCharacter = target != null ? target.GetComponent<IPlayerCharacter>() : null;
-					if (targetCharacter != null)
+					Client.Broadcast(new GuildInviteBroadcast()
 					{
-						Client.Broadcast(new GuildInviteBroadcast()
-						{
-							TargetCharacterID = targetCharacter.ID
-						}, Channel.Reliable);
+						TargetCharacterID = targetCharacter.ID
+					}, Channel.Reliable);
 
-						return;
-					}
+					return;
 				}
 
-				if (UIManager.TryGetTK("UIDialogInputBox", out UITKDialogInputBox tooltip))
-				{
-					tooltip.Open("Please type the name of the person you wish to invite.", (s) =>
+				PromptForCharacterID(
+					"Please type the name of the person you wish to invite.",
+					() => Character,
+					"You can't invite yourself to the guild.",
+					(id) => Client.Broadcast(new GuildInviteBroadcast()
 					{
-						if (Authentication.IsAllowedCharacterName(s))
-						{
-							ClientNamingSystem.GetCharacterID(s, (id) =>
-							{
-								if (id != 0)
-								{
-									if (Character != null && Character.ID != id)
-									{
-										Client.Broadcast(new GuildInviteBroadcast()
-										{
-											TargetCharacterID = id,
-										}, Channel.Reliable);
-									}
-									else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-									{
-										chat.InstantiateChatMessage(ChatChannel.System, "", "You can't invite yourself to the guild.");
-									}
-								}
-								else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-								{
-									chat.InstantiateChatMessage(ChatChannel.System, "", "A person with that name could not be found.");
-								}
-							});
-						}
-					}, null);
-				}
+						TargetCharacterID = id,
+					}, Channel.Reliable));
 			}
 		}
 
@@ -1277,6 +1253,17 @@ namespace FishMMO.Client
 		/// Trimmed to <paramref name="maxLength"/> here as a courtesy so the player is not silently
 		/// truncated at the database, but the server re-applies the same cap — a client's idea of
 		/// a limit is never the limit.
+		/// <para>
+		/// This is NOT <see cref="UITKControl.PromptForCharacterID"/> with different strings, and was
+		/// deliberately left as its own method when the three invite flows were merged into that one.
+		/// It asks for FREE TEXT, not a name: nothing here is validated against
+		/// <see cref="Authentication.IsAllowedCharacterName"/>, nothing is resolved through
+		/// <see cref="ClientNamingSystem"/>, there is no ID to compare against the player's own, and
+		/// it is gated on a guild PERMISSION that the invite flows have no equivalent of. Folding it
+		/// in would have meant a helper with two mutually exclusive halves selected by a flag, which
+		/// is the copy it replaced wearing one name. What it does share — finding the one input
+		/// dialog, and putting a line in chat — it now takes from the base class.
+		/// </para>
 		/// </remarks>
 		private void PromptGuildText(string prompt, string current, int maxLength, GuildPermissions required, Action<string> send)
 		{
@@ -1290,19 +1277,11 @@ namespace FishMMO.Client
 
 			if (!guildController.HasGuildPermission(required))
 			{
-				if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-				{
-					chat.InstantiateChatMessage(ChatChannel.System, "", "Your guild rank does not allow that.");
-				}
+				ShowSystemMessage("Your guild rank does not allow that.");
 				return;
 			}
 
-			if (!UIManager.TryGetTK("UIDialogInputBox", out UITKDialogInputBox input))
-			{
-				return;
-			}
-
-			input.Open(prompt, (s) =>
+			TryPromptForText(prompt, (s) =>
 			{
 				string text = (s ?? string.Empty).Trim();
 				if (text.Length > maxLength)
@@ -1310,7 +1289,7 @@ namespace FishMMO.Client
 					text = text.Substring(0, maxLength);
 				}
 				send(text);
-			}, null);
+			});
 		}
 
 		/// <summary>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/ItemSlotPendingSet.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/ItemSlotPendingSet.cs
@@ -146,6 +146,44 @@ namespace FishMMO.Client
 		}
 
 		/// <summary>
+		/// Collects every slot that currently has a request outstanding.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// For the one question the per-slot accessors cannot answer: which pending slots are no
+		/// longer worth waiting for. A panel viewing a SHARED pile — a corpse, a world chest — is
+		/// re-sent the whole contents whenever any looter takes something, and a slot that has
+		/// vanished from that snapshot is a request this client lost the race on. Its reply is
+		/// already accounted for by the snapshot, so the panel prunes it immediately rather than
+		/// leaving it locked until the watchdog fires, on a row that is no longer on screen.
+		/// Answering that needs the pending set enumerated, because the caller is looking for slots
+		/// it does NOT have any more and so has nothing to ask <see cref="IsPending"/> about.
+		/// </para>
+		/// <para>
+		/// Fills a caller-supplied list rather than returning a shared buffer, unlike
+		/// <see cref="CollectExpired"/>: the caller iterates the result while calling
+		/// <see cref="Release"/>, and a prune interleaved with a tick must not have the tick's
+		/// buffer pulled out from under it.
+		/// </para>
+		/// </remarks>
+		/// <param name="into">Receives the pending slot indices. Not cleared by this call.</param>
+		public void CollectPending(List<int> into)
+		{
+			if (into == null || PendingCount < 1)
+			{
+				return;
+			}
+
+			foreach (KeyValuePair<int, PendingReplyGuard> pair in guards)
+			{
+				if (pair.Value.IsPending)
+				{
+					into.Add(pair.Key);
+				}
+			}
+		}
+
+		/// <summary>
 		/// Collects the slots whose wait has just expired.
 		/// </summary>
 		/// <remarks>

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs
@@ -30,25 +30,26 @@ namespace FishMMO.Client
 	/// A request goes out, the slot is marked as waiting, and the container being replicated back
 	/// is what changes what the player sees.
 	/// </para>
+	/// <para>
+	/// The same argument reached one panel further later on. The equipment panel was a third copy
+	/// of everything a SLOT does — the tracker subscription, the lock overlay, the painters, the
+	/// tooltip, the drag start — and it had already drifted from this one in three places. All of
+	/// that now lives in <see cref="UITKSlotPanelBase"/>, which this class and the equipment panel
+	/// both derive from; read its remarks for what had diverged and how each divergence was
+	/// settled. What stayed here is the grid itself, and the half of the item protocol a grid
+	/// speaks: swap, split, and quick transfer to the other open container.
+	/// </para>
 	/// </remarks>
-	public abstract class UITKItemGridPanel : UITKCharacterControl
+	public abstract class UITKItemGridPanel : UITKSlotPanelBase
 	{
 		// ── What each panel must say about itself ─────────────────────────────
 
-		/// <summary>
-		/// Element and USS name prefix for this panel, without a trailing dash.
-		/// </summary>
-		/// <remarks>
-		/// Every panel-specific name is this prefix plus a fixed suffix — "bank-capacity-fill" and
-		/// "inv-capacity-fill", "bank-currency-value" and "inv-currency-value". The constants that
-		/// followed that pattern in each panel were one string apiece written twice; one prefix
-		/// replaces them. A panel whose markup does not follow it should override the names below
-		/// rather than bend the prefix.
-		/// </remarks>
-		protected abstract string Prefix { get; }
-
-		/// <summary>The drag and operation-tracker identity of this panel's slots.</summary>
-		protected abstract ReferenceButtonType DragType { get; }
+		/* Prefix and DragType are declared by UITKSlotPanelBase now, along with everything a slot
+		 * does once it exists: the tracker subscription, the lock overlay, the painters, the
+		 * tooltip, the drag start and release. What is left in this file is what makes a GRID a
+		 * grid rather than a set of authored sockets — it builds one element per container slot,
+		 * counts its capacity, shows a currency chip, and speaks the swap and split half of the
+		 * item protocol. See that class for why the split is drawn here and not elsewhere. */
 
 		/// <summary>This panel's container, as the server names it in a request.</summary>
 		protected abstract InventoryType OwnInventoryType { get; }
@@ -115,8 +116,8 @@ namespace FishMMO.Client
 
 		// ── Shared UI overlay names (panels resolved by GameObject name via UIManager) ──
 
-		protected const string DRAG_OBJECT_NAME = "UIDragObject";
-		protected const string TOOLTIP_NAME = "UITooltip";
+		/* DRAG_OBJECT_NAME, TOOLTIP_NAME and TOAST_NAME are on UITKSlotPanelBase. The split prompt
+		 * is only reachable from a grid, so its name stays here. */
 		protected const string INPUT_DIALOG_NAME = "UIDialogInputBox";
 
 		// ── USS class names ───────────────────────────────────────────────────
@@ -130,29 +131,13 @@ namespace FishMMO.Client
 		private string CssSlotIconLayout => Prefix + "-slot__icon";
 		private string CssSlotAmountLayout => Prefix + "-slot__amount";
 		private string CssSlotLockLayout => Prefix + "-slot__lock";
-		/// <summary>USS class marking a slot as waiting on the server.</summary>
-		private string CssLockPending => Prefix + "-slot__lock--pending";
-		/// <summary>USS class hiding an element.</summary>
-		protected string CssHidden => Prefix + "-hidden";
 
-		// ── Per-slot view data ────────────────────────────────────────────────
-
-		protected struct SlotView
-		{
-			/// <summary>Root VisualElement of the slot.</summary>
-			public VisualElement Root;
-			/// <summary>Icon element displaying the item sprite.</summary>
-			public VisualElement Icon;
-			/// <summary>Stack-count label.</summary>
-			public Label Amount;
-			/// <summary>Lock overlay element.</summary>
-			public VisualElement Lock;
-		}
+		/* CssHidden and CssLockPending are derived from Prefix by UITKSlotPanelBase, which is where
+		 * the slot painters that use them live. The four names above are grid layout classes and
+		 * have no counterpart in a socket panel. */
 
 		// ── Private state ─────────────────────────────────────────────────────
 
-		/// <summary>Slot views indexed by container slot index.</summary>
-		protected readonly List<SlotView> slotViews = new List<SlotView>();
 		/// <summary>Header line showing slot usage, drawn over the capacity bar.</summary>
 		private Label subtitleLabel;
 		/// <summary>Header capacity bar fill.</summary>
@@ -179,39 +164,6 @@ namespace FishMMO.Client
 
 		/// <summary>The slot grid container element.</summary>
 		private VisualElement slotGrid;
-
-		/// <summary>True while this panel holds a subscription on the shared operation tracker.</summary>
-		private bool trackerSubscribed;
-
-		// ── Container access ──────────────────────────────────────────────────
-
-		/// <summary>
-		/// This panel's own container, or null when the character does not have one yet.
-		/// </summary>
-		protected IItemContainer OwnContainer => ResolveContainer(DragType);
-
-		/// <summary>
-		/// Resolves the character's container for a drag source type.
-		/// </summary>
-		protected IItemContainer ResolveContainer(ReferenceButtonType type)
-		{
-			if (Character == null)
-			{
-				return null;
-			}
-
-			switch (type)
-			{
-				case ReferenceButtonType.Inventory:
-					return Character.TryGet(out IInventoryController inventoryController) ? inventoryController : null;
-				case ReferenceButtonType.Bank:
-					return Character.TryGet(out IBankController bankController) ? bankController : null;
-				case ReferenceButtonType.Equipment:
-					return Character.TryGet(out IEquipmentController equipmentController) ? equipmentController : null;
-				default:
-					return null;
-			}
-		}
 
 		// ── UITKControl lifecycle ─────────────────────────────────────────────
 
@@ -241,84 +193,22 @@ namespace FishMMO.Client
 			}
 		}
 
-		/// <summary>
-		/// Rebuilds the grid after the visual tree has been replaced.
-		/// </summary>
-		protected override void OnAfterStarting()
-		{
-			base.OnAfterStarting();
-			ApplyPerOpenContent();
-		}
+		/* OnAfterStarting, OnAfterShow, OnClientSet, OnClientUnset, OnTick and Hide are all on
+		 * UITKSlotPanelBase, which had to gain them because this panel and the equipment panel
+		 * had written the same six overrides — including the same first-open trap in the same
+		 * comment, twice. */
 
 		/// <summary>
-		/// Fills the grid on every show, including the very first one.
+		/// Destroys all runtime slot elements and detaches from the container.
 		/// </summary>
 		/// <remarks>
-		/// THE CONTRACT: enabling the document re-clones the UXML, so anything written before
-		/// <c>Show()</c> is discarded. <c>OnAfterStarting</c> covers later opens, but on the first
-		/// ever open <c>hasStarted</c> is still false and <c>ReinitializeIfTreeReplaced</c> bails
-		/// out before calling it — and a panel opened by a broadcast has its first open triggered
-		/// by something the player did rather than at startup. Both hooks do the work, and both
-		/// are idempotent.
+		/// The tracker subscription and the drag are released by the base before this runs, which
+		/// is the order this panel already used.
 		/// </remarks>
-		protected override void OnAfterShow()
+		protected override void OnPanelDestroying()
 		{
-			ApplyPerOpenContent();
-		}
-
-		/// <summary>
-		/// Joins the shared operation tracker. Derived panels extend this to register broadcasts.
-		/// </summary>
-		public override void OnClientSet()
-		{
-			SubscribeTracker();
-		}
-
-		/// <summary>
-		/// Leaves the shared operation tracker. Derived panels extend this to unregister broadcasts.
-		/// </summary>
-		public override void OnClientUnset()
-		{
-			UnsubscribeTracker();
-		}
-
-		/// <summary>
-		/// Times out item operations whose reply never arrived.
-		/// </summary>
-		protected override void OnTick()
-		{
-			ItemOperationTracker.Tick();
-		}
-
-		/// <summary>
-		/// Destroys all runtime slot elements and drops every subscription when the control is destroyed.
-		/// </summary>
-		public override void OnDestroying()
-		{
-			UnsubscribeTracker();
-			ReleaseAndClearDrag();
 			UnsubscribeContainer();
 			DestroySlots();
-			base.OnDestroying();
-		}
-
-		/// <summary>
-		/// Hides the panel and abandons anything it had in flight.
-		/// </summary>
-		/// <remarks>
-		/// Closing is not a neutral act: walking out of range of the interactable that opened the
-		/// panel is one of the ways the server refuses an operation, so a slot left marked as
-		/// waiting after the panel closes has a very good chance of never being answered.
-		/// </remarks>
-		/// <param name="overrideIsAlwaysOpen">When true, the call is a no-op.</param>
-		public override void Hide(bool overrideIsAlwaysOpen)
-		{
-			base.Hide(overrideIsAlwaysOpen);
-
-			if (!Visible)
-			{
-				ReleaseAndClearDrag();
-			}
 		}
 
 		// ── Character control ─────────────────────────────────────────────────
@@ -418,112 +308,33 @@ namespace FishMMO.Client
 		/// </remarks>
 		public void OnSlotUpdated(IItemContainer container, Item item, int slotIndex)
 		{
-			if (container == null || slotIndex < 0)
-			{
-				return;
-			}
-
-			/* An index the grid does not have means the grid is smaller than the container — built
-			 * before the container was sized, or against a tree that has been replaced. Rebuilding
-			 * is the recovery; dropping the update silently is what left a panel showing fewer
-			 * slots than the character actually has. */
-			if (slotIndex >= slotViews.Count)
-			{
-				if (!EnsureSlots(OwnContainer) || slotIndex >= slotViews.Count)
-				{
-					return;
-				}
-			}
-
-			ItemOperationTracker.Release(DragType, slotIndex);
-
-			bool empty = container.IsSlotEmpty(slotIndex);
-			if (!empty)
-			{
-				SetSlotItem(slotIndex, item);
-			}
-			else
-			{
-				ClearSlot(slotIndex);
-			}
-
-			// The item itself can be the reason a slot is blocked (no identity yet), and the slot
-			// arriving with its identity is what unblocks it.
-			ApplySlotLockVisual(slotIndex, IsSlotBlocked(slotIndex));
-
-			// A drag started from this slot no longer refers to what it was started from.
-			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject))
-			{
-				dragObject.NotifySlotChanged(DragType, slotIndex, empty ? null : item);
-			}
-		}
-
-		// ── Shared operation tracker ──────────────────────────────────────────
-
-		/// <summary>
-		/// Joins the shared item-operation tracker, once.
-		/// </summary>
-		private void SubscribeTracker()
-		{
-			if (trackerSubscribed)
-			{
-				return;
-			}
-			trackerSubscribed = true;
-
-			/* -= before += on a static event: OnClientSet runs again after a quit to login, and a
-			 * static event outlives this component. */
-			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
-			ItemOperationTracker.SlotPendingChanged += OnTrackerSlotPendingChanged;
-			ItemOperationTracker.ResyncRequested -= OnTrackerResyncRequested;
-			ItemOperationTracker.ResyncRequested += OnTrackerResyncRequested;
-			ItemOperationTracker.Attach();
+			ApplySlotUpdate(container, item, slotIndex);
 		}
 
 		/// <summary>
-		/// Leaves the shared item-operation tracker, once.
+		/// Rebuilds the grid when an update names a slot the grid does not have.
 		/// </summary>
-		private void UnsubscribeTracker()
+		/// <remarks>
+		/// A grid CAN grow, unlike a set of authored sockets, which is why the base asks rather
+		/// than assumes. The index arrives past the end when the grid was built before the
+		/// container was sized — a grid of zero because the panel was opened before the character
+		/// had a container — and nothing else would ever correct it.
+		/// </remarks>
+		protected override bool TryGrowSlotsFor(int slotIndex)
 		{
-			if (!trackerSubscribed)
-			{
-				return;
-			}
-			trackerSubscribed = false;
-
-			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
-			ItemOperationTracker.ResyncRequested -= OnTrackerResyncRequested;
-			ItemOperationTracker.Detach();
+			return EnsureSlots(OwnContainer);
 		}
 
 		/// <summary>
-		/// Repaints a slot when it starts or stops waiting on the server.
+		/// Recomputes the capacity readout whenever a slot's contents are repainted.
 		/// </summary>
-		private void OnTrackerSlotPendingChanged(ReferenceButtonType type, int slot, bool pending)
+		/// <remarks>
+		/// The one thing the shared painters had to be told about. A socket panel has no capacity
+		/// bar, so the base paints the slot and asks here whether anything counts it.
+		/// </remarks>
+		protected override void OnSlotContentChanged()
 		{
-			if (type != DragType || slot < 0 || slot >= slotViews.Count)
-			{
-				return;
-			}
-
-			ApplySlotLockVisual(slot, IsSlotBlocked(slot));
-		}
-
-		/// <summary>
-		/// Re-renders every slot from the replicated container.
-		/// </summary>
-		private void OnTrackerResyncRequested(ReferenceButtonType type)
-		{
-			if (type != DragType)
-			{
-				return;
-			}
-
-			IItemContainer container = OwnContainer;
-			if (container != null)
-			{
-				RefreshAllSlots(container);
-			}
+			RefreshCapacity();
 		}
 
 		// ── Slot element construction ─────────────────────────────────────────
@@ -531,7 +342,7 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Re-reads the whole grid from the character, rebuilding it only if it is stale.
 		/// </summary>
-		protected void ApplyPerOpenContent()
+		protected override void ApplyPerOpenContent()
 		{
 			/* Ahead of the container check. A character with no container yet still has a
 			 * currency, and the footer is the only place this panel draws it. */
@@ -604,27 +415,6 @@ namespace FishMMO.Client
 			}
 
 			RefreshAllSlots(container);
-		}
-
-		/// <summary>
-		/// Repaints every slot's item and lock state from the container.
-		/// </summary>
-		private void RefreshAllSlots(IItemContainer container)
-		{
-			int slotCount = Mathf.Min(slotViews.Count, container.Items.Count);
-			for (int i = 0; i < slotCount; ++i)
-			{
-				if (container.TryGetItem(i, out Item item))
-				{
-					SetSlotItem(i, item);
-				}
-				else
-				{
-					ClearSlot(i);
-				}
-				ApplySlotLockVisual(i, IsSlotBlocked(i));
-			}
-			RefreshCapacity();
 		}
 
 		/// <summary>
@@ -709,45 +499,7 @@ namespace FishMMO.Client
 			slotViews.Clear();
 		}
 
-		// ── Slot visuals ──────────────────────────────────────────────────────
-
-		/// <summary>
-		/// Populates a slot's icon and stack-count badge from an item.
-		/// </summary>
-		private void SetSlotItem(int slotIndex, Item item)
-		{
-			if (item == null || slotIndex < 0 || slotIndex >= slotViews.Count)
-			{
-				return;
-			}
-
-			SlotView view = slotViews[slotIndex];
-			if (view.Root == null)
-			{
-				return;
-			}
-
-			RefreshCapacity();
-
-			// Placeholder when the template has no icon: an occupied slot must look occupied.
-			UITKItemIcon.Apply(view.Icon, item.Template != null ? item.Template.Icon : null);
-
-			if (view.Amount != null)
-			{
-				if (item.IsStackable && item.Stackable != null)
-				{
-					view.Amount.text = item.Stackable.Amount.ToString();
-					view.Amount.RemoveFromClassList(CssHidden);
-				}
-				else
-				{
-					view.Amount.text = "";
-					view.Amount.AddToClassList(CssHidden);
-				}
-			}
-
-			RefreshSlotTooltip(slotIndex, item);
-		}
+		// ── Capacity readout ──────────────────────────────────────────────────
 
 		/// <summary>
 		/// Recomputes the capacity count and the bar it is drawn on.
@@ -896,116 +648,10 @@ namespace FishMMO.Client
 			currencyValueLabel.text = currencyAttribute.Value.ToString();
 		}
 
-		/// <summary>
-		/// Clears a slot's icon and hides its stack-count badge.
-		/// </summary>
-		private void ClearSlot(int slotIndex)
-		{
-			if (slotIndex < 0 || slotIndex >= slotViews.Count)
-			{
-				return;
-			}
-
-			SlotView view = slotViews[slotIndex];
-			if (view.Root == null)
-			{
-				return;
-			}
-
-			RefreshCapacity();
-
-			UITKItemIcon.Clear(view.Icon);
-			if (view.Amount != null)
-			{
-				view.Amount.text = "";
-				view.Amount.AddToClassList(CssHidden);
-			}
-
-			RefreshSlotTooltip(slotIndex, null);
-		}
-
-		/// <summary>
-		/// Keeps the tooltip for a slot in step with what the slot now shows.
-		/// </summary>
-		/// <remarks>
-		/// Called from the two methods that paint a slot, so every path that changes one — a
-		/// replicate arriving, a resync, a rebuild, a panel opening — keeps the tooltip honest
-		/// without having to remember to. The tooltip was opened from the item the pointer found on
-		/// the way in and nothing re-read it, so a swap under a stationary cursor left it describing
-		/// the item that used to be in the slot the player is looking at. Issue #280.
-		/// <para>
-		/// <see cref="UITKTooltip.RefreshFor"/> does nothing unless the pointer is over THIS slot,
-		/// which is what makes the per-slot call safe from the loops above.
-		/// </para>
-		/// </remarks>
-		/// <param name="slotIndex">The slot that was just painted.</param>
-		/// <param name="item">What it now holds, or null when it now holds nothing.</param>
-		private void RefreshSlotTooltip(int slotIndex, Item item)
-		{
-			if (slotIndex < 0 || slotIndex >= slotViews.Count)
-			{
-				return;
-			}
-
-			VisualElement owner = slotViews[slotIndex].Root;
-			if (owner == null)
-			{
-				return;
-			}
-
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				tooltip.RefreshFor(owner, item);
-			}
-		}
-
-		/// <summary>
-		/// Shows or hides the lock overlay on a slot.
-		/// </summary>
-		private void ApplySlotLockVisual(int slotIndex, bool isLocked)
-		{
-			if (slotIndex < 0 || slotIndex >= slotViews.Count)
-			{
-				return;
-			}
-
-			VisualElement lockEl = slotViews[slotIndex].Lock;
-			if (lockEl == null)
-			{
-				return;
-			}
-
-			lockEl.EnableInClassList(CssHidden, !isLocked);
-			lockEl.EnableInClassList(CssLockPending,
-				isLocked && ItemOperationTracker.IsPending(DragType, slotIndex));
-		}
-
-		/// <summary>
-		/// Reports whether a slot is unavailable for a new request, for any reason.
-		/// </summary>
-		protected bool IsSlotBlocked(int slotIndex)
-		{
-			if (ItemOperationTracker.IsPending(DragType, slotIndex))
-			{
-				return true;
-			}
-
-			IItemContainer container = OwnContainer;
-			if (container == null)
-			{
-				return false;
-			}
-			if (container.IsSlotLocked(slotIndex))
-			{
-				return true;
-			}
-
-			/* An item with no identity is one the database has not written yet. The server keeps
-			 * its slot locked until the row lands and re-sends the slot with the assigned id; until
-			 * then every request naming it would be refused, so it is shown as waiting rather than
-			 * offered. */
-			return container.TryGetItem(slotIndex, out Item item) && item != null && item.ID <= 0;
-		}
+		/* SetSlotItem, ClearSlot, RefreshSlotTooltip, ApplySlotLockVisual and IsSlotBlocked are all
+		 * on UITKSlotPanelBase. They were the largest single block of duplication between this
+		 * panel and the equipment panel, and two of them had already diverged — see that class for
+		 * which, and which way the divergence was settled. */
 
 		// ── Slot interaction ──────────────────────────────────────────────────
 
@@ -1166,7 +812,7 @@ namespace FishMMO.Client
 		/// <summary>Shows a transient notice, if the toast panel is up.</summary>
 		private static void Notify(string text, ToastSeverity severity)
 		{
-			if (UIManager.TryGetTK("UIToast", out UITKToast toast))
+			if (UIManager.TryGetTK(TOAST_NAME, out UITKToast toast))
 			{
 				toast.Show(text, severity);
 			}
@@ -1479,69 +1125,9 @@ namespace FishMMO.Client
 			dragObject.Clear();
 		}
 
-		/// <summary>
-		/// Starts a drag from an occupied slot.
-		/// </summary>
-		protected void BeginDragFromSlot(UITKDragObject dragObject, IItemContainer container, int slotIndex)
-		{
-			if (IsSlotBlocked(slotIndex) ||
-				!container.TryGetItem(slotIndex, out Item item) ||
-				item == null)
-			{
-				return;
-			}
-
-			// A missing icon must not prevent the item being moved.
-			Sprite sprite = item.Template != null ? item.Template.Icon : null;
-
-			/* Carry the item, not just the slot number: the slot index stops being true the moment
-			 * anything else writes to that slot, and the drop would then move the wrong item. */
-			dragObject.SetItemReference(sprite, slotIndex, DragType, item);
-		}
-
-		/// <summary>
-		/// Shows the item tooltip when the pointer enters a slot that contains an item.
-		/// </summary>
-		private void OnSlotPointerEnter(int slotIndex, VisualElement owner)
-		{
-			IItemContainer container = OwnContainer;
-			if (container == null || !container.TryGetItem(slotIndex, out Item item))
-			{
-				return;
-			}
-
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				// With an owner, so the tooltip closes itself if this slot is rebuilt under it.
-				tooltip.Open(item, owner);
-			}
-		}
-
-		/// <summary>
-		/// Hides the item tooltip when the pointer leaves a slot.
-		/// </summary>
-		private void OnSlotPointerLeave(VisualElement owner)
-		{
-			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
-			{
-				// HideFor, so a stale leave cannot close a tooltip another slot has since opened.
-				tooltip.HideFor(owner);
-			}
-		}
-
-		/// <summary>
-		/// Abandons this panel's in-flight operations and any drag that started here.
-		/// </summary>
-		protected void ReleaseAndClearDrag()
-		{
-			ItemOperationTracker.ReleaseAll(DragType);
-
-			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject) &&
-				dragObject.IsDragging &&
-				dragObject.Type == DragType)
-			{
-				dragObject.Clear();
-			}
-		}
+		/* BeginDragFromSlot, OnSlotPointerEnter, OnSlotPointerLeave and ReleaseAndClearDrag are on
+		 * UITKSlotPanelBase. Starting a drag, showing a tooltip and abandoning what is in flight
+		 * are the same acts in a bag slot and in a socket — it is only the DROP that differs, a
+		 * swap here and an equip there, which is why the completion half stayed behind. */
 	}
 }

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKSlotPanelBase.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKSlotPanelBase.cs
@@ -1,0 +1,760 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+using FishMMO.Shared;
+using FishMMO.Shared.Core;
+
+namespace FishMMO.Client
+{
+	/// <summary>
+	/// Shared behaviour for every panel that draws a character's item slots — the bag, the bank,
+	/// and the equipment sockets.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// <see cref="UITKItemGridPanel"/> already unified the bank and the inventory, and the comment
+	/// at the top of it explains why. What it did not reach was the equipment panel, which sat
+	/// beside it re-implementing eighteen identically named members: the tracker subscription and
+	/// both of its handlers, the slot-blocked test, the slot painters, the lock overlay, the
+	/// tooltip refresh and the enter/leave pair, the drag start, the container lookup and the drag
+	/// release. Same names, same jobs, two bodies.
+	/// </para>
+	/// <para>
+	/// AND THEY HAD ALREADY DRIFTED, which is the whole argument for this class rather than a
+	/// preference about tidiness. Three ways, found by reading them side by side:
+	/// </para>
+	/// <list type="bullet">
+	/// <item><description>
+	/// <c>IsSlotBlocked</c>: the grid refused a slot holding an item with no database identity yet
+	/// (<c>ID &lt;= 0</c>), because the server keeps such a slot locked until the row lands and
+	/// would refuse any request naming it. The equipment copy did not, so a socket could offer a
+	/// drag the server was certain to reject.
+	/// </description></item>
+	/// <item><description>
+	/// A slot update repainted the lock overlay in the grid and did not in the equipment panel.
+	/// </description></item>
+	/// <item><description>
+	/// Shift-click quick transfer (issue #197) existed only in the grid. See
+	/// <c>UITKEquipment.OnSlotPointerDown</c>, where that is now fixed and said out loud.
+	/// </description></item>
+	/// </list>
+	/// <para>
+	/// The first two are settled here, in the single body, in the grid's favour — it is the one
+	/// that had the reasoning written down. What is NOT settled here is anything that is genuinely
+	/// two operations wearing one name: a drop onto a bag slot is a swap or a split, a drop onto a
+	/// socket is an equip, and those speak different halves of the protocol. Those stay in the two
+	/// panels, and the click dispatch that reaches them stays with them, because hoisting a
+	/// dispatcher whose every branch is abstract buys indirection and no shared behaviour.
+	/// <c>SlotPanelSharingTests</c> is what stops that seam from drifting again.
+	/// </para>
+	/// <para>
+	/// The one thing every slot panel must keep for itself is how its slots come into existence.
+	/// The equipment sockets are authored in <c>UIEquipment.uxml</c> and found by name; the grids
+	/// build theirs in code from the container's slot count. So this class owns what a slot DOES
+	/// and never how it is made: it holds the <see cref="slotViews"/> list, and the derived panel
+	/// fills it.
+	/// </para>
+	/// </remarks>
+	public abstract class UITKSlotPanelBase : UITKCharacterControl
+	{
+		// ── What each panel must say about itself ─────────────────────────────
+
+		/// <summary>
+		/// Element and USS name prefix for this panel, without a trailing dash.
+		/// </summary>
+		/// <remarks>
+		/// "bank", "inv", "eq". Every panel-specific class name is this prefix plus a fixed
+		/// suffix, which is what lets the two USS names this class needs be derived rather than
+		/// declared three times. A panel whose markup does not follow the pattern overrides the
+		/// names below instead of bending the prefix.
+		/// </remarks>
+		protected abstract string Prefix { get; }
+
+		/// <summary>The drag and operation-tracker identity of this panel's slots.</summary>
+		protected abstract ReferenceButtonType DragType { get; }
+
+		// ── Shared UI overlay names (panels resolved by GameObject name via UIManager) ──
+
+		/// <summary>Name of the shared drag object overlay.</summary>
+		protected const string DRAG_OBJECT_NAME = "UIDragObject";
+		/// <summary>Name of the shared tooltip overlay.</summary>
+		protected const string TOOLTIP_NAME = "UITooltip";
+		/// <summary>Name of the shared transient-notice overlay.</summary>
+		protected const string TOAST_NAME = "UIToast";
+
+		// ── USS class names ───────────────────────────────────────────────────
+
+		/// <summary>USS class hiding an element.</summary>
+		protected virtual string CssHidden => Prefix + "-hidden";
+
+		/// <summary>USS class marking a slot as waiting on the server.</summary>
+		/// <remarks>
+		/// The same overlay carries two meanings — the container's own slot lock and a request this
+		/// panel is waiting on — because to the player they are one statement: this slot is busy,
+		/// do not click it. This modifier distinguishes them visually without a second element in
+		/// every slot.
+		/// </remarks>
+		protected virtual string CssLockPending => Prefix + "-slot__lock--pending";
+
+		// ── Per-slot view data ────────────────────────────────────────────────
+
+		/// <summary>Runtime view data for a single slot element.</summary>
+		protected struct SlotView
+		{
+			/// <summary>Root VisualElement of the slot.</summary>
+			public VisualElement Root;
+			/// <summary>Icon element displaying the item sprite.</summary>
+			public VisualElement Icon;
+			/// <summary>Stack-count label.</summary>
+			public Label Amount;
+			/// <summary>Lock overlay element.</summary>
+			public VisualElement Lock;
+		}
+
+		/// <summary>Slot views indexed by container slot index.</summary>
+		/// <remarks>
+		/// <para>
+		/// Filled by the derived panel, because the two sources of a slot element are not alike:
+		/// the grids create one element per container slot, the equipment panel queries ten
+		/// authored sockets out of its UXML. What both owe this list is that index <c>i</c> is
+		/// container slot <c>i</c> — for equipment that means a missing UXML element still
+		/// occupies its place as a default <see cref="SlotView"/> rather than being skipped, or
+		/// every socket after it would draw the wrong item.
+		/// </para>
+		/// <para>
+		/// A list rather than an array, and empty rather than null before the tree has been read.
+		/// The equipment panel used a null array and had to test for it in eight places; one of
+		/// those tests read <c>.Length</c> first and was an NRE on the first equip of any session
+		/// in which the player had not opened the window. An empty list fails every bounds check
+		/// the same way without a special case.
+		/// </para>
+		/// </remarks>
+		protected readonly List<SlotView> slotViews = new List<SlotView>();
+
+		/// <summary>True while this panel holds a subscription on the shared operation tracker.</summary>
+		private bool trackerSubscribed;
+
+		// ── Container access ──────────────────────────────────────────────────
+
+		/// <summary>
+		/// This panel's own container, or null when the character does not have one yet.
+		/// </summary>
+		protected IItemContainer OwnContainer => ResolveContainer(DragType);
+
+		/// <summary>
+		/// Resolves the character's container for a drag source type.
+		/// </summary>
+		/// <remarks>
+		/// Every one of these controllers derives from <see cref="IItemContainer"/> —
+		/// <see cref="IEquipmentController"/> included — which is what lets one body serve a panel
+		/// that thinks in sockets and a panel that thinks in bag slots. That was already true
+		/// before this class existed; the panels simply were not leaning on it.
+		/// </remarks>
+		protected IItemContainer ResolveContainer(ReferenceButtonType type)
+		{
+			if (Character == null)
+			{
+				return null;
+			}
+
+			switch (type)
+			{
+				case ReferenceButtonType.Inventory:
+					return Character.TryGet(out IInventoryController inventoryController) ? inventoryController : null;
+				case ReferenceButtonType.Bank:
+					return Character.TryGet(out IBankController bankController) ? bankController : null;
+				case ReferenceButtonType.Equipment:
+					return Character.TryGet(out IEquipmentController equipmentController) ? equipmentController : null;
+				default:
+					return null;
+			}
+		}
+
+		// ── UITKControl lifecycle ─────────────────────────────────────────────
+
+		/// <summary>
+		/// Joins the shared operation tracker. Derived panels extend this to register broadcasts.
+		/// </summary>
+		public override void OnClientSet()
+		{
+			SubscribeTracker();
+		}
+
+		/// <summary>
+		/// Leaves the shared operation tracker. Derived panels extend this to unregister broadcasts.
+		/// </summary>
+		public override void OnClientUnset()
+		{
+			UnsubscribeTracker();
+		}
+
+		/// <summary>
+		/// Times out item operations whose reply never arrived.
+		/// </summary>
+		/// <remarks>
+		/// The tracker is shared and self-clearing, so it does not matter that all three item
+		/// panels drive it; whichever ticks first in a frame does the work and the others find
+		/// nothing outstanding.
+		/// </remarks>
+		protected override void OnTick()
+		{
+			ItemOperationTracker.Tick();
+		}
+
+		/// <summary>
+		/// Re-applies per-open content after the visual tree has been replaced.
+		/// </summary>
+		protected override void OnAfterStarting()
+		{
+			base.OnAfterStarting();
+			ApplyPerOpenContent();
+		}
+
+		/// <summary>
+		/// Re-applies per-open content on every show, including the very first one.
+		/// </summary>
+		/// <remarks>
+		/// THE CONTRACT, and both panels had written it out separately. Enabling the document
+		/// re-clones the UXML, so anything written before <c>Show()</c> is discarded.
+		/// <c>OnAfterStarting</c> covers later opens, but on the first ever open <c>hasStarted</c>
+		/// is still false and <c>ReinitializeIfTreeReplaced</c> returns before calling it — and a
+		/// panel opened by a broadcast has its first open triggered by something the player did
+		/// rather than at startup. Both hooks do the work, and both are idempotent.
+		/// </remarks>
+		protected override void OnAfterShow()
+		{
+			ApplyPerOpenContent();
+		}
+
+		/// <summary>
+		/// Re-reads everything this panel shows from the character, without rebuilding the tree.
+		/// </summary>
+		/// <remarks>
+		/// Abstract rather than shared, deliberately. The two bodies do not merely differ in
+		/// content, they differ in ORDER, and the order is the part that was hard won: the grid
+		/// repaints its currency chip ahead of the container null check because a character with
+		/// no container still has money, and the equipment panel clears <c>previewFramed</c> after
+		/// the slots so the camera re-frames against the silhouette it can now see. Averaging two
+		/// carefully sequenced methods into one is how a refactor quietly undoes both.
+		/// </remarks>
+		protected abstract void ApplyPerOpenContent();
+
+		/// <summary>
+		/// Hides the panel and abandons anything it had in flight.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Closing is not a neutral act: walking out of range of the interactable that opened the
+		/// panel is one of the ways the server refuses an operation, so a slot left marked as
+		/// waiting after the panel closes has a very good chance of never being answered.
+		/// </para>
+		/// <para>
+		/// <c>Hide(bool)</c> and not <c>Hide()</c>: <c>Hide()</c> delegates here, but Escape
+		/// (<c>UIManager.CloseNext</c>) and quit-to-login (<c>Hide(false)</c>) both arrive at this
+		/// overload directly.
+		/// </para>
+		/// </remarks>
+		/// <param name="overrideIsAlwaysOpen">When true, the call is a no-op.</param>
+		public override void Hide(bool overrideIsAlwaysOpen)
+		{
+			base.Hide(overrideIsAlwaysOpen);
+
+			if (Visible)
+			{
+				return;
+			}
+
+			OnPanelHidden();
+			ReleaseAndClearDrag();
+		}
+
+		/// <summary>
+		/// Lets a panel release what only it holds once it has actually gone off screen.
+		/// </summary>
+		/// <remarks>
+		/// Runs before the drag is abandoned, which is the order the equipment panel already used:
+		/// it hands its preview camera back here, and the cost of that camera is paid every frame
+		/// whether or not anyone is looking at it.
+		/// </remarks>
+		protected virtual void OnPanelHidden()
+		{
+		}
+
+		/// <summary>
+		/// Drops every subscription this class holds when the control is destroyed.
+		/// </summary>
+		public override void OnDestroying()
+		{
+			UnsubscribeTracker();
+			ReleaseAndClearDrag();
+			OnPanelDestroying();
+			base.OnDestroying();
+		}
+
+		/// <summary>
+		/// Lets a panel release what only it holds, after the shared subscriptions are gone.
+		/// </summary>
+		protected virtual void OnPanelDestroying()
+		{
+		}
+
+		// ── Shared operation tracker ──────────────────────────────────────────
+
+		/// <summary>
+		/// Joins the shared item-operation tracker, once.
+		/// </summary>
+		/// <remarks>
+		/// <c>-=</c> before <c>+=</c> on a static event. <c>OnClientSet</c> can run more than once
+		/// in a session (quit to login does <c>SetClient(null)</c> then <c>SetClient(client)</c>),
+		/// and a static event outlives this component, so a missed unsubscribe is a handler
+		/// running forever on a destroyed panel.
+		/// </remarks>
+		protected void SubscribeTracker()
+		{
+			if (trackerSubscribed)
+			{
+				return;
+			}
+			trackerSubscribed = true;
+
+			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
+			ItemOperationTracker.SlotPendingChanged += OnTrackerSlotPendingChanged;
+			ItemOperationTracker.ResyncRequested -= OnTrackerResyncRequested;
+			ItemOperationTracker.ResyncRequested += OnTrackerResyncRequested;
+			ItemOperationTracker.Attach();
+		}
+
+		/// <summary>
+		/// Leaves the shared item-operation tracker, once.
+		/// </summary>
+		protected void UnsubscribeTracker()
+		{
+			if (!trackerSubscribed)
+			{
+				return;
+			}
+			trackerSubscribed = false;
+
+			ItemOperationTracker.SlotPendingChanged -= OnTrackerSlotPendingChanged;
+			ItemOperationTracker.ResyncRequested -= OnTrackerResyncRequested;
+			ItemOperationTracker.Detach();
+		}
+
+		/// <summary>
+		/// Repaints a slot when it starts or stops waiting on the server.
+		/// </summary>
+		private void OnTrackerSlotPendingChanged(ReferenceButtonType type, int slot, bool pending)
+		{
+			if (type != DragType || slot < 0 || slot >= slotViews.Count)
+			{
+				return;
+			}
+
+			ApplySlotLockVisual(slot, IsSlotBlocked(slot));
+		}
+
+		/// <summary>
+		/// Re-renders every slot from the replicated container.
+		/// </summary>
+		/// <remarks>
+		/// Raised when the server said the outcome of an operation is unknown, which is not the
+		/// same as saying it failed — see <c>ItemOperationFailureReason.ServerBusy</c>. Nothing is
+		/// reverted; the container is simply read again.
+		/// </remarks>
+		private void OnTrackerResyncRequested(ReferenceButtonType type)
+		{
+			if (type != DragType)
+			{
+				return;
+			}
+
+			IItemContainer container = OwnContainer;
+			if (container != null)
+			{
+				RefreshAllSlots(container);
+			}
+		}
+
+		// ── Slot visuals ──────────────────────────────────────────────────────
+
+		/// <summary>
+		/// Repaints every slot's item and lock state from the container.
+		/// </summary>
+		/// <remarks>
+		/// Clamped to the container as well as to the view, because the two can disagree: a grid
+		/// built before the character had a container is a grid of zero slots, and one built
+		/// against a tree that has since been replaced still reports a length. A slot with no root
+		/// element is skipped rather than treated as broken — the equipment panel deliberately
+		/// keeps a placeholder for a socket its UXML does not declare, so that the indices after
+		/// it still line up with the container.
+		/// </remarks>
+		protected void RefreshAllSlots(IItemContainer container)
+		{
+			if (container == null)
+			{
+				return;
+			}
+
+			int slotCount = Mathf.Min(slotViews.Count, container.Items.Count);
+			for (int i = 0; i < slotCount; ++i)
+			{
+				if (slotViews[i].Root == null)
+				{
+					continue;
+				}
+
+				if (container.TryGetItem(i, out Item item))
+				{
+					SetSlotItem(i, item);
+				}
+				else
+				{
+					ClearSlot(i);
+				}
+
+				ApplySlotLockVisual(i, IsSlotBlocked(i));
+			}
+
+			OnSlotContentChanged();
+		}
+
+		/// <summary>
+		/// Told whenever what a slot holds has been repainted.
+		/// </summary>
+		/// <remarks>
+		/// The grids recompute their capacity readout from here. The hook exists rather than a
+		/// call to a capacity method because the equipment panel has no capacity: its ten sockets
+		/// are not a resource that fills up, and "8 / 10 sockets used" is not a fact a player
+		/// needs. That asymmetry was the only real difference between the two <c>SetSlotItem</c>
+		/// bodies, so it is the only thing left configurable.
+		/// </remarks>
+		protected virtual void OnSlotContentChanged()
+		{
+		}
+
+		/// <summary>
+		/// Populates a slot's icon and stack-count badge from an item.
+		/// </summary>
+		protected void SetSlotItem(int slotIndex, Item item)
+		{
+			if (item == null || slotIndex < 0 || slotIndex >= slotViews.Count)
+			{
+				return;
+			}
+
+			SlotView view = slotViews[slotIndex];
+			if (view.Root == null)
+			{
+				return;
+			}
+
+			OnSlotContentChanged();
+
+			// Placeholder when the template has no icon: an occupied slot must look occupied.
+			UITKItemIcon.Apply(view.Icon, item.Template != null ? item.Template.Icon : null);
+
+			if (view.Amount != null)
+			{
+				if (item.IsStackable && item.Stackable != null)
+				{
+					view.Amount.text = item.Stackable.Amount.ToString();
+					view.Amount.RemoveFromClassList(CssHidden);
+				}
+				else
+				{
+					view.Amount.text = "";
+					view.Amount.AddToClassList(CssHidden);
+				}
+			}
+
+			RefreshSlotTooltip(slotIndex, item);
+		}
+
+		/// <summary>
+		/// Clears a slot's icon and hides its stack-count badge.
+		/// </summary>
+		protected void ClearSlot(int slotIndex)
+		{
+			if (slotIndex < 0 || slotIndex >= slotViews.Count)
+			{
+				return;
+			}
+
+			SlotView view = slotViews[slotIndex];
+			if (view.Root == null)
+			{
+				return;
+			}
+
+			OnSlotContentChanged();
+
+			UITKItemIcon.Clear(view.Icon);
+			if (view.Amount != null)
+			{
+				view.Amount.text = "";
+				view.Amount.AddToClassList(CssHidden);
+			}
+
+			RefreshSlotTooltip(slotIndex, null);
+		}
+
+		/// <summary>
+		/// Keeps the tooltip for a slot in step with what the slot now shows.
+		/// </summary>
+		/// <remarks>
+		/// Called from the two methods that paint a slot, so every path that changes one — a
+		/// replicate arriving, a resync, a rebuild, a panel opening — keeps the tooltip honest
+		/// without having to remember to. The tooltip was opened from the item the pointer found
+		/// on the way in and nothing re-read it, so a swap under a stationary cursor left it
+		/// describing the item that used to be in the slot the player is looking at. Issue #280,
+		/// which had to be fixed twice — once in the grids and once in the sockets — and is now
+		/// one place.
+		/// <para>
+		/// <see cref="UITKTooltip.RefreshFor"/> does nothing unless the pointer is over THIS slot,
+		/// which is what makes the per-slot call safe from the refresh loop above.
+		/// </para>
+		/// </remarks>
+		/// <param name="slotIndex">The slot that was just painted.</param>
+		/// <param name="item">What it now holds, or null when it now holds nothing.</param>
+		private void RefreshSlotTooltip(int slotIndex, Item item)
+		{
+			if (slotIndex < 0 || slotIndex >= slotViews.Count)
+			{
+				return;
+			}
+
+			VisualElement owner = slotViews[slotIndex].Root;
+			if (owner == null)
+			{
+				return;
+			}
+
+			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
+			{
+				tooltip.RefreshFor(owner, item);
+			}
+		}
+
+		/// <summary>
+		/// Shows or hides the lock overlay on a slot.
+		/// </summary>
+		protected void ApplySlotLockVisual(int slotIndex, bool isLocked)
+		{
+			if (slotIndex < 0 || slotIndex >= slotViews.Count)
+			{
+				return;
+			}
+
+			VisualElement lockEl = slotViews[slotIndex].Lock;
+			if (lockEl == null)
+			{
+				return;
+			}
+
+			lockEl.EnableInClassList(CssHidden, !isLocked);
+			lockEl.EnableInClassList(CssLockPending,
+				isLocked && ItemOperationTracker.IsPending(DragType, slotIndex));
+		}
+
+		/// <summary>
+		/// Reports whether a slot is unavailable for a new request, for any reason.
+		/// </summary>
+		/// <remarks>
+		/// /* DELIBERATE BEHAVIOUR CHANGE, equipment panel. */ The two copies of this test had
+		/// drifted: the grid refused a slot whose item has no database identity yet, and the
+		/// equipment copy stopped at the container's own lock. The grid is right and the socket
+		/// was wrong, so the socket now follows it. An item with <c>ID &lt;= 0</c> is one the
+		/// database has not written yet; the server keeps its slot locked until the row lands and
+		/// re-sends the slot with the assigned id, so until then every request naming it would be
+		/// refused. Showing it as waiting costs the player nothing and saves a round trip that
+		/// ends in a refusal they did not ask for. The practical effect on sockets is small —
+		/// equipped items have identities — which is exactly why the divergence survived unnoticed.
+		/// </remarks>
+		protected bool IsSlotBlocked(int slotIndex)
+		{
+			if (ItemOperationTracker.IsPending(DragType, slotIndex))
+			{
+				return true;
+			}
+
+			IItemContainer container = OwnContainer;
+			if (container == null)
+			{
+				return false;
+			}
+			if (container.IsSlotLocked(slotIndex))
+			{
+				return true;
+			}
+
+			return container.TryGetItem(slotIndex, out Item item) && item != null && item.ID <= 0;
+		}
+
+		/// <summary>
+		/// Applies a slot the server has sent back: releases its pending mark, repaints it, and
+		/// tells any drag that was started from it.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// The slot arriving from the server IS the acknowledgement of whatever this panel asked
+		/// for, so the pending mark is released here rather than on a separate reply message. What
+		/// the player is waiting to see is the slot.
+		/// </para>
+		/// <para>
+		/// /* DELIBERATE BEHAVIOUR CHANGE, equipment panel. */ The grid repainted the lock overlay
+		/// after applying an update and the equipment copy did not. The item itself can be the
+		/// reason a slot is blocked (no identity yet), and the slot arriving with its identity is
+		/// what unblocks it, so the repaint belongs on every path. It is idempotent — the release
+		/// above already raises <c>SlotPendingChanged</c>, which repaints the same overlay — so
+		/// the socket gains correctness in the one case it was missing and nothing else.
+		/// </para>
+		/// </remarks>
+		/// <param name="container">The container the update came from.</param>
+		/// <param name="item">What the slot now holds, as the event reported it.</param>
+		/// <param name="slotIndex">The slot that changed.</param>
+		protected void ApplySlotUpdate(IItemContainer container, Item item, int slotIndex)
+		{
+			if (container == null || slotIndex < 0)
+			{
+				return;
+			}
+
+			/* An index the view does not have means the view is smaller than the container — built
+			 * before the container was sized, or against a tree that has been replaced. Rebuilding
+			 * is the recovery where a panel can rebuild; dropping the update silently is what left
+			 * a grid showing fewer slots than the character actually has. */
+			if (slotIndex >= slotViews.Count &&
+				(!TryGrowSlotsFor(slotIndex) || slotIndex >= slotViews.Count))
+			{
+				return;
+			}
+
+			ItemOperationTracker.Release(DragType, slotIndex);
+
+			OnSlotUpdateReceived(slotIndex);
+
+			bool empty = container.IsSlotEmpty(slotIndex);
+			if (!empty)
+			{
+				SetSlotItem(slotIndex, item);
+			}
+			else
+			{
+				ClearSlot(slotIndex);
+			}
+
+			ApplySlotLockVisual(slotIndex, IsSlotBlocked(slotIndex));
+
+			// A drag started from this slot no longer refers to what it was started from.
+			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject))
+			{
+				dragObject.NotifySlotChanged(DragType, slotIndex, empty ? null : item);
+			}
+		}
+
+		/// <summary>
+		/// Asked to make room for a slot index the view does not have. Returns true if it grew.
+		/// </summary>
+		/// <remarks>
+		/// False by default, because not every panel can: the equipment sockets are authored in
+		/// UXML and there is no eleventh one to create, so an out-of-range socket index is a bug
+		/// upstream rather than a view to repair. The grids rebuild from the container's count.
+		/// </remarks>
+		protected virtual bool TryGrowSlotsFor(int slotIndex)
+		{
+			return false;
+		}
+
+		/// <summary>
+		/// Told that a slot update has been accepted, before the slot is repainted.
+		/// </summary>
+		/// <remarks>
+		/// The equipment panel invalidates its preview framing here: equipment changes the
+		/// silhouette, a two-handed weapon reaches further than a dagger, and a frame sized before
+		/// it existed crops it.
+		/// </remarks>
+		protected virtual void OnSlotUpdateReceived(int slotIndex)
+		{
+		}
+
+		// ── Slot interaction ──────────────────────────────────────────────────
+
+		/// <summary>
+		/// Shows the item tooltip when the pointer enters a slot that contains an item.
+		/// </summary>
+		/// <param name="slotIndex">The slot the pointer entered.</param>
+		/// <param name="owner">The slot element, so the tooltip can close itself if it is rebuilt.</param>
+		protected void OnSlotPointerEnter(int slotIndex, VisualElement owner)
+		{
+			IItemContainer container = OwnContainer;
+			if (container == null || !container.TryGetItem(slotIndex, out Item item))
+			{
+				return;
+			}
+
+			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
+			{
+				// With an owner, so the tooltip closes itself if this slot is rebuilt under it.
+				tooltip.Open(item, owner);
+			}
+		}
+
+		/// <summary>
+		/// Hides the item tooltip when the pointer leaves a slot.
+		/// </summary>
+		protected void OnSlotPointerLeave(VisualElement owner)
+		{
+			if (UIManager.TryGetTK(TOOLTIP_NAME, out UITKTooltip tooltip))
+			{
+				// HideFor, so a stale leave cannot close a tooltip another slot has since opened.
+				tooltip.HideFor(owner);
+			}
+		}
+
+		/// <summary>
+		/// Starts a drag from an occupied slot.
+		/// </summary>
+		/// <remarks>
+		/// The refusal is logged, not just the success. A drag that will not start looks identical
+		/// to a click the game did not receive, and the three reasons it can refuse — the slot is
+		/// waiting, the slot is empty, the item is gone — are indistinguishable from the outside.
+		/// </remarks>
+		protected void BeginDragFromSlot(UITKDragObject dragObject, IItemContainer container, int slotIndex)
+		{
+			Item item = null;
+			bool blocked = IsSlotBlocked(slotIndex);
+			bool gotItem = container != null && container.TryGetItem(slotIndex, out item);
+
+			if (blocked || !gotItem || item == null)
+			{
+				FishMMO.Logging.Log.Debug(GetType().Name,
+					$"BeginDrag REFUSED slot {slotIndex}: blocked={blocked} " +
+					$"(pending={ItemOperationTracker.IsPending(DragType, slotIndex)}) " +
+					$"gotItem={gotItem} itemNull={item == null}.");
+				return;
+			}
+
+			// A missing icon must not prevent the item being moved.
+			Sprite sprite = item.Template != null ? item.Template.Icon : null;
+
+			/* Carry the item, not just the slot number: the slot index stops being true the moment
+			 * anything else writes to that slot, and the drop would then move the wrong item. */
+			dragObject.SetItemReference(sprite, slotIndex, DragType, item);
+		}
+
+		/// <summary>
+		/// Abandons this panel's in-flight operations and any drag that started here.
+		/// </summary>
+		protected void ReleaseAndClearDrag()
+		{
+			ItemOperationTracker.ReleaseAll(DragType);
+
+			if (UIManager.TryGetTK(DRAG_OBJECT_NAME, out UITKDragObject dragObject) &&
+				dragObject.IsDragging &&
+				dragObject.Type == DragType)
+			{
+				dragObject.Clear();
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKSlotPanelBase.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/ItemContainers/UITKSlotPanelBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adcddf2350c14629a464e0af904b7056
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Loot/UITKLoot.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Loot/UITKLoot.cs
@@ -99,10 +99,20 @@ namespace FishMMO.Client
 		/// Seconds a request may go unanswered before its row is made clickable again.
 		/// </summary>
 		/// <remarks>
+		/// <para>
 		/// The server replies to every take, successful or not, so this should never fire. It
 		/// exists because the alternative failure mode is unrecoverable: a reply lost to a dropped
 		/// connection would leave the row waiting forever, and the player cannot clear it without
 		/// closing a window whose corpse is about to decay.
+		/// </para>
+		/// <para>
+		/// Passed explicitly to every <see cref="ItemSlotPendingSet.TryBegin"/> and
+		/// <see cref="PendingReplyGuard.Begin"/> call below rather than letting the shared types
+		/// apply their own defaults, which are longer — 8s for an item operation, 30s for a login
+		/// round trip. A corpse is a shared pile that another looter is emptying while this panel
+		/// watches, so a row locked for eight seconds after a lost reply is a row the player
+		/// watches somebody else take.
+		/// </para>
 		/// </remarks>
 		private const float PENDING_TIMEOUT_SECONDS = 5f;
 
@@ -140,18 +150,46 @@ namespace FishMMO.Client
 		/// <summary>Rendered rows, one per non-empty corpse slot.</summary>
 		private readonly List<RowView> rowViews = new List<RowView>();
 
+		/*  Both of these used to be hand-rolled here: a Dictionary<int, float> of send times and a
+		 *  float sentinel, swept against Time.time by the tick below. That was a live bug, not just
+		 *  duplication. Time.time is scaled by Time.timeScale, so anything that pauses or slows the
+		 *  game — a settings menu, a death screen, a cutscene — stops this panel's watchdog dead
+		 *  while the network keeps running. A take whose reply is lost during a pause left its row
+		 *  locked with nothing able to release it, and at timeScale 0 the row stayed locked for the
+		 *  rest of the corpse's life however long the player waited.
+		 *
+		 *  ItemSlotPendingSet and PendingReplyGuard both measure in Time.unscaledTime, which is the
+		 *  only correct clock for a deadline on something the server is doing: the server does not
+		 *  slow down when this client opens a menu. Adopting them fixes the clock and removes the
+		 *  second copy of the sweep in one move — see PendingSlotWatchdogTests for the guard that
+		 *  keeps a third copy from appearing. */
+
 		/// <summary>
-		/// Corpse slots with a take in flight, mapped to the time the request was sent.
+		/// Corpse slots with a take in flight.
 		/// </summary>
 		/// <remarks>
 		/// Keyed by slot rather than by row index because rows are rebuilt whenever the server
 		/// re-sends the contents, and a row's position moves as other looters empty slots above
 		/// it. The slot index is the only identifier that survives a rebuild.
 		/// </remarks>
-		private readonly Dictionary<int, float> pendingSlots = new Dictionary<int, float>();
+		private readonly ItemSlotPendingSet pendingSlots = new ItemSlotPendingSet();
 
-		/// <summary>True while a currency or take-all request is in flight.</summary>
-		private float pendingBulkTime = -1f;
+		/// <summary>
+		/// Watchdog for a currency or take-all request, which are not per-slot.
+		/// </summary>
+		/// <remarks>
+		/// A single <see cref="PendingReplyGuard"/> rather than a slot in
+		/// <see cref="pendingSlots"/>, because that is exactly what this is: one wait, not a set of
+		/// them. Currency and take-all have no slot index — the server answers both with
+		/// <see cref="NON_ITEM_SLOT"/> — and giving them a fake key in a map of corpse slots would
+		/// make every reader of that map responsible for remembering which key is not a slot.
+		/// <see cref="ItemSlotPendingSet"/> is the same guard keyed by slot, so this shares its
+		/// clock and its self-clearing timeout without pretending to be per-slot state.
+		/// </remarks>
+		private readonly PendingReplyGuard bulkPending = new PendingReplyGuard();
+
+		/// <summary>Reused by the prune below so a corpse refresh allocates nothing.</summary>
+		private readonly List<int> pendingScratch = new List<int>();
 
 		/// <summary>The container runtime rows are appended to.</summary>
 		private VisualElement listRoot;
@@ -327,8 +365,8 @@ namespace FishMMO.Client
 					}, Channel.Reliable);
 				}
 
-				pendingSlots.Clear();
-				pendingBulkTime = -1f;
+				pendingSlots.ReleaseAll();
+				bulkPending.Clear();
 				SetStatus(string.Empty);
 			}
 
@@ -365,11 +403,11 @@ namespace FishMMO.Client
 
 			if (msg.Slot == NON_ITEM_SLOT)
 			{
-				pendingBulkTime = -1f;
+				bulkPending.Clear();
 			}
 			else
 			{
-				pendingSlots.Remove(msg.Slot);
+				pendingSlots.Release(msg.Slot);
 			}
 
 			SetStatus(msg.Success ? string.Empty : DescribeFailure(msg.Reason));
@@ -415,13 +453,14 @@ namespace FishMMO.Client
 			}
 
 			// One request per slot at a time. A shared pile makes double-clicking a row the
-			// natural reaction to it not disappearing immediately.
-			if (pendingSlots.ContainsKey(slot))
+			// natural reaction to it not disappearing immediately. TryBegin refusing rather than
+			// re-arming is what lets a genuinely stuck row time out: re-arming would push the
+			// deadline out on every impatient click.
+			if (!pendingSlots.TryBegin(slot, PENDING_TIMEOUT_SECONDS))
 			{
 				return;
 			}
 
-			pendingSlots[slot] = Time.time;
 			ApplyPendingVisuals();
 
 			Client.Broadcast(new CorpseLootTakeItemBroadcast()
@@ -436,12 +475,12 @@ namespace FishMMO.Client
 		/// </summary>
 		private void RequestTakeCurrency()
 		{
-			if (corpseID == 0 || Client == null || corpseCurrency < 1 || pendingBulkTime >= 0f)
+			if (corpseID == 0 || Client == null || corpseCurrency < 1 || bulkPending.IsPending)
 			{
 				return;
 			}
 
-			pendingBulkTime = Time.time;
+			bulkPending.Begin(PENDING_TIMEOUT_SECONDS);
 			ApplyPendingVisuals();
 
 			Client.Broadcast(new CorpseLootTakeCurrencyBroadcast()
@@ -455,12 +494,12 @@ namespace FishMMO.Client
 		/// </summary>
 		private void RequestTakeAll()
 		{
-			if (corpseID == 0 || Client == null || pendingBulkTime >= 0f)
+			if (corpseID == 0 || Client == null || bulkPending.IsPending)
 			{
 				return;
 			}
 
-			pendingBulkTime = Time.time;
+			bulkPending.Begin(PENDING_TIMEOUT_SECONDS);
 			ApplyPendingVisuals();
 
 			Client.Broadcast(new CorpseLootTakeAllBroadcast()
@@ -472,38 +511,18 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Re-enables requests whose reply never arrived.
 		/// </summary>
+		/// <remarks>
+		/// Both watchdogs are self-clearing and report a timeout exactly once, so this can be driven
+		/// straight from the tick without tracking anything itself — and a late reply arriving after
+		/// the release is still handled normally, because releasing only re-enables the row.
+		/// </remarks>
 		private void ReleaseTimedOutRequests()
 		{
-			bool changed = false;
-			float now = Time.time;
+			bool changed = bulkPending.HasExpired();
 
-			if (pendingBulkTime >= 0f && now - pendingBulkTime > PENDING_TIMEOUT_SECONDS)
+			if (pendingSlots.HasAnyPending && pendingSlots.CollectExpired().Count > 0)
 			{
-				pendingBulkTime = -1f;
 				changed = true;
-			}
-
-			if (pendingSlots.Count > 0)
-			{
-				// Collected before removing: the dictionary cannot be modified while enumerated.
-				List<int> expired = null;
-				foreach (KeyValuePair<int, float> kvp in pendingSlots)
-				{
-					if (now - kvp.Value > PENDING_TIMEOUT_SECONDS)
-					{
-						expired ??= new List<int>();
-						expired.Add(kvp.Key);
-					}
-				}
-
-				if (expired != null)
-				{
-					for (int i = 0; i < expired.Count; ++i)
-					{
-						pendingSlots.Remove(expired[i]);
-					}
-					changed = true;
-				}
 			}
 
 			if (changed && Visible)
@@ -696,7 +715,7 @@ namespace FishMMO.Client
 		/// </summary>
 		private void ApplyPendingVisuals()
 		{
-			bool bulkPending = pendingBulkTime >= 0f;
+			bool bulkWaiting = bulkPending.IsPending;
 
 			for (int i = 0; i < rowViews.Count; ++i)
 			{
@@ -707,7 +726,7 @@ namespace FishMMO.Client
 				}
 
 				// A take-all covers every row, so all of them wait on it.
-				bool waiting = bulkPending || pendingSlots.ContainsKey(view.Slot);
+				bool waiting = bulkWaiting || pendingSlots.IsPending(view.Slot);
 				if (waiting)
 				{
 					view.Pending.RemoveFromClassList(CSS_HIDDEN);
@@ -718,9 +737,9 @@ namespace FishMMO.Client
 				}
 			}
 
-			if (takeAllButton != null && (bulkPending || rowViews.Count > 0 || corpseCurrency > 0))
+			if (takeAllButton != null && (bulkWaiting || rowViews.Count > 0 || corpseCurrency > 0))
 			{
-				takeAllButton.SetEnabled(!bulkPending && (rowViews.Count > 0 || corpseCurrency > 0));
+				takeAllButton.SetEnabled(!bulkWaiting && (rowViews.Count > 0 || corpseCurrency > 0));
 			}
 		}
 
@@ -729,18 +748,24 @@ namespace FishMMO.Client
 		/// </summary>
 		private void PrunePendingSlots()
 		{
-			if (pendingSlots.Count < 1)
+			if (!pendingSlots.HasAnyPending)
 			{
 				return;
 			}
 
-			List<int> stale = null;
-			foreach (KeyValuePair<int, float> kvp in pendingSlots)
+			/* Enumerated rather than asked slot by slot, because the slots worth releasing are the
+			 * ones this panel no longer has — there is nothing left on screen to ask about. */
+			pendingScratch.Clear();
+			pendingSlots.CollectPending(pendingScratch);
+
+			for (int i = 0; i < pendingScratch.Count; ++i)
 			{
+				int slot = pendingScratch[i];
+
 				bool stillPresent = false;
-				for (int i = 0; i < slotData.Length; ++i)
+				for (int j = 0; j < slotData.Length; ++j)
 				{
-					if (slotData[i].Slot == kvp.Key)
+					if (slotData[j].Slot == slot)
 					{
 						stillPresent = true;
 						break;
@@ -749,19 +774,8 @@ namespace FishMMO.Client
 
 				if (!stillPresent)
 				{
-					stale ??= new List<int>();
-					stale.Add(kvp.Key);
+					pendingSlots.Release(slot);
 				}
-			}
-
-			if (stale == null)
-			{
-				return;
-			}
-
-			for (int i = 0; i < stale.Count; ++i)
-			{
-				pendingSlots.Remove(stale[i]);
 			}
 		}
 
@@ -774,8 +788,8 @@ namespace FishMMO.Client
 			corpseName = string.Empty;
 			corpseCurrency = 0;
 			slotData = new CorpseLootSlotData[0];
-			pendingSlots.Clear();
-			pendingBulkTime = -1f;
+			pendingSlots.ReleaseAll();
+			bulkPending.Clear();
 			SetStatus(string.Empty);
 			DestroyRows();
 		}

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Merchant/UITKMerchant.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Merchant/UITKMerchant.cs
@@ -1076,9 +1076,21 @@ namespace FishMMO.Client
 		private void SetQuantity(int quantity)
 		{
 			int clamped = UnityEngine.Mathf.Clamp(quantity, 1, selectedMaxQuantity);
-			if (quantityField != null && quantityField.value != clamped)
+			if (quantityField != null)
 			{
-				// SetValueWithoutNotify: the change callback re-enters this method otherwise.
+				/* Written every time, not only when the number changes.
+				 *
+				 * An IntegerField's visible text is produced BY the write. Guarding the write on
+				 * `value != clamped` meant the common case never wrote at all: the UXML authors the
+				 * field as value="1", so the first SetQuantity(1) after a selection found them equal,
+				 * skipped the assignment, and left the inner text element empty. The field was live and
+				 * editable the whole time and simply displayed nothing, which reads as a dead control.
+				 *
+				 * It also recurs after any tree rebuild — hiding the panel disposes the visual tree, so
+				 * the re-queried field is back at the authored 1 with no text — which is why it looked
+				 * intermittent rather than simply broken.
+				 *
+				 * SetValueWithoutNotify rather than value: the change callback re-enters this method. */
 				quantityField.SetValueWithoutNotify(clamped);
 			}
 			RefreshQuantityControls();

--- a/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Party/UITKParty.cs
+++ b/FishMMO-Unity/Assets/Scripts/Client/GUI/World/Party/UITKParty.cs
@@ -969,6 +969,14 @@ namespace FishMMO.Client
 		/// <summary>
 		/// Invites the hovered or pinned target, or prompts for a name, to the party.
 		/// </summary>
+		/// <remarks>
+		/// Target first, name second. Both halves live on <see cref="UITKControl"/> now — see
+		/// <see cref="UITKControl.TryResolveTargetCharacter"/> and
+		/// <see cref="UITKControl.PromptForCharacterID"/> — because this method and the guild
+		/// panel's were the same code twice, comment included, and the friend list held a third
+		/// copy of the name half. What stays here is the party-specific part: the guard, the
+		/// broadcast, and the one sentence that names the party.
+		/// </remarks>
 		public void OnButtonInviteToParty()
 		{
 			if (Character != null &&
@@ -976,56 +984,24 @@ namespace FishMMO.Client
 				partyController.ID > 0 &&
 				Client.NetworkManager.IsClientStarted)
 			{
-				if (Character.TryGet(out ITargetController targetController))
+				if (TryResolveTargetCharacter(Character, out IPlayerCharacter targetCharacter))
 				{
-					/* The hovered character first, then the pinned one. The pointer is on this
-					 * button when it fires, so the hover target is usually empty — and the
-					 * pinned card is exactly the player's way of saying "this one" ahead of time. */
-					Transform target = targetController.Current.Target != null
-						? targetController.Current.Target
-						: targetController.PinnedTarget;
-					IPlayerCharacter targetCharacter = target != null ? target.GetComponent<IPlayerCharacter>() : null;
-					if (targetCharacter != null)
+					Client.Broadcast(new PartyInviteBroadcast()
 					{
-						Client.Broadcast(new PartyInviteBroadcast()
-						{
-							TargetCharacterID = targetCharacter.ID,
-						}, Channel.Reliable);
+						TargetCharacterID = targetCharacter.ID,
+					}, Channel.Reliable);
 
-						return;
-					}
+					return;
 				}
 
-				if (UIManager.TryGetTK("UIDialogInputBox", out UITKDialogInputBox tooltip))
-				{
-					tooltip.Open("Please type the name of the person you wish to invite.", (s) =>
+				PromptForCharacterID(
+					"Please type the name of the person you wish to invite.",
+					() => Character,
+					"You can't invite yourself to the party.",
+					(id) => Client.Broadcast(new PartyInviteBroadcast()
 					{
-						if (Authentication.IsAllowedCharacterName(s))
-						{
-							ClientNamingSystem.GetCharacterID(s, (id) =>
-							{
-								if (id != 0)
-								{
-									if (Character != null && Character.ID != id)
-									{
-										Client.Broadcast(new PartyInviteBroadcast()
-										{
-											TargetCharacterID = id,
-										}, Channel.Reliable);
-									}
-									else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-									{
-										chat.InstantiateChatMessage(ChatChannel.System, "", "You can't invite yourself to the party.");
-									}
-								}
-								else if (UIManager.TryGetTK("UIChat", out UITKChat chat))
-								{
-									chat.InstantiateChatMessage(ChatChannel.System, "", "A person with that name could not be found.");
-								}
-							});
-						}
-					}, null);
-				}
+						TargetCharacterID = id,
+					}, Channel.Reliable));
 			}
 		}
 

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.PlayerRequests.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.PlayerRequests.cs
@@ -1,0 +1,172 @@
+using FishNet.Connection;
+using FishMMO.Shared.Core;
+
+namespace FishMMO.Server.Implementation
+{
+	/// <summary>
+	/// Whether a player request passes through the character-state gate before the handler runs.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// An enum rather than a <c>bool</c>, because the opt-out is the dangerous half and a bare
+	/// <c>false</c> at a call site carries no reason with it. <c>SkipCanAct</c> has to be typed out,
+	/// which is the point: it is the spelling a reviewer can grep for, and the one that reads wrong
+	/// on a handler that mutates game state.
+	/// </para>
+	/// </remarks>
+	public enum PlayerRequestGate
+	{
+		/// <summary>
+		/// Refuse the request unless <see cref="CharacterStateValidation.CanAct"/> passes. The
+		/// default, and correct for anything that changes game state.
+		/// </summary>
+		RequireCanAct = 0,
+
+		/// <summary>
+		/// Resolve the character but do not ask whether it may act.
+		/// </summary>
+		/// <remarks>
+		/// Only for requests that are not themselves an action — joining a queue, asking the server
+		/// what it already knows — AND where the action the request eventually leads to is gated
+		/// separately. A handler that reaches for this needs a comment saying which later gate
+		/// covers it; see <c>OnServerGroupFinderQueueBroadcastReceived</c> and
+		/// <c>TryResolveArenaBoard</c>, both of which lead to a transfer that
+		/// <c>HandleMatchedEntry</c> gates on <see cref="CharacterStateValidation.CanActOrMove"/>.
+		/// </remarks>
+		SkipCanAct = 1,
+	}
+
+	/// <summary>
+	/// The acting player behind one client request, resolved once at the top of a broadcast handler.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// A struct rather than a bare <c>out IPlayerCharacter</c> so that what the preamble produces can
+	/// grow without touching every call site again. The whole reason this type exists is that the
+	/// preamble HAS grown, repeatedly, and each growth spurt was pasted: the connection check, then
+	/// the first-object check, then <c>CanAct</c>, then a controller lookup. Thirty-odd handlers
+	/// carried private copies of the sequence and the copies had already drifted apart in which
+	/// checks they ran and in what order.
+	/// </para>
+	/// <para>
+	/// Deliberately NOT carrying the ingress guard key. The guard lives in per-system runtime data
+	/// (<c>IGuildSystemRuntimeData</c>, <c>IInteractableSystemRuntimeData</c>, one per system), is
+	/// keyed by a per-system operation enum, and its debounce interval is a serialized field on the
+	/// system asset — so acquiring it here would mean passing three system-specific things through a
+	/// base-class method. More to the point, a REFUSED guard is answered differently by almost every
+	/// handler: some return in silence, some send a throttle reason, one re-sends the whole hotkey
+	/// bar so the client stops believing its own optimistic edit. Folding that into the shared
+	/// preamble is a separate change; this one moves only the part that is genuinely identical.
+	/// </para>
+	/// </remarks>
+	public readonly struct PlayerRequestContext
+	{
+		/// <summary>The connection the request arrived on. Never null when <see cref="IsValid"/>.</summary>
+		public readonly NetworkConnection Connection;
+
+		/// <summary>The acting player character. Never null when <see cref="IsValid"/>.</summary>
+		public readonly IPlayerCharacter Character;
+
+		internal PlayerRequestContext(NetworkConnection connection, IPlayerCharacter character)
+		{
+			Connection = connection;
+			Character = character;
+		}
+
+		/// <summary>True when a character was resolved. False on a <c>default</c> context.</summary>
+		public bool IsValid => Character != null;
+
+		/// <summary>The acting character's database id, or 0 on a <c>default</c> context.</summary>
+		public long CharacterID => Character != null ? Character.ID : 0;
+
+		/// <summary>
+		/// Resolves one of the acting character's controllers.
+		/// </summary>
+		/// <remarks>
+		/// Null-safe on a <c>default</c> context, so a caller that ignored the return of
+		/// <c>TryBeginPlayerRequest</c> gets a refusal rather than a NullReferenceException.
+		/// </remarks>
+		public bool TryGet<TBehaviour>(out TBehaviour behaviour)
+			where TBehaviour : class, ICharacterBehaviour
+		{
+			if (Character == null)
+			{
+				behaviour = null;
+				return false;
+			}
+			return Character.TryGet(out behaviour);
+		}
+	}
+
+	public abstract partial class ServerBehaviour
+	{
+		/// <summary>
+		/// Resolves the acting player behind a client request and applies the character-state gate.
+		/// The single entry point every player-initiated broadcast handler should open with.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Usage:
+		/// <code>
+		/// if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
+		/// {
+		///     return;
+		/// }
+		/// </code>
+		/// The ingress guard, and whatever this handler answers a refused guard with, stay at the
+		/// call site — see <see cref="PlayerRequestContext"/> for why.
+		/// </para>
+		/// <para>
+		/// The checks here are exactly the ones the hand-written preambles ran, in the order they
+		/// ran them, and nothing more. In particular a MISSING character refuses silently rather
+		/// than through <see cref="CharacterStateValidation.CanAct"/>, which logs its refusals: the
+		/// inline copies returned without a word, and this replaces them rather than changing what
+		/// they do. That is also why this does not delegate to
+		/// <c>CharacterStateValidation.TryGetPlayerAndValidate</c>, the Shared-assembly cousin that
+		/// declares itself canonical and has no callers — it folds the null-character case into
+		/// <c>CanAct</c>, and it cannot express <see cref="PlayerRequestGate.SkipCanAct"/>.
+		/// </para>
+		/// <para>
+		/// <c>conn.FirstObject</c>, not the character mapping table, because that is what the
+		/// handlers being replaced used. <c>CharacterSystem</c>'s own handlers resolve through
+		/// <c>ICharacterMappingData.ConnectionCharacters</c> instead and are NOT interchangeable
+		/// with this: the two disagree for a connection mid-hand-off, whose network object exists
+		/// before the mapping entry does.
+		/// </para>
+		/// </remarks>
+		/// <param name="conn">The connection the broadcast arrived on. May be null.</param>
+		/// <param name="context">The acting player, or <c>default</c> when the request is refused.</param>
+		/// <param name="gate">
+		/// Leave at <see cref="PlayerRequestGate.RequireCanAct"/> unless the request is not an action
+		/// and something downstream gates the action it leads to.
+		/// </param>
+		/// <returns>True when the handler may proceed.</returns>
+		protected bool TryBeginPlayerRequest(
+			NetworkConnection conn,
+			out PlayerRequestContext context,
+			PlayerRequestGate gate = PlayerRequestGate.RequireCanAct)
+		{
+			context = default;
+
+			if (conn == null || conn.FirstObject == null)
+			{
+				return false;
+			}
+
+			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();
+			if (character == null)
+			{
+				return false;
+			}
+
+			if (gate == PlayerRequestGate.RequireCanAct &&
+				!CharacterStateValidation.CanAct(character))
+			{
+				return false;
+			}
+
+			context = new PlayerRequestContext(conn, character);
+			return true;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.PlayerRequests.cs.meta
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.PlayerRequests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48c438db45804420b1abdf1b0c9345b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/ServerBehaviour.cs
@@ -16,7 +16,7 @@ namespace FishMMO.Server.Implementation
 	/// Base class for all server-side behaviours in the FishMMO server architecture.
 	/// Provides registration, initialization, and lifecycle management for server behaviours.
 	/// </summary>
-	public abstract class ServerBehaviour : ScriptableObject, IServerBehaviour<INetworkManagerWrapper, ServerManager, NetworkConnection, IServerBehaviour>
+	public abstract partial class ServerBehaviour : ScriptableObject, IServerBehaviour<INetworkManagerWrapper, ServerManager, NetworkConnection, IServerBehaviour>
 	{
 		/// <summary>
 		/// Indicates whether this behaviour has been initialized.

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Friend/FriendSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Friend/FriendSystem.cs
@@ -219,14 +219,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerFriendAddNewBroadcastReceived(NetworkConnection conn, FriendAddNewBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.AddFriend, out long guardKey))
 			{
@@ -372,14 +368,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerFriendRemoveBroadcastReceived(NetworkConnection conn, FriendRemoveBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.RemoveFriend, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Guild/GuildSystem.Recruitment.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Guild/GuildSystem.Recruitment.cs
@@ -165,16 +165,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		public void OnServerGuildDirectoryRequestBroadcastReceived(NetworkConnection conn, GuildDirectoryRequestBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-			{
-				return;
-			}
+			IPlayerCharacter player = request.Character;
 
 			if (Server?.Database?.ServiceRegistry == null)
 			{
@@ -277,16 +272,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		public void OnServerGuildApplyBroadcastReceived(NetworkConnection conn, GuildApplyBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-			{
-				return;
-			}
+			IPlayerCharacter player = request.Character;
 
 			if (Server?.Database?.ServiceRegistry == null || msg.GuildID < 1)
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Guild/GuildSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Guild/GuildSystem.cs
@@ -995,14 +995,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildCreateBroadcastReceived(NetworkConnection conn, GuildCreateBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
+			IPlayerCharacter player = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Create, out long guardKey))
 			{
@@ -1476,14 +1473,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildInviteBroadcastReceived(NetworkConnection conn, GuildInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Invite, out long guardKey))
 			{
@@ -1708,14 +1701,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildAcceptInviteBroadcastReceived(NetworkConnection conn, GuildAcceptInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.AcceptInvite, out long guardKey))
 			{
@@ -1972,14 +1961,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildDeclineInviteBroadcastReceived(NetworkConnection conn, GuildDeclineInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.DeclineInvite, out long guardKey))
 			{
@@ -2017,14 +2002,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildLeaveBroadcastReceived(NetworkConnection conn, GuildLeaveBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Leave, out long guardKey))
 			{
@@ -2351,14 +2332,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildRemoveBroadcastReceived(NetworkConnection conn, GuildRemoveBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Remove, out long guardKey))
 			{
@@ -2532,14 +2509,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildChangeRankBroadcastReceived(NetworkConnection conn, GuildChangeRankBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.ChangeRank, out long guardKey))
 			{
@@ -2736,14 +2709,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		private void HandleGuildTextEdit(NetworkConnection conn, string text, int maxLength, bool isMessageOfTheDay)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.SetInfo, out long guardKey))
 			{
@@ -2927,14 +2896,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		public void OnServerGuildTransferLeadershipBroadcastReceived(NetworkConnection conn, GuildTransferLeadershipBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.TransferLeadership, out long guardKey))
 			{
@@ -3084,14 +3049,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerGuildDisbandBroadcastReceived(NetworkConnection conn, GuildDisbandBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Disband, out long guardKey))
 			{
@@ -3329,14 +3290,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		public void OnServerGuildLogRequestBroadcastReceived(NetworkConnection conn, GuildLogRequestBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.LogRequest, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Hotkey/HotkeySystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Hotkey/HotkeySystem.cs
@@ -325,17 +325,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerHotkeySetBroadcastReceived(NetworkConnection conn, HotkeySetBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter playerCharacter = conn.FirstObject.GetComponent<IPlayerCharacter>();
-
-			if (playerCharacter == null || !CharacterStateValidation.CanAct(playerCharacter))
-			{
-				return;
-			}
+			IPlayerCharacter playerCharacter = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.SetSingle, out long guardKey))
 			{
@@ -383,14 +377,13 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerHotkeySetMultipleBroadcastReceived(NetworkConnection conn, HotkeySetMultipleBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
+			IPlayerCharacter playerCharacter = request.Character;
 
-			IPlayerCharacter playerCharacter = conn.FirstObject.GetComponent<IPlayerCharacter>();
-
-			if (playerCharacter == null || msg.Hotkeys == null || msg.Hotkeys.Length < 1 || !CharacterStateValidation.CanAct(playerCharacter))
+			if (msg.Hotkeys == null || msg.Hotkeys.Length < 1)
 			{
 				return;
 			}

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Arena.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Arena.cs
@@ -217,21 +217,31 @@ namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 		/// Validates that a connection is standing at a board that offers the arena and format it
 		/// asked for. Main thread only.
 		/// </summary>
+		/// <remarks>
+		/// Deliberately NOT gated on <see cref="CharacterStateValidation.CanAct"/>, for the same
+		/// reason the group-finder queue handler states outright: queuing is not a move. The gate
+		/// that matters is on the TRANSFER, not on the request — an arena entry is a
+		/// <c>GroupFinderEntry</c> in the same <c>groupFinderEntries</c> table as a dungeon one
+		/// (see <c>BuildArenaEntry</c>), and <c>HandleMatchedEntry</c> refuses to move any matched
+		/// entry unless <see cref="CharacterStateValidation.CanActOrMove"/> passes and the player is
+		/// still at the door. So a player who dies, is stunned or starts teleporting after queuing
+		/// keeps their place and is not moved; gating here as well would only refuse the request
+		/// earlier, and would refuse a dead player the right to queue for their next match.
+		/// </remarks>
 		private bool TryResolveArenaBoard(NetworkConnection conn, ArenaQueueBroadcast msg, out ArenaRequestContext context, out GroupFinderRefusalReason refusal)
 		{
 			context = default;
 			refusal = GroupFinderRefusalReason.NoEntrance;
 
-			if (conn == null || conn.FirstObject == null)
+			/* PlayerRequestGate.SkipCanAct, not an oversight — see the remarks above for which
+			 * later gate covers this one. Written through the shared entry point so that the
+			 * opt-out is a named argument rather than an absence nobody can tell from a bug. */
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request, PlayerRequestGate.SkipCanAct))
 			{
 				return false;
 			}
 
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (character == null)
-			{
-				return false;
-			}
+			IPlayerCharacter character = request.Character;
 
 			if (!ValidateSceneObject(msg.InteractableID, character.GameObject.scene.handle, out ISceneObject sceneObject))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Container.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Container.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FishNet.Connection;
 using FishNet.Transporting;
 using FishMMO.Shared;
@@ -31,6 +31,17 @@ namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 				!character.TryGet(out IInventoryController inventoryController) ||
 				!CharacterStateValidation.CanAct(character))
 			{
+				/* Answer, do not just drop it.
+				 *
+				 * SendContainerResult is what releases the client's pending lock on the slot, and
+				 * the throttle gate immediately below already understood that. This gate did not:
+				 * a player who is dead, stunned, teleporting or mid-load clicking a chest slot got
+				 * silence, and the slot stayed locked in their client until the window was closed.
+				 *
+				 * The guard key is taken below, so this cannot fold into the try/finally that covers
+				 * every later exit — EndIngressGuard would have nothing to release. Replying here is
+				 * the same shape the throttle path uses, which keeps the two gates symmetrical. */
+				SendContainerResult(conn, msg.InteractableID, msg.Slot, false, ContainerFailureReason.ServerError);
 				return;
 			}
 

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Dialogue.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Dialogue.cs
@@ -443,18 +443,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 		/// </summary>
 		private void OnServerDialogueChoiceBroadcastReceived(NetworkConnection conn, DialogueChoiceBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-			
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Mailbox.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Interactable/InteractableSystem.Mailbox.cs
@@ -36,18 +36,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 		/// </summary>
 		private void OnServerMailFetchBroadcastReceived(NetworkConnection conn, MailFetchBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, out long guardKey))
 			{
@@ -970,18 +963,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer.Interactable
 		/// </summary>
 		private void OnServerMailDeleteBroadcastReceived(NetworkConnection conn, MailDeleteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-			
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Party/PartySystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Party/PartySystem.cs
@@ -2177,14 +2177,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		public void OnServerPartyCreateBroadcastReceived(NetworkConnection conn, PartyCreateBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
+			IPlayerCharacter player = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Create, out long guardKey))
 			{
@@ -2330,14 +2327,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyInviteBroadcastReceived(NetworkConnection conn, PartyInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Invite, out long guardKey))
 			{
@@ -2531,14 +2524,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyAcceptInviteBroadcastReceived(NetworkConnection conn, PartyAcceptInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.AcceptInvite, out long guardKey))
 			{
@@ -3096,14 +3085,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyDeclineInviteBroadcastReceived(NetworkConnection conn, PartyDeclineInviteBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (character == null || !CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.DeclineInvite, out long guardKey))
 			{
@@ -3138,14 +3124,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyLeaveBroadcastReceived(NetworkConnection conn, PartyLeaveBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Leave, out long guardKey))
 			{
@@ -4073,14 +4055,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyRemoveBroadcastReceived(NetworkConnection conn, PartyRemoveBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Remove, out long guardKey))
 			{
@@ -4261,14 +4239,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// <param name="channel">Network channel used for the broadcast.</param>
 		public void OnServerPartyChangeRankBroadcastReceived(NetworkConnection conn, PartyChangeRankBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.ChangeRank, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Pet/PetSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Pet/PetSystem.cs
@@ -243,14 +243,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnPetFollowBroadcastReceived(NetworkConnection conn, PetFollowBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Follow, out long guardKey))
 			{
@@ -280,14 +276,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnPetStayBroadcastReceived(NetworkConnection conn, PetStayBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Stay, out long guardKey))
 			{
@@ -356,14 +348,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnPetSummonBroadcastReceived(NetworkConnection conn, PetSummonBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Summon, out long guardKey))
 			{
@@ -415,14 +403,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnPetReleaseBroadcastReceived(NetworkConnection conn, PetReleaseBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
+			IPlayerCharacter player = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Release, out long guardKey))
 			{
@@ -538,14 +523,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		private void OnPetAttackBroadcastReceived(NetworkConnection conn, PetAttackBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
+			IPlayerCharacter player = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.Attack, out long guardKey))
 			{
@@ -637,14 +619,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </remarks>
 		private void OnPetAttackPriorityBroadcastReceived(NetworkConnection conn, PetAttackPriorityBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.AttackPriority, out long guardKey))
 			{
@@ -680,14 +658,10 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnPetStanceBroadcastReceived(NetworkConnection conn, PetStanceBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out _))
 			{
 				return;
 			}
-
-			IPlayerCharacter player = conn.FirstObject.GetComponent<IPlayerCharacter>();
-			if (player == null || !CharacterStateValidation.CanAct(player))
-				return;
 
 			// Reject values outside the enum rather than casting a hostile byte straight in.
 			if (!Enum.IsDefined(typeof(PetStance), msg.Stance))

--- a/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Quest/QuestSystem.cs
+++ b/FishMMO-Unity/Assets/Scripts/Server/Implementation/World/SceneServer/Quest/QuestSystem.cs
@@ -482,17 +482,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnServerQuestAcceptBroadcastReceived(NetworkConnection conn, QuestAcceptBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.QuestAccepted, out long guardKey))
 			{
@@ -579,17 +573,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnServerQuestTurnInBroadcastReceived(NetworkConnection conn, QuestTurnInBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.QuestTurnedIn, out long guardKey))
 			{
@@ -671,17 +659,11 @@ namespace FishMMO.Server.Implementation.World.SceneServer
 		/// </summary>
 		private void OnServerQuestAbandonBroadcastReceived(NetworkConnection conn, QuestAbandonBroadcast msg, Channel channel)
 		{
-			if (conn == null || conn.FirstObject == null)
+			if (!TryBeginPlayerRequest(conn, out PlayerRequestContext request))
 			{
 				return;
 			}
-
-			IPlayerCharacter character = conn.FirstObject.GetComponent<IPlayerCharacter>();if (character == null)
-			{
-				return;
-			}
-			if (!CharacterStateValidation.CanAct(character))
-				return;
+			IPlayerCharacter character = request.Character;
 
 			if (!TryBeginIngressGuard(conn.ClientId, IngressOperation.QuestAbandoned, out long guardKey))
 			{

--- a/FishMMO-Unity/Assets/UnitTests/InviteByNameHelperTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/InviteByNameHelperTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that inviting somebody by name is ONE flow, and that consolidating it did not flatten
+	/// what the panels legitimately say differently.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Three panels had an independent copy of the same five steps: find the shared input dialog,
+	/// validate the typed name, resolve it to a character ID through the naming system, refuse the
+	/// player's own ID, broadcast. Guild and party additionally shared the hover-then-pinned target
+	/// fallback ahead of it, comment and all. They differed only in the broadcast sent and two
+	/// sentences.
+	/// </para>
+	/// <para>
+	/// Every step of that flow has a way of being wrong that produces NO error where it is written.
+	/// Omit the name validation and an unvalidatable string travels to the server to be rejected;
+	/// omit the <c>id == 0</c> test and a failed lookup invites character zero; omit the self test
+	/// and the player invites themselves and waits for a dialog that never comes. A fourth panel
+	/// growing an invite button would be written by copying whichever of the three its author found
+	/// first, and a step dropped in the copying looks exactly like working code. That is what this
+	/// fixture exists to catch — not the duplication as an aesthetic matter, but the silent omission
+	/// duplication invites.
+	/// </para>
+	/// <para>
+	/// The other half of the fixture is the opposite worry. Consolidation is only correct while each
+	/// panel still sends ITS OWN broadcast and says its own words — "you can't invite yourself to
+	/// the guild" is not "you can't add yourself as a friend", and a helper that unified those would
+	/// be a regression dressed as a cleanup. Those are pinned per panel below.
+	/// </para>
+	/// <para>
+	/// Source assertions, deliberately: the flow is a sequence of calls into a shared panel
+	/// registry, an async naming cache and the network, so exercising it needs a running client and
+	/// a registered dialog. What can be proven cheaply is the CONTRACT — that the shared helper is
+	/// what the panels call — which is exactly the thing that regresses.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class InviteByNameHelperTests
+	{
+		/// <summary>The base class that owns the shared prompt and target helpers.</summary>
+		private const string ControlPath = "Assets/Scripts/Client/GUI/UITKControl.cs";
+
+		private const string GuildPath = "Assets/Scripts/Client/GUI/World/Guild/UITKGuild.cs";
+		private const string PartyPath = "Assets/Scripts/Client/GUI/World/Party/UITKParty.cs";
+		private const string FriendListPath = "Assets/Scripts/Client/GUI/World/FriendList/UITKFriendList.cs";
+
+		/// <summary>Every GUI source file, which is the population the sweeps below run over.</summary>
+		private static string GuiRoot =>
+			Path.Combine(Directory.GetCurrentDirectory(), "Assets/Scripts/Client/GUI");
+
+		/// <summary>The text of a source file, with its line endings normalised to \n.</summary>
+		/// <remarks>
+		/// The patterns below span line breaks — a call written across four lines is the normal shape
+		/// in this tree. Whether a working tree stores a file LF or CRLF is decided by git on
+		/// checkout and by each developer's core.autocrlf, so a bound written with \n silently stops
+		/// matching on a Windows checkout and the assertion then reports the code as missing while it
+		/// sits there unchanged.
+		/// </remarks>
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path).Replace("\r\n", "\n");
+		}
+
+		/// <summary>
+		/// A source file with its comments removed.
+		/// </summary>
+		/// <remarks>
+		/// Required rather than tidy. The consolidated call sites EXPLAIN what they no longer do —
+		/// they name the naming system and the validation they used to call inline — so a sweep for
+		/// those names over raw text would report the explanation as the offence it warns about.
+		/// Comments are where this project keeps its reasoning, so a rule that cannot tell code from
+		/// prose would push that reasoning out of the files.
+		/// <para>
+		/// Only WHOLE-LINE line comments are removed, not trailing ones. A trailing <c>//</c> cannot
+		/// be told from a <c>//</c> inside a string literal without parsing the file properly, and
+		/// cutting at the wrong one takes the rest of a real line of code with it — which would
+		/// unbalance the braces <see cref="MethodBody"/> counts and fail on a file that is perfectly
+		/// fine. Every comment this needs to see past is a <c>///</c> block on its own lines.
+		/// </para>
+		/// </remarks>
+		private static string StripComments(string source)
+		{
+			source = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+			return Regex.Replace(source, @"(?m)^[ \t]*//[^\n]*", string.Empty);
+		}
+
+		/// <summary>Every GUI source file except the base class that owns the shared helpers.</summary>
+		private static IEnumerable<string> PanelSources()
+		{
+			foreach (string file in Directory.GetFiles(GuiRoot, "*.cs", SearchOption.AllDirectories))
+			{
+				if (Path.GetFileName(file) == "UITKControl.cs")
+				{
+					continue;
+				}
+
+				yield return file;
+			}
+		}
+
+		/// <summary>
+		/// The body of a method, from its signature to its matching closing brace.
+		/// </summary>
+		/// <param name="source">The file's source text.</param>
+		/// <param name="signature">A signature fragment that occurs exactly once in the file.</param>
+		/// <remarks>
+		/// Brace counting rather than a regex: these methods contain string literals, lambdas and
+		/// nested initialisers, and a pattern loose enough to match them all is loose enough to run
+		/// on into the next method — which for a test that asserts "this method sends THAT
+		/// broadcast" would pass by reading a neighbour.
+		/// </remarks>
+		private static string MethodBody(string source, string signature)
+		{
+			int start = source.IndexOf(signature, StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, $"'{signature}' must exist.");
+
+			int open = source.IndexOf('{', start);
+			LogAssert.IsTrue(open >= 0, $"'{signature}' must open a body.");
+
+			int depth = 0;
+			for (int i = open; i < source.Length; ++i)
+			{
+				if (source[i] == '{')
+				{
+					++depth;
+				}
+				else if (source[i] == '}')
+				{
+					if (--depth == 0)
+					{
+						return source.Substring(start, i - start + 1);
+					}
+				}
+			}
+
+			Assert.Fail($"'{signature}' has no matching closing brace.");
+			return null;
+		}
+
+		/// <summary>
+		/// The shared helpers exist, and the failure wording nobody owns is a constant.
+		/// </summary>
+		/// <remarks>
+		/// The sweeps below are all of the form "no panel may do this itself". Each of them passes
+		/// trivially if the shared helper is deleted and nothing replaces it, so the helper's
+		/// existence is asserted first: without this test the fixture could go green on a codebase
+		/// where the feature had simply been removed.
+		/// </remarks>
+		[Test]
+		public void TheSharedHelpersExist()
+		{
+			string control = ReadSource(ControlPath);
+
+			LogAssert.IsTrue(control.Contains("protected static bool PromptForCharacterID("),
+				"UITKControl must own the prompt-then-resolve-a-name flow.");
+			LogAssert.IsTrue(control.Contains("protected static bool TryResolveTargetCharacter("),
+				"UITKControl must own the hover-then-pinned target fallback.");
+			LogAssert.IsTrue(control.Contains("UnknownCharacterMessage = \"A person with that name could not be found.\""),
+				"The not-found wording belongs to one constant — it is not panel-specific.");
+		}
+
+		/// <summary>
+		/// No panel resolves a typed name into a character ID by itself.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="FishMMO.Client.ClientNamingSystem"/>'s reverse lookup is the giveaway step: a
+		/// panel only ever needs a name turned into an ID because the player typed the name, and
+		/// that is the flow the shared helper performs end to end. Calling it from a panel means the
+		/// four checks around it have been re-decided locally, which is where the silent omissions
+		/// described in the fixture remarks come from.
+		/// </remarks>
+		[Test]
+		public void NoPanelResolvesANameItself()
+		{
+			List<string> offenders = new List<string>();
+
+			foreach (string file in PanelSources())
+			{
+				string source = StripComments(File.ReadAllText(file).Replace("\r\n", "\n"));
+
+				if (source.Contains("ClientNamingSystem.GetCharacterID("))
+				{
+					offenders.Add(Path.GetFileName(file));
+				}
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"a panel must reach a character ID through UITKControl.PromptForCharacterID, not resolve the name itself: "
+				+ string.Join("; ", offenders));
+		}
+
+		/// <summary>
+		/// No panel writes the not-found sentence itself.
+		/// </summary>
+		/// <remarks>
+		/// Three panels spelled it identically, which is the state a shared string is in immediately
+		/// before somebody rewords one of them. The message reports that a name did not resolve — it
+		/// has nothing to do with guilds, parties or friends — so a panel that has its own copy of it
+		/// is a panel that has its own copy of the lookup.
+		/// </remarks>
+		[Test]
+		public void NoPanelSpellsTheNotFoundMessageItself()
+		{
+			List<string> offenders = new List<string>();
+
+			foreach (string file in PanelSources())
+			{
+				string source = StripComments(File.ReadAllText(file).Replace("\r\n", "\n"));
+
+				if (source.Contains("A person with that name could not be found."))
+				{
+					offenders.Add(Path.GetFileName(file));
+				}
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"the not-found wording lives on UITKControl.UnknownCharacterMessage: " + string.Join("; ", offenders));
+		}
+
+		/// <summary>
+		/// No panel hand-rolls the hover-then-pinned target fallback.
+		/// </summary>
+		/// <remarks>
+		/// The ORDER is the rule: the hovered target is read first and the pin is the fallback,
+		/// because the pointer is on the button when it fires and so the hover is usually empty. A
+		/// second copy of that ternary is a second place for the order to be swapped, and a swapped
+		/// order is not a crash — it is a button that quietly invites the wrong person whenever a pin
+		/// is held. Reading <c>PinnedTarget</c> at all is deliberately NOT the offence: the pet
+		/// panel sends both the pinned and the hovered target to the server and lets it choose,
+		/// which is a different contract.
+		/// </remarks>
+		[Test]
+		public void NoPanelHandRollsTheTargetFallback()
+		{
+			List<string> offenders = new List<string>();
+
+			foreach (string file in PanelSources())
+			{
+				string source = StripComments(File.ReadAllText(file).Replace("\r\n", "\n"));
+
+				if (Regex.IsMatch(source, @"Current\.Target\s*!=\s*null[^;]{0,200}PinnedTarget", RegexOptions.Singleline))
+				{
+					offenders.Add(Path.GetFileName(file));
+				}
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"the hovered-then-pinned fallback belongs to UITKControl.TryResolveTargetCharacter: "
+				+ string.Join("; ", offenders));
+		}
+
+		/// <summary>
+		/// Each panel calls the shared helper, and still sends its own broadcast.
+		/// </summary>
+		/// <remarks>
+		/// The behaviour-preserving half. A helper that took over the broadcast as well would have
+		/// had to be told which one to send, and the obvious way to tell it — a flag, or a channel
+		/// enum — reintroduces the duplication inside the helper while making every panel's wire
+		/// message harder to find. The broadcast is the one part of this flow that is genuinely the
+		/// panel's, so the test insists it stays there.
+		/// </remarks>
+		[Test]
+		public void EachPanelCallsTheHelperAndSendsItsOwnBroadcast()
+		{
+			(string path, string signature, string broadcast)[] panels = new[]
+			{
+				(GuildPath, "public void OnButtonInviteToGuild()", "GuildInviteBroadcast"),
+				(PartyPath, "public void OnButtonInviteToParty()", "PartyInviteBroadcast"),
+				(FriendListPath, "public void OnButtonAddFriend()", "FriendAddNewBroadcast"),
+			};
+
+			foreach ((string path, string signature, string broadcast) panel in panels)
+			{
+				string body = MethodBody(StripComments(ReadSource(panel.path)), panel.signature);
+
+				LogAssert.IsTrue(body.Contains("PromptForCharacterID("),
+					$"{panel.signature} must ask for a name through the shared helper.");
+				LogAssert.IsTrue(body.Contains(panel.broadcast),
+					$"{panel.signature} must still send {panel.broadcast} itself.");
+			}
+		}
+
+		/// <summary>
+		/// Each panel still refuses the player in its own words.
+		/// </summary>
+		/// <remarks>
+		/// Three distinct sentences, checked as three, because "you can't invite yourself to the
+		/// guild" tells the player which action was refused and a single shared "you can't do that to
+		/// yourself" would not. Sharing the mechanism is the point of the refactor; sharing the
+		/// wording would have been a loss, and this is the test that would have caught it.
+		/// </remarks>
+		[Test]
+		public void EachPanelKeepsItsOwnRefusalWording()
+		{
+			(string path, string signature, string message)[] panels = new[]
+			{
+				(GuildPath, "public void OnButtonInviteToGuild()", "You can't invite yourself to the guild."),
+				(PartyPath, "public void OnButtonInviteToParty()", "You can't invite yourself to the party."),
+				(FriendListPath, "public void OnButtonAddFriend()", "You can't add yourself as a friend."),
+			};
+
+			foreach ((string path, string signature, string message) panel in panels)
+			{
+				string body = MethodBody(StripComments(ReadSource(panel.path)), panel.signature);
+
+				LogAssert.IsTrue(body.Contains(panel.message),
+					$"{panel.signature} must pass its own refusal wording: \"{panel.message}\".");
+			}
+		}
+
+		/// <summary>
+		/// The self test survives, wherever it now lives.
+		/// </summary>
+		/// <remarks>
+		/// The one check with no visible consequence when it is missing: inviting yourself sends a
+		/// broadcast the server drops, so the button appears to work and no dialog ever arrives. It
+		/// was written out three times and is now written once, which is a saving only while the once
+		/// is still there.
+		/// </remarks>
+		[Test]
+		public void TheSharedHelperStillRefusesThePlayerThemselves()
+		{
+			string body = MethodBody(StripComments(ReadSource(ControlPath)),
+				"protected static bool PromptForCharacterID(");
+
+			LogAssert.IsTrue(body.Contains("Authentication.IsAllowedCharacterName("),
+				"An unvalidatable name must not reach the naming system.");
+			LogAssert.IsTrue(body.Contains("id == 0"),
+				"An unresolved name must not be broadcast as character zero.");
+			LogAssert.IsTrue(body.Contains(".ID == id"),
+				"The player's own ID must still be refused.");
+
+			int selfTest = body.IndexOf(".ID == id", StringComparison.Ordinal);
+			int invoke = body.IndexOf("onResolved?.Invoke(id)", StringComparison.Ordinal);
+
+			LogAssert.IsTrue(invoke >= 0, "A resolved ID must still reach the caller.");
+			LogAssert.IsTrue(selfTest < invoke,
+				"The self test decides BEFORE the caller is handed the ID, or the refusal is decoration.");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/InviteByNameHelperTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/InviteByNameHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ebd5faba4ac466f8094cda7fea5e9bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FishMMO-Unity/Assets/UnitTests/MerchantQuantityFieldTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/MerchantQuantityFieldTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that the merchant's quantity field shows the number it holds (issues #263, #277).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// A UI Toolkit <c>IntegerField</c> renders its text AS A RESULT of being written to. Guarding
+	/// that write on "only if the number changed" therefore skips the one case that matters: the
+	/// UXML authors the field as <c>value="1"</c>, so the <c>SetQuantity(1)</c> that runs when an
+	/// entry is selected found the values equal, wrote nothing, and left the inner text element
+	/// empty.
+	/// </para>
+	/// <para>
+	/// The field was live and editable throughout — it simply displayed nothing, which reads as a
+	/// dead control rather than a blank one. Hiding the panel disposes the visual tree, so the
+	/// re-queried field returns to the authored 1 with no text and the fault recurs, which is why
+	/// it presented as intermittent.
+	/// </para>
+	/// <para>
+	/// The rule this pins: a control whose visible text is produced by the write must be written
+	/// unconditionally. Comparing before assigning is an optimisation that costs correctness here.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class MerchantQuantityFieldTests
+	{
+		private const string MerchantPath =
+			"Assets/Scripts/Client/GUI/World/Merchant/UITKMerchant.cs";
+
+		/// <summary>Source text with line endings normalised, so bounds do not depend on checkout.</summary>
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path).Replace("\r\n", "\n");
+		}
+
+		/// <summary>The body of a named method, bounded by the next member's signature.</summary>
+		private static string MethodBody(string source, string signature, string nextSymbol)
+		{
+			int start = source.IndexOf(signature, StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, $"the source must still declare {signature}");
+
+			int end = source.IndexOf(nextSymbol, start, StringComparison.Ordinal);
+			LogAssert.IsTrue(end > start, $"the end of {signature} must be locatable");
+
+			return source.Substring(start, end - start);
+		}
+
+		[Test]
+		public void TheQuantityFieldIsWrittenEvenWhenTheNumberIsUnchanged()
+		{
+			string body = MethodBody(ReadSource(MerchantPath),
+				"private void SetQuantity(int quantity)", "private void RefreshQuantityControls");
+
+			LogAssert.IsTrue(body.Contains("SetValueWithoutNotify(clamped)"),
+				"the quantity must still be pushed into the field");
+
+			/* The defect in one line. Any comparison of the field's current value against the value
+			 * being written re-introduces the skip that leaves the text blank. */
+			LogAssert.IsFalse(body.Contains("quantityField.value != clamped"),
+				"guarding the write on a value comparison leaves the field's text unrendered");
+		}
+
+		[Test]
+		public void SelectingAnEntryStillSeedsTheQuantity()
+		{
+			/* The write only helps if something calls it on selection. This is the call the guard
+			 * was swallowing, so it is the one worth pinning. */
+			string source = ReadSource(MerchantPath);
+
+			LogAssert.IsTrue(source.Contains("SetQuantity(1)"),
+				"selecting an entry must seed the quantity, or the field starts empty");
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/MerchantQuantityFieldTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/MerchantQuantityFieldTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e08153b724e4361abd994ffbb69c15b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/UnitTests/PendingSlotWatchdogTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/PendingSlotWatchdogTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using FishMMO.Client;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// There is one pending-slot watchdog in the client, and it runs on the unscaled clock.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Every panel that shows a shared pile — the corpse loot window, the world container window —
+	/// locks a row while its take is in flight, because the row cannot disappear until the server
+	/// says the item is gone and a player whose click appears to do nothing clicks again. A lock
+	/// needs a watchdog: the reply can be lost to a dropped connection, a handler that returned
+	/// without broadcasting, or a scene hand-off, and a lock with nothing to release it is worse
+	/// than no lock at all — the row is dead for the life of the window.
+	/// </para>
+	/// <para>
+	/// Both panels had written that watchdog themselves, and they disagreed about the clock. The
+	/// loot panel measured against <c>Time.time</c>, which Unity scales by <c>Time.timeScale</c>,
+	/// so any pause or slow-motion froze its watchdog while the network kept running: a reply lost
+	/// during a pause left the row locked, and at <c>timeScale</c> 0 no amount of waiting could
+	/// ever release it. The container panel, doing the same job twenty lines of code away, used
+	/// <c>Time.unscaledTime</c> and was right. That is the shape of bug duplication produces —
+	/// not two copies of one behaviour, but two behaviours wearing the same name.
+	/// </para>
+	/// <para>
+	/// Both now use <see cref="ItemSlotPendingSet"/>, which keys one
+	/// <see cref="PendingReplyGuard"/> per slot and expires against unscaled time. These tests are
+	/// deliberately part source-scan and part reflection rather than purely behavioural: the thing
+	/// worth preventing is not a wrong answer from a function, it is a third copy of the watchdog
+	/// appearing in the next panel somebody writes. A behavioural test cannot see that, because a
+	/// fresh hand-rolled dictionary passes every behavioural test on the day it is written — it is
+	/// the day the game first pauses that it fails. Sources are read with line endings normalised,
+	/// because the tree is CRLF on Windows and CI has checked it out both ways.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class PendingSlotWatchdogTests
+	{
+		private const string LootPath = "Assets/Scripts/Client/GUI/World/Loot/UITKLoot.cs";
+		private const string ContainerPath = "Assets/Scripts/Client/GUI/World/Container/UITKContainer.cs";
+		private const string SharedSetPath = "Assets/Scripts/Client/GUI/World/ItemContainers/ItemSlotPendingSet.cs";
+		private const string GuardPath = "Assets/Scripts/Client/GUI/Core/PendingReplyGuard.cs";
+		private const string GuiRoot = "Assets/Scripts/Client/GUI";
+
+		/// <summary>The scaled clock, and only it — <c>Time.timeScale</c> must not match.</summary>
+		private static readonly Regex ScaledClock = new Regex(@"\bTime\.time\b", RegexOptions.Compiled);
+
+		/// <summary>A slot-to-timestamp map, however it is spaced.</summary>
+		private static readonly Regex SlotTimestampMap =
+			new Regex(@"Dictionary\s*<\s*int\s*,\s*(float|double)\s*>", RegexOptions.Compiled);
+
+		/// <summary>A dictionary field or local whose name says it tracks pending state.</summary>
+		private static readonly Regex PendingMapDeclaration =
+			new Regex(@"Dictionary\s*<[^>]*>\s+\w*[Pp]ending\w*", RegexOptions.Compiled);
+
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path).Replace("\r\n", "\n");
+		}
+
+		/// <summary>
+		/// The source with comment lines dropped, so a scan sees code and not prose.
+		/// </summary>
+		/// <remarks>
+		/// Both panels explain the timeScale bug in a comment, and those comments name
+		/// <c>Time.time</c> — the explanation is the point of them. Scanning raw text would make the
+		/// fix fail its own test and, worse, would teach the next person to delete the explanation
+		/// to get green. Line-level stripping is enough here: this is a grep with manners, not a
+		/// parser, and a trailing comment after real code still leaves the code visible.
+		/// </remarks>
+		private static string CodeOnly(string source)
+		{
+			string[] lines = source.Split('\n');
+			System.Text.StringBuilder code = new System.Text.StringBuilder(source.Length);
+
+			for (int i = 0; i < lines.Length; ++i)
+			{
+				string trimmed = lines[i].TrimStart();
+				if (trimmed.StartsWith("//", StringComparison.Ordinal) ||
+					trimmed.StartsWith("/*", StringComparison.Ordinal) ||
+					trimmed.StartsWith("*", StringComparison.Ordinal))
+				{
+					continue;
+				}
+
+				code.Append(lines[i]).Append('\n');
+			}
+
+			return code.ToString();
+		}
+
+		/// <summary>Every C# file under the client GUI tree.</summary>
+		private static List<string> GuiSources()
+		{
+			string root = Path.Combine(Directory.GetCurrentDirectory(), GuiRoot);
+			LogAssert.IsTrue(Directory.Exists(root), $"the client GUI tree must exist at {root}.");
+
+			List<string> files = new List<string>(Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories));
+			LogAssert.IsTrue(files.Count > 0, "the GUI tree must contain sources to scan");
+			return files;
+		}
+
+		[Test]
+		public void NeitherWorldItemPanelKeepsItsOwnPendingSlotMap()
+		{
+			/* The duplication itself. Both panels must hold the shared set rather than a private
+			 * slot-to-timestamp dictionary, because a private one is where the clock can drift out
+			 * of agreement again without anybody noticing. */
+			string loot = CodeOnly(ReadSource(LootPath));
+			string container = CodeOnly(ReadSource(ContainerPath));
+
+			LogAssert.IsTrue(loot.Contains("new ItemSlotPendingSet()"),
+				"the loot panel must track pending slots with the shared set");
+			LogAssert.IsTrue(container.Contains("new ItemSlotPendingSet()"),
+				"the container panel must track pending slots with the shared set");
+
+			LogAssert.IsFalse(SlotTimestampMap.IsMatch(loot),
+				"the loot panel must not keep its own slot-to-send-time map");
+			LogAssert.IsFalse(SlotTimestampMap.IsMatch(container),
+				"the container panel must not keep its own slot-to-send-time map");
+		}
+
+		[Test]
+		public void ThePanelsHoldTheSharedSetRatherThanAnythingShapedLikeItsReplacement()
+		{
+			/* Reflection rather than text, so renaming the field or wrapping the dictionary in a
+			 * helper struct does not slip past. A panel is allowed to hold no pending set at all —
+			 * the inventory-side panels share the static ones in ItemOperationTracker — but it is
+			 * not allowed to hold a map from slot to a timestamp. */
+			AssertNoHandRolledPendingMap(typeof(UITKLoot));
+			AssertNoHandRolledPendingMap(typeof(UITKContainer));
+
+			LogAssert.IsTrue(HasFieldOfType(typeof(UITKLoot), typeof(ItemSlotPendingSet)),
+				"UITKLoot must hold an ItemSlotPendingSet");
+			LogAssert.IsTrue(HasFieldOfType(typeof(UITKContainer), typeof(ItemSlotPendingSet)),
+				"UITKContainer must hold an ItemSlotPendingSet");
+
+			/* The bulk watchdog — take-all and currency — is one wait rather than a set of them, so
+			 * it is a bare guard. What matters is that it is the SAME guard type, and therefore the
+			 * same clock, and not a float sentinel compared against a timestamp again. */
+			LogAssert.IsTrue(HasFieldOfType(typeof(UITKLoot), typeof(PendingReplyGuard)),
+				"UITKLoot's take-all and currency wait must use PendingReplyGuard, not a float sentinel");
+		}
+
+		[Test]
+		public void EveryPendingWatchdogInTheGuiRunsOnTheUnscaledClock()
+		{
+			/* The bug, stated as a rule. A deadline on something the SERVER is doing cannot be
+			 * measured on a clock the client can stop: the server does not slow down when a player
+			 * opens the settings menu or dies behind a slow-motion effect.
+			 *
+			 * Scoped to files that mention pending state rather than banning Time.time from the
+			 * whole GUI tree, because a purely cosmetic animation is entitled to scale with the
+			 * game. A file that tracks a request in flight is not. */
+			List<string> offenders = new List<string>();
+			List<string> files = GuiSources();
+
+			for (int i = 0; i < files.Count; ++i)
+			{
+				string raw = File.ReadAllText(files[i]).Replace("\r\n", "\n");
+				if (raw.IndexOf("pending", StringComparison.OrdinalIgnoreCase) < 0)
+				{
+					continue;
+				}
+
+				string code = CodeOnly(raw);
+				if (ScaledClock.IsMatch(code))
+				{
+					offenders.Add($"{Path.GetFileName(files[i])} measures a pending wait against Time.time");
+				}
+
+				if (PendingMapDeclaration.IsMatch(code))
+				{
+					offenders.Add($"{Path.GetFileName(files[i])} declares its own pending dictionary");
+				}
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"pending waits belong to ItemSlotPendingSet/PendingReplyGuard on unscaled time: " +
+				string.Join("; ", offenders.ToArray()));
+		}
+
+		[Test]
+		public void TheSharedWatchdogItselfNeverReadsTheScaledClock()
+		{
+			/* Where the fix actually lives. Both panels are now only as correct as these two types,
+			 * so the clock is pinned here as well as at the call sites. */
+			string set = CodeOnly(ReadSource(SharedSetPath));
+			string guard = CodeOnly(ReadSource(GuardPath));
+
+			LogAssert.IsFalse(ScaledClock.IsMatch(set), "ItemSlotPendingSet must not read Time.time");
+			LogAssert.IsFalse(ScaledClock.IsMatch(guard), "PendingReplyGuard must not read Time.time");
+			LogAssert.IsTrue(guard.Contains("Time.unscaledTime"),
+				"PendingReplyGuard expires against unscaled time");
+		}
+
+		[Test]
+		public void TheFiveSecondTimeoutSurvivedTheMoveToTheSharedSet()
+		{
+			/* Adopting a shared type is where a timeout silently changes. ItemSlotPendingSet
+			 * defaults to 8s and PendingReplyGuard to 30s; both of these panels lock a row in a pile
+			 * somebody else is emptying and have always used 5s. Every claim must therefore pass the
+			 * constant explicitly — an argument-less TryBegin here is a behaviour change disguised as
+			 * a cleanup. */
+			AssertTimeoutIsPassedExplicitly(LootPath);
+			AssertTimeoutIsPassedExplicitly(ContainerPath);
+		}
+
+		/// <summary>
+		/// Asserts one panel still declares a 5s timeout and hands it to every claim it makes.
+		/// </summary>
+		private static void AssertTimeoutIsPassedExplicitly(string relativePath)
+		{
+			string name = Path.GetFileName(relativePath);
+			string code = CodeOnly(ReadSource(relativePath));
+
+			LogAssert.IsTrue(Regex.IsMatch(code, @"PENDING_TIMEOUT_SECONDS\s*=\s*5f"),
+				$"{name} must still time a pending row out after 5 seconds");
+
+			/* Matched as a bare call rather than a whole statement: both panels claim inside an
+			 * `if (!...TryBegin(...))`, so there is no semicolon to anchor on. Arguments here never
+			 * contain a nested call or a line break, which is what makes this safe without a
+			 * parser. */
+			MatchCollection claims = Regex.Matches(code, @"(?:TryBegin|\.Begin)\s*\(([^()\n]*)\)");
+			LogAssert.IsTrue(claims.Count > 0, $"{name} must claim a pending wait somewhere");
+
+			for (int i = 0; i < claims.Count; ++i)
+			{
+				LogAssert.IsTrue(claims[i].Groups[1].Value.Contains("PENDING_TIMEOUT_SECONDS"),
+					$"{name} must pass its own timeout rather than inherit a longer default: {claims[i].Value.Trim()}");
+			}
+		}
+
+		[Test]
+		public void ASecondClaimOnAWaitingSlotIsRefusedRatherThanRearmed()
+		{
+			/* The behaviour the panels depend on, and the reason TryBegin returns a bool instead of
+			 * just recording the claim: re-arming on every click would push a stuck row's deadline
+			 * out forever, so the one player most likely to be stuck — the one clicking repeatedly —
+			 * would be the one the watchdog never helps. */
+			ItemSlotPendingSet set = new ItemSlotPendingSet();
+
+			LogAssert.IsTrue(set.TryBegin(4, 5f), "a free slot is claimed");
+			LogAssert.IsFalse(set.TryBegin(4, 5f), "and a second claim on it is refused");
+			LogAssert.IsTrue(set.IsPending(4), "the slot is still waiting after the refusal");
+			LogAssert.AreEqual(1, set.PendingCount, "and the refusal did not count as a second wait");
+
+			LogAssert.IsTrue(set.Release(4), "the reply releases it");
+			LogAssert.IsFalse(set.IsPending(4), "after which the row is clickable again");
+			LogAssert.IsTrue(set.TryBegin(4, 5f), "and the slot can be claimed afresh");
+		}
+
+		[Test]
+		public void PendingSlotsCanBeEnumeratedSoALostRaceIsPrunedImmediately()
+		{
+			/* What the loot panel's prune needs. A corpse is re-sent whole whenever any looter takes
+			 * something, so a slot that has vanished from the snapshot is a race this client lost;
+			 * its row is already gone, and leaving the claim to time out would hold a lock on a slot
+			 * nobody can see. The panel is looking for slots it no longer HAS, so it cannot ask
+			 * IsPending about them — the set has to be enumerable. */
+			ItemSlotPendingSet set = new ItemSlotPendingSet();
+			set.TryBegin(1, 5f);
+			set.TryBegin(7, 5f);
+			set.Release(1);
+
+			List<int> pending = new List<int>();
+			set.CollectPending(pending);
+
+			LogAssert.AreEqual(1, pending.Count, "only the slot still waiting is reported");
+			LogAssert.AreEqual(7, pending[0], "and it is the one that was never released");
+
+			/* Released guards are kept for reuse rather than removed, so a set that has been busy
+			 * must still report nothing once everything is answered. */
+			set.Release(7);
+			pending.Clear();
+			set.CollectPending(pending);
+			LogAssert.AreEqual(0, pending.Count, "a fully answered set reports no pending slots");
+			LogAssert.IsFalse(set.HasAnyPending, "and knows it has nothing outstanding");
+		}
+
+		/// <summary>Whether a type declares a field of exactly <paramref name="fieldType"/>.</summary>
+		private static bool HasFieldOfType(Type owner, Type fieldType)
+		{
+			FieldInfo[] fields = owner.GetFields(BindingFlags.Instance | BindingFlags.Static |
+				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+			for (int i = 0; i < fields.Length; ++i)
+			{
+				if (fields[i].FieldType == fieldType)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Asserts a panel holds no field that maps a slot index to a timestamp.
+		/// </summary>
+		private static void AssertNoHandRolledPendingMap(Type owner)
+		{
+			FieldInfo[] fields = owner.GetFields(BindingFlags.Instance | BindingFlags.Static |
+				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+			for (int i = 0; i < fields.Length; ++i)
+			{
+				Type type = fields[i].FieldType;
+				if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(Dictionary<,>))
+				{
+					continue;
+				}
+
+				Type[] args = type.GetGenericArguments();
+				bool slotKeyed = args[0] == typeof(int);
+				bool timestampValued = args[1] == typeof(float) || args[1] == typeof(double);
+
+				LogAssert.IsFalse(slotKeyed && timestampValued,
+					$"{owner.Name}.{fields[i].Name} is a hand-rolled pending-slot watchdog; use ItemSlotPendingSet");
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/PendingSlotWatchdogTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/PendingSlotWatchdogTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79a189cc60dd480c8b54a1572dac933f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/UnitTests/PlayerRequestPreambleTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/PlayerRequestPreambleTests.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// Proofs that the player-request preamble is written in one place, and that a new server
+	/// handler cannot quietly hand-roll its own copy.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Every player-initiated broadcast handler opens the same way: is there a connection, has it
+	/// spawned an object, is that object a player character, and may that character act. The
+	/// sequence had been pasted into roughly thirty handlers, and the copies had drifted — some
+	/// checked <c>CanAct</c>, some did not, some resolved a controller in the same condition, and
+	/// six carried a literal copy-paste scar with the newline lost in transit. Drift in a state
+	/// gate is the failure mode that matters here: a handler that silently omits <c>CanAct</c> lets
+	/// a dead, stunned or mid-teleport character act, and nothing about the omission looks any
+	/// different from the deliberate ones.
+	/// </para>
+	/// <para>
+	/// So this fixture does not check that the preamble is CORRECT — <c>CharacterStateValidation</c>
+	/// owns that. It checks that there is only one of it. The budget below lists the places that
+	/// still write it by hand, each for a reason; anything NOT on the list must go through
+	/// <c>ServerBehaviour.TryBeginPlayerRequest</c>. A file may drop below its budget freely (that
+	/// is a later migration), but it may never exceed it, and a new file may not appear at all.
+	/// </para>
+	/// <para>
+	/// Source-scanning, like its neighbours, with the limits that implies: it sees what was
+	/// WRITTEN, not what runs. Its value is that it fails when a copy is added, rather than when a
+	/// player reports being able to trade while dead.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class PlayerRequestPreambleTests
+	{
+		private const string EntryPointPath =
+			"Assets/Scripts/Server/Implementation/ServerBehaviour.PlayerRequests.cs";
+
+		private const string EntryPointKey =
+			"Implementation/ServerBehaviour.PlayerRequests.cs";
+
+		/// <summary>The resolution the shared entry point replaces.</summary>
+		private const string Resolution = "conn.FirstObject.GetComponent<IPlayerCharacter>()";
+
+		private static string ServerRoot =>
+			Path.Combine(Directory.GetCurrentDirectory(), "Assets/Scripts/Server");
+
+		/// <summary>
+		/// Files still allowed to resolve the acting player by hand, and how many times each may.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Three kinds of entry. The first is the earlier consolidations — <c>TryBeginGuildRequest</c>,
+		/// <c>TryResolveOpenSession</c>, <c>TryGetActingPlayer</c>, <c>TryResolveCorpseRequest</c>, plus
+		/// the arena and dungeon-entrance resolvers. Each has callers and its own out-parameters, so
+		/// folding them into the shared entry point has a blast radius and is not this change.
+		/// </para>
+		/// <para>
+		/// The second is handlers whose preamble is NOT the common one: they answer each refusal
+		/// differently — a purchase result, a sell result, a craft failure, a container result, a
+		/// travel refusal — and a shared boolean cannot say which check refused. Rewriting them to
+		/// fit would either drop those answers or invent new ones, and a handler that stops
+		/// answering is exactly the defect <c>MerchantPurchaseResultTests</c> exists to prevent.
+		/// </para>
+		/// <para>
+		/// The third is not a preamble at all: post-commit achievement increments on the async path,
+		/// which re-resolve the character because the handler's own local is long out of scope by
+		/// then, and the naming system, which requires <c>IsLoaded</c> rather than <c>CanAct</c> in
+		/// order to close a name-enumeration oracle.
+		/// </para>
+		/// </remarks>
+		private static Dictionary<string, int> HandWrittenBudget()
+		{
+			return new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+			{
+				// The shared entry point itself. This is the one copy that is supposed to exist.
+				{ EntryPointKey, 1 },
+
+				// Earlier consolidations, each with live callers. Candidates for a later pass.
+				{ "Implementation/World/SceneServer/Guild/GuildSystem.Ranks.cs", 1 },
+				{ "Implementation/World/SceneServer/Housing/HousingSystem.Network.cs", 1 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Corpse.cs", 2 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.DungeonFinder.cs", 2 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Arena.cs", 1 },
+				{ "Implementation/World/SceneServer/Trade/TradeSystem.Handlers.cs", 4 },
+
+				// Handlers that answer each refusal with its own reason.
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.AbilityCraft.cs", 1 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Container.cs", 1 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Mailbox.cs", 3 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Merchant.cs", 2 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.Waypoint.cs", 1 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.cs", 1 },
+
+				// Resolved after the guard, inside a try/finally that reports the failure reason.
+				{ "Implementation/World/SceneServer/CharacterInventory/CharacterInventorySystem.cs", 5 },
+
+				// Not the state gate at all: these require IsLoaded, to close a name-enumeration oracle.
+				{ "Implementation/World/SceneServer/Naming/NamingSystem.cs", 2 },
+
+				// Post-commit achievement increments on the async path, not handler preambles.
+				{ "Implementation/World/SceneServer/Friend/FriendSystem.cs", 1 },
+				/* Five, not three: guild create and guild join each re-resolve twice on their async
+				 * continuation — once to build the self roster entry for the GuildAddBroadcast and once
+				 * for the achievement increment. These run AFTER the database call returns, where the
+				 * handler-entry helper has nothing to offer: the request was admitted long ago and what
+				 * is wanted is the character as it stands now. Raised deliberately when the join path
+				 * gained the same pair the create path already had. */
+				{ "Implementation/World/SceneServer/Guild/GuildSystem.cs", 5 },
+				{ "Implementation/World/SceneServer/Party/PartySystem.cs", 3 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.ArenaMatch.cs", 1 },
+				{ "Implementation/World/SceneServer/Interactable/InteractableSystem.GroupFinder.cs", 1 },
+			};
+		}
+
+		/// <summary>Source text with line endings normalised, so offsets do not depend on checkout.</summary>
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path).Replace("\r\n", "\n");
+		}
+
+		/// <summary>Every server script, keyed by its path relative to the server root.</summary>
+		private static Dictionary<string, string> ServerSources()
+		{
+			var sources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+			foreach (string file in Directory.GetFiles(ServerRoot, "*.cs", SearchOption.AllDirectories))
+			{
+				string key = file.Substring(ServerRoot.Length)
+					.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+					.Replace('\\', '/');
+				sources[key] = File.ReadAllText(file).Replace("\r\n", "\n");
+			}
+
+			LogAssert.IsTrue(sources.Count > 0, "there must be server sources to scan");
+			return sources;
+		}
+
+		private static int Occurrences(string text, string needle)
+		{
+			int count = 0;
+			int at = 0;
+			while (true)
+			{
+				at = text.IndexOf(needle, at, StringComparison.Ordinal);
+				if (at < 0)
+				{
+					return count;
+				}
+				++count;
+				at += needle.Length;
+			}
+		}
+
+		[Test]
+		public void TheSharedEntryPointExists()
+		{
+			string source = ReadSource(EntryPointPath);
+
+			LogAssert.IsTrue(source.Contains("protected bool TryBeginPlayerRequest("),
+				"the shared entry point must exist on ServerBehaviour, or there is nothing to migrate to");
+			LogAssert.IsTrue(source.Contains("public readonly struct PlayerRequestContext"),
+				"the preamble's result must be a named type, so what it produces can grow without touching every handler");
+			LogAssert.IsTrue(source.Contains("public enum PlayerRequestGate"),
+				"the CanAct opt-out must be a named value rather than a bare bool at the call site");
+		}
+
+		[Test]
+		public void TheSharedEntryPointRunsEveryCheckThePreamblesRan()
+		{
+			/* The refactor is safe only if this method is the union of what it replaced and nothing
+			 * less. Each of these four checks stood in every inline copy that was migrated. */
+			string source = ReadSource(EntryPointPath);
+			int start = source.IndexOf("protected bool TryBeginPlayerRequest(", StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, "the entry point must still be declared");
+
+			string body = source.Substring(start);
+
+			LogAssert.IsTrue(body.Contains("if (conn == null || conn.FirstObject == null)"),
+				"a request with no connection, or none spawned yet, must still be refused");
+			LogAssert.IsTrue(body.Contains(Resolution),
+				"the acting player must still be resolved from the connection's first object");
+			LogAssert.IsTrue(body.Contains("if (character == null)"),
+				"a first object that is not a player character must still be refused");
+			LogAssert.IsTrue(body.Contains("CharacterStateValidation.CanAct(character)"),
+				"the character-state gate must still run — this is the check whose omission is a security bug");
+		}
+
+		[Test]
+		public void TheCanActGateIsOnByDefaultAndOptedOutOfByName()
+		{
+			/* Which way the default points is the whole safety property. A handler written without
+			 * thinking about the gate gets the gate; skipping it has to be typed out, and what gets
+			 * typed out is greppable. */
+			string source = ReadSource(EntryPointPath);
+
+			LogAssert.IsTrue(source.Contains("PlayerRequestGate gate = PlayerRequestGate.RequireCanAct"),
+				"the default must REQUIRE CanAct, so forgetting to think about it is the safe outcome");
+			LogAssert.IsTrue(source.Contains("RequireCanAct = 0"),
+				"RequireCanAct must be the zero value, so a default-initialised gate is the strict one");
+			LogAssert.IsTrue(source.Contains("SkipCanAct"),
+				"the opt-out must exist: at least one request is deliberately not gated on character state");
+		}
+
+		[Test]
+		public void EveryOptOutSaysWhichLaterGateCoversIt()
+		{
+			/* An ungated request is indistinguishable from a forgotten gate unless it says so.
+			 * TryResolveArenaBoard was exactly that: no CanAct, no explanation, alongside a
+			 * group-finder handler whose identical omission is documented in full. */
+			foreach (KeyValuePair<string, string> entry in ServerSources())
+			{
+				if (entry.Key == EntryPointKey ||
+					!entry.Value.Contains("PlayerRequestGate.SkipCanAct"))
+				{
+					continue;
+				}
+
+				LogAssert.IsTrue(entry.Value.Contains("CanActOrMove"),
+					$"{entry.Key} skips the character-state gate, so it must name the later gate that covers it");
+			}
+		}
+
+		[Test]
+		public void EveryCallSiteRefusesTheRequestWhenTheEntryPointRefuses()
+		{
+			/* A caller that ignores the return reads its character off a `default` context and acts
+			 * for somebody who was never resolved. Every call site is written as a refusal. */
+			int callSites = 0;
+
+			foreach (KeyValuePair<string, string> entry in ServerSources())
+			{
+				if (entry.Key == EntryPointKey)
+				{
+					// Its own declaration and doc comment name it without calling it.
+					continue;
+				}
+
+				int guarded = Occurrences(entry.Value, "if (!TryBeginPlayerRequest(");
+				int total = Occurrences(entry.Value, "TryBeginPlayerRequest(");
+
+				LogAssert.AreEqual(total, guarded,
+					$"every TryBeginPlayerRequest in {entry.Key} must be used as a refusal, not called and ignored");
+				callSites += guarded;
+			}
+
+			LogAssert.IsTrue(callSites >= 38,
+				"the migrated handlers must still go through the shared entry point");
+		}
+
+		[Test]
+		public void NoHandlerOutsideTheBudgetResolvesTheActingPlayerByHand()
+		{
+			Dictionary<string, int> budget = HandWrittenBudget();
+			var offenders = new List<string>();
+
+			foreach (KeyValuePair<string, string> entry in ServerSources())
+			{
+				int found = Occurrences(entry.Value, Resolution);
+				if (found == 0)
+				{
+					continue;
+				}
+
+				int allowed;
+				if (!budget.TryGetValue(entry.Key, out allowed))
+				{
+					offenders.Add($"{entry.Key}: {found} hand-written resolution(s), none budgeted — " +
+						"use ServerBehaviour.TryBeginPlayerRequest");
+					continue;
+				}
+
+				/* Deliberately one-sided. Fewer is a migration, and welcome; more is a new copy. */
+				if (found > allowed)
+				{
+					offenders.Add($"{entry.Key}: {found} hand-written resolution(s), {allowed} budgeted");
+				}
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"the player-request preamble must be written once: " + string.Join("; ", offenders.ToArray()));
+		}
+
+		[Test]
+		public void TheCopyPasteScarIsGone()
+		{
+			/* Six handlers carried the resolution and the null check jammed onto one line — the same
+			 * paste, propagated six times, missing newline and all. Harmless in itself, and the
+			 * clearest possible evidence of how this preamble spread. If it comes back, something
+			 * was pasted rather than called. */
+			foreach (KeyValuePair<string, string> entry in ServerSources())
+			{
+				LogAssert.IsTrue(!entry.Value.Contains("GetComponent<IPlayerCharacter>();if "),
+					$"{entry.Key} carries the pasted preamble scar; call TryBeginPlayerRequest instead");
+			}
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/PlayerRequestPreambleTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/PlayerRequestPreambleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1a1629740bf42cdae4b3772376d6c9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/UnitTests/SlotPanelSharingTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/SlotPanelSharingTests.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using FishMMO.Client;
+using LogAssert = FishMMO.UnitTests.Harness.LogAssert;
+
+namespace FishMMO.UnitTests
+{
+	/// <summary>
+	/// There is one implementation of what an item slot does, and every slot panel uses it.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The bag, the bank and the equipment sockets all draw a row of item slots, and all three had
+	/// written the same slot behaviour themselves. <see cref="UITKItemGridPanel"/> unified the
+	/// first two; the equipment panel sat beside it with eighteen identically named members —
+	/// <c>SubscribeTracker</c>, <c>OnTrackerSlotPendingChanged</c>, <c>IsSlotBlocked</c>,
+	/// <c>SetSlotItem</c>, <c>ClearSlot</c>, <c>ApplySlotLockVisual</c>, <c>RefreshSlotTooltip</c>,
+	/// the pointer enter/leave pair, <c>BeginDragFromSlot</c>, <c>ResolveContainer</c>,
+	/// <c>ReleaseAndClearDrag</c> and the rest — doing the same jobs in its own words.
+	/// </para>
+	/// <para>
+	/// It is not the duplication that these tests are about. It is that the copies HAD ALREADY COME
+	/// APART, in three ways, and every one of them was invisible from inside either file:
+	/// shift-click quick transfer (issue #197) reached the grid and not the socket, so a player who
+	/// learned the gesture in their bag found it dead on what they were wearing; the grid refused a
+	/// slot whose item had no database identity yet and the socket offered it, costing a round trip
+	/// that ends in a refusal nobody asked for; and a slot update repainted the lock overlay in one
+	/// and not the other. A second copy does not double the work of a fix, it halves the chance of
+	/// one.
+	/// </para>
+	/// <para>
+	/// So these tests are deliberately part reflection and part source scan rather than
+	/// behavioural, for the reason <c>PendingSlotWatchdogTests</c> gives about its watchdog: what
+	/// is worth preventing is not a wrong answer from a function, it is a FOURTH hand-rolled copy
+	/// appearing in the next panel somebody writes, or — the specific accident this refactor can
+	/// have — a panel that derives from the shared base and goes on declaring its own
+	/// <c>SubscribeTracker</c> beside it, quietly SHADOWING the inherited one rather than using it.
+	/// That compiles. It passes every behavioural test. It is strictly worse than the duplication
+	/// it looks like it removed, because now the two copies appear to be one.
+	/// </para>
+	/// <para>
+	/// What is deliberately NOT pinned here is slot creation. The sockets are authored in
+	/// <c>UIEquipment.uxml</c> and found by class name; the grids build one element per container
+	/// slot in code. That difference is real and the base must stay out of it, so one test asserts
+	/// the base does not create slots and each panel still creates its own its own way.
+	/// </para>
+	/// <para>
+	/// Sources are read with line endings normalised, because the tree is CRLF on Windows and CI
+	/// has checked it out both ways.
+	/// </para>
+	/// </remarks>
+	[TestFixture]
+	public class SlotPanelSharingTests
+	{
+		private const string BasePath =
+			"Assets/Scripts/Client/GUI/World/ItemContainers/UITKSlotPanelBase.cs";
+		private const string GridPath =
+			"Assets/Scripts/Client/GUI/World/ItemContainers/UITKItemGridPanel.cs";
+		private const string EquipmentPath =
+			"Assets/Scripts/Client/GUI/World/Equipment/UITKEquipment.cs";
+		private const string BankPath =
+			"Assets/Scripts/Client/GUI/World/Bank/UITKBank.cs";
+		private const string InventoryPath =
+			"Assets/Scripts/Client/GUI/World/Inventory/UITKInventory.cs";
+
+		/// <summary>Every panel that draws item slots, base excluded.</summary>
+		private static readonly string[] PanelPaths =
+		{
+			GridPath, EquipmentPath, BankPath, InventoryPath,
+		};
+
+		/// <summary>The same panels as types, for the reflection half.</summary>
+		private static readonly Type[] PanelTypes =
+		{
+			typeof(UITKItemGridPanel), typeof(UITKEquipment), typeof(UITKBank), typeof(UITKInventory),
+		};
+
+		/// <summary>
+		/// Members whose one implementation belongs to the shared base and nowhere else.
+		/// </summary>
+		/// <remarks>
+		/// Each of these existed twice before the base did. They are the acts a slot performs once
+		/// it exists — join the tracker, decide whether it can be clicked, paint it, describe it,
+		/// pick it up, let it go — as opposed to the acts that differ by panel, which are the DROP
+		/// (a swap or a split in a grid, an equip in a socket) and the CREATION of the slot itself.
+		/// Those two are deliberately absent from this list.
+		/// </remarks>
+		private static readonly string[] SharedMembers =
+		{
+			"SubscribeTracker",
+			"UnsubscribeTracker",
+			"OnTrackerSlotPendingChanged",
+			"OnTrackerResyncRequested",
+			"RefreshAllSlots",
+			"IsSlotBlocked",
+			"SetSlotItem",
+			"ClearSlot",
+			"RefreshSlotTooltip",
+			"ApplySlotLockVisual",
+			"OnSlotPointerEnter",
+			"OnSlotPointerLeave",
+			"BeginDragFromSlot",
+			"ResolveContainer",
+			"ReleaseAndClearDrag",
+		};
+
+		private static string ReadSource(string relativePath)
+		{
+			string path = Path.Combine(Directory.GetCurrentDirectory(), relativePath);
+			LogAssert.IsTrue(File.Exists(path), $"{relativePath} not found at {path}.");
+			return File.ReadAllText(path).Replace("\r\n", "\n");
+		}
+
+		/// <summary>
+		/// The source with comment lines dropped, so a scan sees code and not prose.
+		/// </summary>
+		/// <remarks>
+		/// Every one of these files explains in a comment what moved to the base and names the
+		/// members by name — that explanation is the point of them. Scanning raw text would make
+		/// the refactor fail its own test and, worse, would teach the next person to delete the
+		/// explanation to get green. Line-level stripping is enough: this is a grep with manners,
+		/// not a parser, and a trailing comment after real code still leaves the code visible.
+		/// </remarks>
+		private static string CodeOnly(string source)
+		{
+			string[] lines = source.Split('\n');
+			StringBuilder code = new StringBuilder(source.Length);
+
+			for (int i = 0; i < lines.Length; ++i)
+			{
+				string trimmed = lines[i].TrimStart();
+				if (trimmed.StartsWith("//", StringComparison.Ordinal) ||
+					trimmed.StartsWith("/*", StringComparison.Ordinal) ||
+					trimmed.StartsWith("*", StringComparison.Ordinal))
+				{
+					continue;
+				}
+
+				code.Append(lines[i]).Append('\n');
+			}
+
+			return code.ToString();
+		}
+
+		/// <summary>
+		/// Whether a file DECLARES a method of this name, as opposed to calling one.
+		/// </summary>
+		/// <remarks>
+		/// An access modifier on the same line is what separates the two. Every declaration in this
+		/// codebase carries one — there are no implicitly private members in the panels — and no
+		/// call site does.
+		/// </remarks>
+		private static bool Declares(string code, string member)
+		{
+			return Regex.IsMatch(code, @"\b(?:private|protected|public|internal)\b[^\n;=]*\b" +
+				Regex.Escape(member) + @"\s*\(");
+		}
+
+		/// <summary>
+		/// The body of a method, brace-matched from its declaration.
+		/// </summary>
+		/// <remarks>
+		/// Brace counting, not parsing, so it would be fooled by a brace inside a string or a
+		/// character literal. That is acceptable because it is only ever pointed at the pointer-down
+		/// routers, which contain neither; anything more adventurous should extract by anchors the
+		/// way the neighbouring fixtures do.
+		/// </remarks>
+		private static string MethodBody(string source, string signature)
+		{
+			int start = source.IndexOf(signature, StringComparison.Ordinal);
+			LogAssert.IsTrue(start >= 0, $"the source must still declare {signature}");
+
+			int open = source.IndexOf('{', start);
+			LogAssert.IsTrue(open > start, $"{signature} must have a body");
+
+			int depth = 0;
+			for (int i = open; i < source.Length; ++i)
+			{
+				if (source[i] == '{')
+				{
+					++depth;
+				}
+				else if (source[i] == '}')
+				{
+					--depth;
+					if (depth == 0)
+					{
+						return source.Substring(open, i - open + 1);
+					}
+				}
+			}
+
+			LogAssert.IsTrue(false, $"{signature}'s body must be balanced");
+			return string.Empty;
+		}
+
+		// ── The invariant itself ──────────────────────────────────────────────
+
+		[Test]
+		public void EverySlotPanelDerivesFromTheSharedBase()
+		{
+			/* The whole point, stated as a type relationship rather than as a string: a panel that
+			 * stops deriving from the base is a panel that has started keeping its own copy of slot
+			 * behaviour again, whatever its source file happens to say. */
+			for (int i = 0; i < PanelTypes.Length; ++i)
+			{
+				LogAssert.IsTrue(typeof(UITKSlotPanelBase).IsAssignableFrom(PanelTypes[i]),
+					$"{PanelTypes[i].Name} must derive from UITKSlotPanelBase, or it is keeping " +
+					"its own copy of the tracker, the lock overlay and the drag");
+			}
+
+			/* And the base must still be the shared thing it claims to be, rather than a marker
+			 * class somebody emptied out to silence the test above. */
+			LogAssert.IsTrue(typeof(UITKSlotPanelBase).IsAbstract,
+				"UITKSlotPanelBase is a base class, not a panel");
+		}
+
+		[Test]
+		public void NoPanelDeclaresAMemberTheSharedBaseAlreadyOwns()
+		{
+			/* THE ACCIDENT THIS REFACTOR CAN HAVE, and the reason this test is reflection rather
+			 * than text. Reparenting a panel to the base and forgetting to delete its now-duplicate
+			 * members compiles perfectly: `private void SubscribeTracker()` beside an inherited one
+			 * simply SHADOWS it. The panel keeps running its own copy, the base's version never
+			 * executes, and the file looks refactored. That is worse than the duplication it
+			 * appears to have removed, because the two copies now look like one.
+			 *
+			 * Scoped to what the base itself declares, not to everything it inherits: panels are
+			 * entitled to override OnStarting, Hide and the character hooks, and those come from
+			 * UITKControl. */
+			HashSet<string> owned = DeclaredMemberNames(typeof(UITKSlotPanelBase));
+			List<string> offenders = new List<string>();
+
+			for (int i = 0; i < PanelTypes.Length; ++i)
+			{
+				CollectShadowedMembers(PanelTypes[i], owned, offenders);
+			}
+
+			LogAssert.IsTrue(offenders.Count == 0,
+				"a member that shares a base member's name must be an override, never a second " +
+				"declaration beside it: " + string.Join("; ", offenders.ToArray()));
+		}
+
+		[Test]
+		public void TheTrackerIsSubscribedInExactlyOnePlace()
+		{
+			/* The subscription is the piece with the sharpest failure mode. It is a STATIC event
+			 * that outlives the panel, so the -= before += and the matching Detach are not tidiness
+			 * — a missed unsubscribe is a handler running forever on a destroyed panel. Both copies
+			 * got that right, and both explained it in the same words, which is exactly how you
+			 * know it was copied rather than reasoned about twice. */
+			string sharedBase = CodeOnly(ReadSource(BasePath));
+
+			LogAssert.IsTrue(sharedBase.Contains("ItemOperationTracker.SlotPendingChanged"),
+				"the base must be the thing that subscribes to the tracker");
+			LogAssert.IsTrue(sharedBase.Contains("ItemOperationTracker.Attach()") &&
+				sharedBase.Contains("ItemOperationTracker.Detach()"),
+				"and the thing that attaches and detaches it");
+
+			for (int i = 0; i < PanelPaths.Length; ++i)
+			{
+				string code = CodeOnly(ReadSource(PanelPaths[i]));
+				string name = Path.GetFileName(PanelPaths[i]);
+
+				LogAssert.IsFalse(code.Contains("ItemOperationTracker.SlotPendingChanged"),
+					$"{name} must not wire the tracker's events itself");
+				LogAssert.IsFalse(code.Contains("ItemOperationTracker.ResyncRequested"),
+					$"{name} must not wire the tracker's resync itself");
+				LogAssert.IsFalse(Regex.IsMatch(code, @"ItemOperationTracker\.(?:Attach|Detach)\s*\("),
+					$"{name} must not attach or detach the tracker itself");
+			}
+		}
+
+		[Test]
+		public void SlotBehaviourIsDeclaredOnlyByTheSharedBase()
+		{
+			/* The eighteen-member duplication, listed. A panel is welcome to CALL any of these; what
+			 * it may not do is grow another one. */
+			string sharedBase = CodeOnly(ReadSource(BasePath));
+
+			for (int i = 0; i < SharedMembers.Length; ++i)
+			{
+				LogAssert.IsTrue(Declares(sharedBase, SharedMembers[i]),
+					$"UITKSlotPanelBase must declare {SharedMembers[i]}");
+			}
+
+			for (int p = 0; p < PanelPaths.Length; ++p)
+			{
+				string code = CodeOnly(ReadSource(PanelPaths[p]));
+				string name = Path.GetFileName(PanelPaths[p]);
+
+				for (int i = 0; i < SharedMembers.Length; ++i)
+				{
+					LogAssert.IsFalse(Declares(code, SharedMembers[i]),
+						$"{name} declares its own {SharedMembers[i]}; the shared one is inherited");
+				}
+			}
+		}
+
+		[Test]
+		public void SlotCreationStaysWithThePanelThatKnowsHowItsSlotsAreMade()
+		{
+			/* The line the base must NOT cross, and the reason this is a test rather than a note.
+			 * A base that also built the slots would have to choose one of the two ways they come
+			 * into existence, and either choice breaks a panel: the sockets are authored in
+			 * UIEquipment.uxml and queried by class name, so there is no eleventh one to create,
+			 * while a grid's count follows the container and has to be rebuilt when it changes. So
+			 * the base holds the list and neither fills it. */
+			string sharedBase = CodeOnly(ReadSource(BasePath));
+
+			LogAssert.IsTrue(sharedBase.Contains("slotViews"),
+				"the base owns the slot list, which is what lets the shared painters be shared");
+			LogAssert.IsFalse(sharedBase.Contains("slotViews.Add("),
+				"but it must not populate the list; only a panel knows where its slots come from");
+			LogAssert.IsFalse(sharedBase.Contains("fish-slot"),
+				"and it must not know the markup, which is the grids' and the sockets' own business");
+
+			string equipment = CodeOnly(ReadSource(EquipmentPath));
+			LogAssert.IsTrue(equipment.Contains("className: \"fish-slot__icon\""),
+				"the equipment panel finds its sockets in the UXML it was authored with");
+			LogAssert.IsTrue(equipment.Contains("SlotElementNames"),
+				"one authored element per ItemSlot, in enum order — that array is the contract");
+
+			string grid = CodeOnly(ReadSource(GridPath));
+			LogAssert.IsTrue(grid.Contains("slotGrid.Add("),
+				"the grids build their slots in code, sized from the container");
+		}
+
+		// ── The divergences, pinned individually ──────────────────────────────
+
+		[Test]
+		public void BothPointerDownRoutersHonourShiftClick()
+		{
+			/* THE DIVERGENCE THAT WAS A PLAYER-VISIBLE BUG. Shift-click means "send this to the
+			 * other container" (issue #197) in the bag and in the bank, and a socket's other
+			 * container is the bag. The equipment panel's router was the same method under the same
+			 * name with that branch missing, so the gesture was dead on everything the player was
+			 * wearing — and a shift-click that does nothing is indistinguishable from one the game
+			 * did not receive.
+			 *
+			 * The routers are the one part of the click path that could not be hoisted: each one
+			 * dispatches to a completion that speaks a different half of the item protocol, a swap
+			 * or a split in a grid and an equip in a socket. So this test stands in for the base
+			 * class that cannot exist here. Two routers, one rule. */
+			string grid = ReadSource(GridPath);
+			string equipment = ReadSource(EquipmentPath);
+
+			string gridRouter = MethodBody(grid, "private void OnSlotPointerDown");
+			string socketRouter = MethodBody(equipment, "private void OnSlotPointerDown");
+
+			LogAssert.IsTrue(gridRouter.Contains("evt.shiftKey"),
+				"the grid router must read shift from the click that happened");
+			LogAssert.IsTrue(socketRouter.Contains("evt.shiftKey"),
+				"and so must the socket router, which is where this was missing");
+
+			/* Read from the event, never polled. The modifier that matters is the one held when
+			 * this click happened, and a poll can answer for a moment either side of it. */
+			LogAssert.IsFalse(socketRouter.Contains("Keyboard.current"),
+				"the modifier must come from the event, not from global input state");
+		}
+
+		[Test]
+		public void ASlotHoldingAnItemWithNoIdentityIsTreatedAsBusy()
+		{
+			/* The second divergence. An item with ID <= 0 is one the database has not written yet;
+			 * the server keeps its slot locked until the row lands and would refuse any request
+			 * naming it. The grid knew that and the socket did not, so a socket offered a drag that
+			 * was certain to be refused. Settled in the grid's favour in the one shared body — this
+			 * pins the rule so that a later simplification of IsSlotBlocked cannot drop it again
+			 * for both panels at once. */
+			string body = MethodBody(ReadSource(BasePath), "protected bool IsSlotBlocked");
+
+			LogAssert.IsTrue(body.Contains("IsPending("),
+				"a slot waiting on this client's own request is busy");
+			LogAssert.IsTrue(body.Contains("IsSlotLocked("),
+				"and so is one the container has locked");
+			LogAssert.IsTrue(body.Contains("item.ID <= 0"),
+				"and so is one holding an item the database has not written yet");
+		}
+
+		[Test]
+		public void ApplyingAServerSlotRepaintsItsLockOverlay()
+		{
+			/* The third divergence, and the subtlest: the grid repainted the lock overlay after
+			 * applying an update and the socket did not. The item ITSELF can be the reason a slot
+			 * is blocked — see the identity rule above — so the slot arriving with its identity is
+			 * what unblocks it, and a panel that only listens for lock-change events misses that
+			 * moment. */
+			string body = MethodBody(ReadSource(BasePath), "protected void ApplySlotUpdate");
+
+			LogAssert.IsTrue(body.Contains("ItemOperationTracker.Release("),
+				"the slot arriving IS the acknowledgement, so the pending mark comes off here");
+			LogAssert.IsTrue(body.Contains("ApplySlotLockVisual("),
+				"and the overlay is repainted, which is what the socket copy never did");
+			LogAssert.IsTrue(body.Contains("NotifySlotChanged("),
+				"a drag started from this slot no longer refers to what it was started from");
+		}
+
+		// ── Reflection helpers ────────────────────────────────────────────────
+
+		private const BindingFlags AllDeclared =
+			BindingFlags.Instance | BindingFlags.Static |
+			BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+		/// <summary>Every member name a type declares itself, nested types included.</summary>
+		private static HashSet<string> DeclaredMemberNames(Type owner)
+		{
+			HashSet<string> names = new HashSet<string>();
+
+			MemberInfo[] members = owner.GetMembers(AllDeclared);
+			for (int i = 0; i < members.Length; ++i)
+			{
+				if (!IsCompilerGenerated(members[i]) && !IsConstructor(members[i]))
+				{
+					names.Add(members[i].Name);
+				}
+			}
+
+			Type[] nested = owner.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic);
+			for (int i = 0; i < nested.Length; ++i)
+			{
+				names.Add(nested[i].Name);
+			}
+
+			return names;
+		}
+
+		/// <summary>
+		/// Adds one panel's shadowing members to <paramref name="offenders"/>.
+		/// </summary>
+		/// <remarks>
+		/// A method or property that shares a base member's name is fine as long as it OVERRIDES
+		/// it, which <see cref="MethodInfo.GetBaseDefinition"/> answers: for an override it reports
+		/// a declaring type further up the chain. A field or a nested type cannot override anything,
+		/// so a name collision there is always a shadow.
+		/// </remarks>
+		private static void CollectShadowedMembers(Type panel, HashSet<string> owned, List<string> offenders)
+		{
+			MemberInfo[] members = panel.GetMembers(AllDeclared);
+			for (int i = 0; i < members.Length; ++i)
+			{
+				MemberInfo member = members[i];
+				if (IsCompilerGenerated(member) || IsConstructor(member) || !owned.Contains(member.Name))
+				{
+					continue;
+				}
+
+				MethodInfo method = member as MethodInfo;
+				if (method != null)
+				{
+					if (method.GetBaseDefinition().DeclaringType == method.DeclaringType)
+					{
+						offenders.Add($"{panel.Name}.{member.Name}() hides the base's");
+					}
+					continue;
+				}
+
+				PropertyInfo property = member as PropertyInfo;
+				if (property != null)
+				{
+					MethodInfo getter = property.GetGetMethod(true);
+					if (getter == null || getter.GetBaseDefinition().DeclaringType == getter.DeclaringType)
+					{
+						offenders.Add($"{panel.Name}.{member.Name} hides the base's");
+					}
+					continue;
+				}
+
+				offenders.Add($"{panel.Name}.{member.Name} hides the base's member of that name");
+			}
+		}
+
+		/// <summary>
+		/// Whether a member was written by the compiler rather than by a person.
+		/// </summary>
+		/// <remarks>
+		/// Lambdas and their closure classes are how every slot registers its callbacks here, so
+		/// the panels are full of them. They are named with angle brackets, which no C# identifier
+		/// can contain, and they carry the attribute as well — both are checked because the display
+		/// classes hold the attribute while some of their members only have the name.
+		/// </remarks>
+		private static bool IsCompilerGenerated(MemberInfo member)
+		{
+			return member.Name.IndexOf('<') >= 0 ||
+				member.IsDefined(typeof(CompilerGeneratedAttribute), false);
+		}
+
+		/// <summary>
+		/// Whether a member is a constructor.
+		/// </summary>
+		/// <remarks>
+		/// Every one of these types has one, they are all called <c>.ctor</c>, and a constructor
+		/// cannot override anything — so without this the shadowing scan would report each panel
+		/// hiding the base's constructor, which is not a thing that can happen.
+		/// </remarks>
+		private static bool IsConstructor(MemberInfo member)
+		{
+			return member.MemberType == MemberTypes.Constructor;
+		}
+	}
+}

--- a/FishMMO-Unity/Assets/UnitTests/SlotPanelSharingTests.cs.meta
+++ b/FishMMO-Unity/Assets/UnitTests/SlotPanelSharingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66865823dd7549eab1f5c6d2759341a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FishMMO-Unity/Assets/UnitTests/TextInputHeightTests.cs
+++ b/FishMMO-Unity/Assets/UnitTests/TextInputHeightTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -163,6 +163,7 @@ namespace FishMMO.UnitTests
 			LogAssert.IsTrue(Directory.Exists(GuiRoot), $"the GUI must live at {GuiRoot}");
 
 			Dictionary<string, string> wornBy = ClassesWornBySingleLineTextFields();
+			HashSet<string> compactFields = FieldsWearingCompact();
 			LogAssert.IsTrue(wornBy.Count > 0, "there must be text fields to check");
 
 			List<string> offenders = new List<string>();
@@ -197,11 +198,23 @@ namespace FishMMO.UnitTests
 
 					foreach (KeyValuePair<string, string> worn in wornBy)
 					{
-						if (Targets(selector, worn.Key))
+						if (!Targets(selector, worn.Key))
 						{
-							offenders.Add(
-								$"{Path.GetFileName(sheet)} '{selector}' pins the height of {worn.Value}");
+							continue;
 						}
+
+						/* A pinned height is legal WITH fish-input--compact, which is the theme's own
+						 * remedy: it zeroes the padding Unity puts inside the editable surface, which is
+						 * what starves the glyph box at small heights. A field that pins a height and does
+						 * not wear it renders an empty box — the rule this test exists to hold. */
+						if (compactFields.Contains(worn.Value))
+						{
+							continue;
+						}
+
+						offenders.Add(
+							$"{Path.GetFileName(sheet)} '{selector}' pins the height of {worn.Value} " +
+							"without fish-input--compact");
 					}
 				}
 			}
@@ -209,6 +222,30 @@ namespace FishMMO.UnitTests
 			LogAssert.IsTrue(offenders.Count == 0,
 				"a single-line text field must size to its own text or its glyphs clip — use min-height. " +
 				string.Join("; ", offenders));
+		}
+
+		/// <summary>The fields that carry fish-input--compact, by the same where-key as wornBy.</summary>
+		private static HashSet<string> FieldsWearingCompact()
+		{
+			HashSet<string> compact = new HashSet<string>();
+
+			foreach (string layout in Directory.GetFiles(GuiRoot, "*.uxml", SearchOption.AllDirectories))
+			{
+				foreach (Match field in Regex.Matches(File.ReadAllText(layout),
+					"<ui:(TextField|IntegerField|FloatField|LongField|DoubleField)\\b[^>]*>"))
+				{
+					string tag = field.Value;
+					if (!tag.Contains("fish-input--compact"))
+					{
+						continue;
+					}
+
+					Match named = Regex.Match(tag, "name=\"([^\"]*)\"");
+					compact.Add($"{Path.GetFileName(layout)}:{(named.Success ? named.Groups[1].Value : "?")}");
+				}
+			}
+
+			return compact;
 		}
 
 		/// <summary>Every USS class worn by a single-line TextField, mapped to where it is worn.</summary>
@@ -220,7 +257,14 @@ namespace FishMMO.UnitTests
 			{
 				string source = File.ReadAllText(layout);
 
-				foreach (Match field in Regex.Matches(source, "<ui:TextField\\b[^>]*>"))
+				/* Every field type that draws glyphs, not only TextField.
+				 *
+				 * Scanning for TextField alone is how issues #263 and #277 returned after this test was
+				 * written: the merchant quantity box is an IntegerField, so it was never checked, and it
+				 * pinned an exact height exactly as the TextFields once did. The numeric fields derive
+				 * from the same TextInputBaseField and their glyph box collapses the same way. */
+				foreach (Match field in Regex.Matches(source,
+					"<ui:(TextField|IntegerField|FloatField|LongField|DoubleField)\\b[^>]*>"))
 				{
 					string tag = field.Value;
 


### PR DESCRIPTION
Four places where the same logic existed more than once — plus the bugs that had settled into the copies nobody remembered to update.

## Server: one entry point for the handler preamble

Of 123 broadcast handlers, 76 resolve a player and **37 repeated the preamble inline**. It had already been consolidated **four separate times** into helpers that disagree about whether `CanAct` applies — and a fifth, `CharacterStateValidation.TryGetPlayerAndValidate`, declares itself *"the canonical pattern for server-side broadcast handlers"* and has **zero callers**. Six sites carried the same copy-paste scar: a missing newline in `GetComponent<IPlayerCharacter>();if (character == null)`.

`TryBeginPlayerRequest` performs exactly the four checks it replaced. The gate is an **enum, not a bool**, so `SkipCanAct` must be typed out and can be grepped for — a bare `false` at a call site carries no reason with it.

38 sites migrated. Handlers whose gates answer with **distinct refusal reasons** were deliberately left alone: a boolean cannot say which gate refused, and flattening them would lose the reason the client is told.

`TryResolveArenaBoard` omits `CanAct` with no explanation, unlike the group-finder equivalent which documents why. Rather than guess, this traces the arena path: `BuildArenaEntry` puts queuers in the same table, and `HandleMatchedEntry` refuses the transfer unless `CanActOrMove` passes. Entry **is** gated later. Recorded in remarks; behaviour unchanged.

## Client: the slot panel base

`UITKEquipment` re-implemented **eighteen** members `UITKItemGridPanel` already had — and they had drifted. `UITKSlotPanelBase` now owns tracker subscription, painting, locking, drag and tooltips. Grid **1547 → 1133**, Equipment **1531 → 1243**.

Slot *creation* stays per-panel (the grid builds slots in code, equipment reads them from UXML), and so does click dispatch — a grid drop is a swap or split, a socket drop is an equip. Those are different halves of the protocol, not one behaviour written twice.

## Client: invite-by-name existed three times

Guild, Party and FriendList shared the flow verbatim, including a comment. Now one helper on `UITKControl`; each panel keeps its own broadcast and wording. FriendList's missing connection guard and missing hover-then-pinned path turned out to be **deliberate**, and are now documented rather than looking like omissions.

## The bugs the duplication hid

| Bug | Detail |
|---|---|
| **Loot watchdog froze** | `UITKLoot` measured its slot timeout with `Time.time`. Any `timeScale` change froze it and a stuck row never released. `UITKContainer` — the copy — used unscaled time and was correct. |
| **Shift-click missing** | Quick transfer existed only in the grid panel. |
| **Container slot locked** | Take-item answered its throttle gate but not its state gate, so a dead or stunned player's slot stayed locked client-side until the window closed. |
| **Merchant field blank** (#263, #277) | Two faults, below. |

**The merchant one is worth spelling out**, because the first diagnosis was wrong. It is not the hide-when-max-is-1 logic. Two faults:

1. `SetQuantity` guarded the write on `value != clamped` — and an `IntegerField`'s visible text is produced **by** that write. The UXML authors `value="1"`, so the `SetQuantity(1)` on selection wrote nothing.
2. `.fish-input--compact` — the rule that zeroes the padding otherwise starving the glyph box — was type-qualified for `TextField` only, so Unity's own type-qualified rule won on every numeric field.

The field was live and correct throughout and simply **drew nothing**, at any value. The theme's own comment names #263 and #277 and says colour was never involved; it was right about the mechanism and had never been applied to `IntegerField`. `TextInputHeightTests` scanned `<ui:TextField>` only, which is how an IntegerField slipped a guard written for exactly this bug — it now covers the numeric types and encodes the real rule: pin a height only when also wearing `fish-input--compact`.

## Divergences settled deliberately

Where the duplicated panels disagreed, this does not silently keep whichever copy survived extraction:

- **shift-click** — added to equipment, reusing the unequip request right-click already used, so no new server path
- **`IsSlotBlocked` on `ID <= 0`** — settled in the grid's favour
- **lock repaint after a slot update** — settled in the grid's favour, and idempotent

## Tests

Six new fixtures. The one that matters most, `NoPanelDeclaresAMemberTheSharedBaseAlreadyOwns`, is the failure mode of an aborted earlier attempt at this refactor: it flags any declared member sharing a base member's name that is not an override. The preamble fixture uses a per-file budget with a written reason for each entry, so later migrations do not fight it.

## Verification

- EditMode **2440/2440**
- Client and server rebuilt; all six services ran **five minutes** with zero errors and zero exceptions
- `TryBeginPlayerRequest` audited against the code it replaced — no handler lost a check
- No live `Time.time` remains in `UITKLoot`

**The shift-click addition is new player-facing behaviour and wants a play-test.** It is the one change here that a green suite cannot vouch for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)